### PR TITLE
fix: address minor philosophy violations

### DIFF
--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -261,11 +261,12 @@ func defaultControls(statusCode int, requestID string) []hypermedia.Control {
 }
 
 // HandleNotFound renders a full-page 404 within the base layout for direct
-// navigation. HTMX requests fall through to ErrorHandlerMiddleware for OOB
-// banner delivery. Register with e.RouteNotFound.
+// navigation. HTMX requests return a hypermedia error with back/home/report
+// controls, rendered as an OOB banner by ErrorHandlerMiddleware.
+// Register with e.RouteNotFound.
 func HandleNotFound(c echo.Context) error {
 	if c.Request().Header.Get("HX-Request") == "true" {
-		return echo.NewHTTPError(http.StatusNotFound, "Not Found")
+		return HandleHypermediaError(c, http.StatusNotFound, "Not Found", nil)
 	}
 	c.Response().Status = http.StatusNotFound
 	return RenderBaseLayout(c, views.NotFoundPage(c.Request().URL.Path))

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -50,6 +50,7 @@ type appRoutes struct {
 	issueReporter IssueReporter
 	startTime     time.Time
 	healthCfg     health.Config
+	pollCount     int64 // atomic; demo counter for SSE polling
 	// setup:feature:session_settings:start
 	settingsRepo repository.SessionSettingsRepository
 	// setup:feature:session_settings:end

--- a/internal/routes/routes_hypermedia.go
+++ b/internal/routes/routes_hypermedia.go
@@ -360,9 +360,6 @@ func crudItemsToView(items []crudItem) []views.CRUDViewItem {
 	return out
 }
 
-// pollCount is accessed atomically from the realtime routes file.
-var globalPollCount int64
-
-func incrementPollCount() int64 {
-	return atomic.AddInt64(&globalPollCount, 1)
+func (ar *appRoutes) incrementPollCount() int64 {
+	return atomic.AddInt64(&ar.pollCount, 1)
 }

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -23,7 +23,7 @@ import (
 
 func (ar *appRoutes) initRealtimeRoutes(broker *ssebroker.SSEBroker) {
 	ar.e.GET("/hypermedia/realtime", ar.handleRealtimePage())
-	ar.e.GET("/hypermedia/realtime/poll", handleRealtimePoll)
+	ar.e.GET("/hypermedia/realtime/poll", ar.handleRealtimePoll)
 	ar.e.GET("/hypermedia/realtime/sse-connect", handleSSEConnect)
 	ar.e.GET("/sse/system", handleSSESystem(broker))
 	ar.e.GET("/sse/dashboard", handleSSEDashboard(broker))
@@ -45,8 +45,8 @@ func (ar *appRoutes) handleRealtimePage() echo.HandlerFunc {
 	}
 }
 
-func handleRealtimePoll(c echo.Context) error {
-	n := incrementPollCount()
+func (ar *appRoutes) handleRealtimePoll(c echo.Context) error {
+	n := ar.incrementPollCount()
 	return handler.RenderComponent(c, views.PollCountFragment(n))
 }
 


### PR DESCRIPTION
## Summary
- **Statelessness**: Moved `globalPollCount` from a package-level `var` into the `appRoutes` struct as `pollCount`. Converted `incrementPollCount` and `handleRealtimePoll` to methods on `appRoutes` so the counter is tied to the application lifecycle rather than existing as stray mutable global state.
- **Error recovery controls**: Changed `HandleNotFound`'s HTMX branch from `echo.NewHTTPError` (which goes through the middleware's generic `handleError` with only a report-issue button) to `HandleHypermediaError` (which provides back, home, and report-issue controls via `defaultControls` for 404s). A not-found is a navigational error — the user needs a way to recover.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes — all existing tests green
- [ ] Manual: visit a non-existent route via HTMX navigation and verify the error banner includes back/home/report controls
- [ ] Manual: click the SSE polling demo and verify the counter still increments correctly