### PR TITLE
fix: convert getElementById patterns to _hyperscript

### DIFF
--- a/web/components/core/error_controls.templ
+++ b/web/components/core/error_controls.templ
@@ -70,7 +70,7 @@ templ htmxButton(ctrl hypermedia.Control) {
 templ dismissButton(ctrl hypermedia.Control) {
 	<button
 		class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded text-error-content/70 hover:text-error-content hover:underline focus:outline-none"
-		x-on:click="document.getElementById('error-status').innerHTML = ''"
+		_="on click set #error-status.innerHTML to ''"
 	>
 		{ ctrl.Label }
 	</button>

--- a/web/components/core/modal.templ
+++ b/web/components/core/modal.templ
@@ -82,7 +82,7 @@ templ Modal(cfg hypermedia.ModalConfig) {
 // Log data is retrieved from the ring buffer server-side when the report is submitted.
 // When fetched dynamically via HTMX the dialog auto-opens on load.
 templ ReportIssueModal(cfg hypermedia.ModalConfig) {
-	<div x-data x-init={ "$nextTick(() => document.getElementById('" + cfg.ID + "').showModal())" }>
+	<div _={ "init call #" + cfg.ID + ".showModal()" }>
 	@Modal(cfg) {
 		<p class="text-sm text-base-content/70 mb-3">This will send error details to our support team for investigation.</p>
 		<div x-ref="addToggle">

--- a/web/components/core/nav.templ
+++ b/web/components/core/nav.templ
@@ -37,7 +37,7 @@ templ NavBar(items []hypermedia.NavItem) {
 		<div class="flex-none">
 			<button
 				class="btn btn-ghost btn-sm btn-circle"
-				x-on:click="document.getElementById('settings-modal').showModal()"
+				_="on click call #settings-modal.showModal()"
 				aria-label="Settings"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>

--- a/web/views/app_nav_layout.templ
+++ b/web/views/app_nav_layout.templ
@@ -18,8 +18,7 @@ templ AppNavLayout(content templ.Component, items []hypermedia.NavItem, promoted
 					<a href="/" class="font-bold text-lg">{ appName }</a>
 					<button
 						class="btn btn-ghost btn-sm btn-circle"
-						x-data
-						x-on:click="document.getElementById('settings-modal').showModal()"
+						_="on click call #settings-modal.showModal()"
 						aria-label="Settings"
 					>
 						@settingsGearIcon()
@@ -97,7 +96,7 @@ templ appNav(items []hypermedia.NavItem, promoted *hypermedia.NavItem, maxVisibl
 			<div class="nav-settings items-center ml-1">
 				<button
 					class="nav-link"
-					x-on:click="document.getElementById('settings-modal').showModal()"
+					_="on click call #settings-modal.showModal()"
 					aria-label="Settings"
 				>
 					@settingsGearIcon()

--- a/web/views/settings.templ
+++ b/web/views/settings.templ
@@ -40,7 +40,7 @@ templ SettingsPage(sections []demo.SettingsSection) {
 						if i == 0 {
 							hx-trigger="click, load"
 						}
-						x-on:click="document.querySelectorAll('.settings-tab').forEach(t => t.classList.remove('active')); $el.classList.add('active')"
+						_="on click take .active from .settings-tab then add .active to me"
 					>
 						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 shrink-0">
 							<path stroke-linecap="round" stroke-linejoin="round" d={ settingsIcons[sec.ID] }></path>


### PR DESCRIPTION
## Summary

- Convert `document.getElementById()` and `document.querySelector()` patterns to `_hyperscript` in 5 template files
- Preserves identical behavior while improving locality of behavior (LoB)
- Removes orphaned `x-data` attributes where Alpine was only used for the converted click handler

## Files changed

- `web/components/core/error_controls.templ` — dismiss button
- `web/components/core/nav.templ` — settings modal open
- `web/components/core/modal.templ` — report issue auto-open
- `web/views/app_nav_layout.templ` — settings modal open (2 locations)
- `web/views/settings.templ` — tab switching

## Test plan

- [ ] Error banner dismiss still clears the error
- [ ] Settings gear opens the settings modal (mobile + desktop)
- [ ] Report issue modal auto-opens when triggered
- [ ] Settings tabs switch correctly with active state