### PR TITLE
docs: add JSDoc to undocumented inline script functions

### DIFF
--- a/web/views/admin_settings.templ
+++ b/web/views/admin_settings.templ
@@ -238,10 +238,18 @@ templ debugScript() {
 		(function() {
 			var KEY = 'dothog_debug';
 
+			/**
+			 * Load persisted debug toggle state from localStorage.
+			 * @returns {Object<string, boolean>} Map of toggle keys to enabled state
+			 */
 			function load() {
 				try { return JSON.parse(localStorage.getItem(KEY)) || {}; }
 				catch(e) { return {}; }
 			}
+			/**
+			 * Persist debug toggle state to localStorage.
+			 * @param {Object<string, boolean>} state - Map of toggle keys to enabled state
+			 */
 			function save(state) {
 				localStorage.setItem(KEY, JSON.stringify(state));
 			}
@@ -299,6 +307,11 @@ templ debugScript() {
 				'debug-alpine': 'alpine-events'
 			};
 
+			/**
+			 * Toggle a single debug feature on or off and persist the change.
+			 * @param {string} key - Handler key (e.g. 'htmx-log')
+			 * @param {boolean} enabled - Whether to enable or disable
+			 */
 			function toggle(key, enabled) {
 				var state = load();
 				state[key] = enabled;
@@ -306,6 +319,10 @@ templ debugScript() {
 				if (enabled) handlers[key].on(); else handlers[key].off();
 			}
 
+			/**
+			 * Toggle all debug features on or off, updating each checkbox.
+			 * @param {boolean} enabled - Whether to enable or disable all toggles
+			 */
 			function toggleAll(enabled) {
 				for (var id in checkboxMap) {
 					var key = checkboxMap[id];

--- a/web/views/architecture.templ
+++ b/web/views/architecture.templ
@@ -208,8 +208,9 @@ templ archCompareSlider() {
 				if (!handle || !container) return;
 
 				/**
+				 * Convert a pointer X position to a split percentage within the container.
 				 * @param {number} clientX - Pointer X coordinate
-				 * @returns {number} Clamped percentage (2–98)
+				 * @returns {number} Clamped percentage (2-98)
 				 */
 				function calcPercent(clientX) {
 					const rect = container.getBoundingClientRect();

--- a/web/views/canvas.templ
+++ b/web/views/canvas.templ
@@ -79,7 +79,11 @@ templ CanvasPage(startColor string) {
 
 				window._canvasColor = canvas.dataset.defaultColor;
 
-				/** @param {number} x @param {number} y */
+				/**
+				 * Paint a single pixel and broadcast the placement to the server.
+				 * @param {number} x - Grid column index
+				 * @param {number} y - Grid row index
+				 */
 				function paint(x, y) {
 					var color = window._canvasColor;
 					ctx.fillStyle = color;
@@ -90,7 +94,11 @@ templ CanvasPage(startColor string) {
 					});
 				}
 
-				/** @param {MouseEvent|Touch} e @returns {{x:number,y:number}|null} */
+				/**
+				 * Convert a pointer event to grid coordinates.
+				 * @param {MouseEvent|Touch} e - Pointer or touch event
+				 * @returns {{x: number, y: number}|null} Grid cell, or null if out of bounds
+				 */
 				function gridCoords(e) {
 					var rect = canvas.getBoundingClientRect();
 					var x = Math.floor((e.clientX - rect.left) * size / rect.width);


### PR DESCRIPTION
## Summary
- Expand terse single-line JSDoc on `paint()` and `gridCoords()` in `canvas.templ` into full multi-line format with descriptions
- Add JSDoc to `load()`, `save()`, `toggle()`, and `toggleAll()` in `admin_settings.templ`
- Add missing description line to `calcPercent()` in `architecture.templ`

## Test plan
- [ ] Verify no behavioral changes — only JSDoc comments were added
- [ ] Confirm templates still render correctly (`templ generate` + build)