### PR TITLE
fix: wrap bare error returns with context and handle discarded errors

### DIFF
--- a/internal/demo/db.go
+++ b/internal/demo/db.go
@@ -167,15 +167,15 @@ func (d *DB) initSchema() error {
 		created_at TEXT    NOT NULL
 	)`)
 	if err != nil {
-		return err
+		return fmt.Errorf("create items table: %w", err)
 	}
 	var count int
 	if err := d.db.QueryRow("SELECT COUNT(*) FROM items").Scan(&count); err != nil {
-		return err
+		return fmt.Errorf("count items rows: %w", err)
 	}
 	if count == 0 {
 		if err := d.seed(); err != nil {
-			return err
+			return fmt.Errorf("seed items: %w", err)
 		}
 	}
 	if err := d.initPeople(); err != nil {
@@ -278,18 +278,18 @@ func IntToBool(i int) bool {
 func seedBulk(db *sql.DB, query string, count int, argsFn func(i int) []any) error {
 	tx, err := db.Begin()
 	if err != nil {
-		return err
+		return fmt.Errorf("begin transaction: %w", err)
 	}
 	stmt, err := tx.Prepare(query)
 	if err != nil {
 		_ = tx.Rollback()
-		return err
+		return fmt.Errorf("prepare statement: %w", err)
 	}
 	defer stmt.Close()
 	for i := range count {
 		if _, err := stmt.Exec(argsFn(i)...); err != nil {
 			_ = tx.Rollback()
-			return err
+			return fmt.Errorf("exec row %d: %w", i, err)
 		}
 	}
 	return tx.Commit()

--- a/internal/demo/people.go
+++ b/internal/demo/people.go
@@ -136,11 +136,11 @@ func (d *DB) initPeople() error {
 		created_at TEXT NOT NULL
 	)`)
 	if err != nil {
-		return err
+		return fmt.Errorf("create people table: %w", err)
 	}
 	var count int
 	if err := d.db.QueryRow("SELECT COUNT(*) FROM people").Scan(&count); err != nil {
-		return err
+		return fmt.Errorf("count people rows: %w", err)
 	}
 	if count == 0 {
 		return d.seedPeople()

--- a/internal/demo/tasks.go
+++ b/internal/demo/tasks.go
@@ -292,7 +292,7 @@ func (d *DB) initTasks() error {
 
 	var count int
 	if err := d.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", TasksTable.Name)).Scan(&count); err != nil {
-		return err
+		return fmt.Errorf("count tasks rows: %w", err)
 	}
 	if count == 0 {
 		for _, stmt := range TasksTable.SeedSQL(sqliteDialect) {

--- a/internal/demo/vendor_contact.go
+++ b/internal/demo/vendor_contact.go
@@ -112,7 +112,7 @@ func (d *DB) initVendors() error {
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		name TEXT NOT NULL, category TEXT NOT NULL
 	)`); err != nil {
-		return err
+		return fmt.Errorf("create vendors table: %w", err)
 	}
 	if _, err := d.db.Exec(`CREATE TABLE IF NOT EXISTS contacts (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -120,12 +120,12 @@ func (d *DB) initVendors() error {
 		email TEXT NOT NULL, phone TEXT, role TEXT,
 		FOREIGN KEY (vendor_id) REFERENCES vendors(id)
 	)`); err != nil {
-		return err
+		return fmt.Errorf("create contacts table: %w", err)
 	}
 
 	var count int
 	if err := d.db.QueryRow("SELECT COUNT(*) FROM vendors").Scan(&count); err != nil {
-		return err
+		return fmt.Errorf("count vendors rows: %w", err)
 	}
 	if count > 0 {
 		return nil
@@ -172,7 +172,7 @@ func (d *DB) initVendors() error {
 		len(vendors), func(i int) []any {
 			return []any{vendors[i].name, vendors[i].cat}
 		}); err != nil {
-		return err
+		return fmt.Errorf("seed vendors: %w", err)
 	}
 	return seedBulk(d.db,
 		"INSERT INTO contacts (vendor_id,name,email,phone,role) VALUES (?,?,?,?,?)",

--- a/internal/repository/session_settings_repository.go
+++ b/internal/repository/session_settings_repository.go
@@ -61,7 +61,7 @@ func (r *sessionSettingsRepository) GetByUUID(ctx context.Context, uuid string) 
 func (r *sessionSettingsRepository) Upsert(ctx context.Context, s *domain.SessionSettings) error {
 	existing, err := r.GetByUUID(ctx, s.SessionUUID)
 	if err != nil {
-		return err
+		return fmt.Errorf("lookup existing session settings: %w", err)
 	}
 	if existing != nil {
 		query := fmt.Sprintf("UPDATE %s SET %s WHERE SessionUUID = @SessionUUID",

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -112,7 +112,12 @@ func (ar *appRoutes) InitRoutes() error {
 		description := c.FormValue("description")
 		var trace *promolog.ErrorTrace
 		if ar.reqLogStore != nil && requestID != "" {
-			trace, _ = ar.reqLogStore.Get(c.Request().Context(), requestID)
+			var err error
+			trace, err = ar.reqLogStore.Get(c.Request().Context(), requestID)
+			if err != nil {
+				logger.WithContext(c.Request().Context()).Error("Failed to retrieve error trace for report",
+					"request_id", requestID, "error", err)
+			}
 		}
 		if err := ar.issueReporter.Report(requestID, description, trace); err != nil {
 			logger.WithContext(c.Request().Context()).Error("Issue report failed",

--- a/internal/routes/routes_canvas.go
+++ b/internal/routes/routes_canvas.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"strconv"
@@ -60,8 +61,14 @@ func (cr *canvasRoutes) handleCanvasState(c echo.Context) error {
 
 func (cr *canvasRoutes) handlePlace(c echo.Context) error {
 	clientID := getOrCreateClientID(c)
-	x, _ := strconv.Atoi(c.FormValue("x"))
-	y, _ := strconv.Atoi(c.FormValue("y"))
+	x, err := strconv.Atoi(c.FormValue("x"))
+	if err != nil {
+		return c.String(http.StatusBadRequest, "invalid x coordinate")
+	}
+	y, err := strconv.Atoi(c.FormValue("y"))
+	if err != nil {
+		return c.String(http.StatusBadRequest, "invalid y coordinate")
+	}
 	color := c.FormValue("color")
 	if err := cr.canvas.PlaceColor(x, y, color); err != nil {
 		return c.String(http.StatusBadRequest, err.Error())
@@ -135,7 +142,11 @@ func (cr *canvasRoutes) broadcastPixel(x, y int, color string) {
 	if !cr.broker.HasSubscribers(ssebroker.TopicCanvasUpdate) {
 		return
 	}
-	data, _ := json.Marshal(map[string]any{"x": x, "y": y, "color": color})
+	data, err := json.Marshal(map[string]any{"x": x, "y": y, "color": color})
+	if err != nil {
+		slog.Error("marshal pixel update", "error", err)
+		return
+	}
 	msg := ssebroker.NewSSEMessage("pixel-update", string(data)).String()
 	cr.broker.Publish(ssebroker.TopicCanvasUpdate, msg)
 }
@@ -145,7 +156,11 @@ func (cr *canvasRoutes) broadcastClients() {
 		return
 	}
 	clients := cr.canvas.ActiveClients()
-	data, _ := json.Marshal(map[string]any{"count": len(clients), "clients": clients})
+	data, err := json.Marshal(map[string]any{"count": len(clients), "clients": clients})
+	if err != nil {
+		slog.Error("marshal clients update", "error", err)
+		return
+	}
 	msg := ssebroker.NewSSEMessage("clients-update", string(data)).String()
 	cr.broker.Publish(ssebroker.TopicCanvasUpdate, msg)
 }

--- a/internal/routes/routes_error_traces.go
+++ b/internal/routes/routes_error_traces.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"catgoose/dothog/internal/logger"
 	"github.com/catgoose/promolog"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/routes/hypermedia"
@@ -61,7 +62,11 @@ func (ar *appRoutes) handleErrorTracesList(c echo.Context) error {
 
 func (ar *appRoutes) handleErrorTraceDetail(c echo.Context) error {
 	requestID := c.Param("requestID")
-	trace, _ := ar.reqLogStore.Get(c.Request().Context(), requestID)
+	trace, err := ar.reqLogStore.Get(c.Request().Context(), requestID)
+	if err != nil {
+		logger.WithContext(c.Request().Context()).Error("Failed to retrieve error trace",
+			"request_id", requestID, "error", err)
+	}
 	if trace == nil {
 		return handler.HandleHypermediaError(c, 404, "Error trace not found", nil)
 	}

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -105,7 +105,11 @@ func (ar *appRoutes) initLoggingRoutes() {
 		if ar.reqLogStore == nil {
 			return handler.HandleHypermediaError(c, 404, "Store not configured", nil)
 		}
-		trace, _ := ar.reqLogStore.Get(c.Request().Context(), requestID)
+		trace, err := ar.reqLogStore.Get(c.Request().Context(), requestID)
+		if err != nil {
+			logger.WithContext(c.Request().Context()).Error("Failed to retrieve error trace",
+				"request_id", requestID, "error", err)
+		}
 		if trace == nil {
 			return handler.HandleHypermediaError(c, 404, "Trace not found or expired", nil)
 		}

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -116,7 +116,10 @@ func (p *peopleRoutes) handlePersonUpdate(c echo.Context) error {
 		return handler.HandleHypermediaError(c, 500, "Failed to update person", err)
 	}
 	// Re-fetch to get full data including created_at
-	person, _ = p.db.GetPerson(c.Request().Context(), id)
+	person, err = p.db.GetPerson(c.Request().Context(), id)
+	if err != nil {
+		return handler.HandleHypermediaError(c, 500, "Failed to re-fetch person after update", err)
+	}
 
 	// Record activity and broadcast to feed
 	evt := p.actLog.Record("updated", "person", id, person.FullName(), "profile updated")

--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"catgoose/dothog/internal/logger"
 	// setup:feature:session_settings:start
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/routes/middleware"
@@ -40,7 +41,9 @@ func (ar *appRoutes) handleTheme(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 		settings := middleware.GetSessionSettings(c)
 		settings.Theme = theme
 		if ar.settingsRepo != nil {
-			_ = ar.settingsRepo.Upsert(c.Request().Context(), settings)
+			if err := ar.settingsRepo.Upsert(c.Request().Context(), settings); err != nil {
+				logger.WithContext(c.Request().Context()).Error("Failed to save theme setting", "error", err)
+			}
 		}
 
 		// Broadcast theme change to all connected browsers.


### PR DESCRIPTION
## Summary

- Wrap all bare `return err` calls with `fmt.Errorf` context in `internal/demo/` (tasks, vendors, people, db init/seed) and `internal/repository/session_settings_repository.go`
- Return 400 errors for invalid grid coordinate form values in canvas place handler instead of silently defaulting to 0
- Log `json.Marshal` failures in canvas SSE broadcast functions instead of silently sending empty data
- Handle `GetPerson` error after update in people routes instead of ignoring it
- Log `Upsert` failure when saving theme settings
- Log error trace retrieval failures in report, logging, and error trace detail handlers

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — all tests green