### PR TITLE
refactor: narrow SessionSettingsRepository to consumer-defined interfaces

### DIFF
--- a/internal/repository/session_settings_repository.go
+++ b/internal/repository/session_settings_repository.go
@@ -14,23 +14,15 @@ import (
 	"github.com/catgoose/fraggle/dbrepo"
 )
 
-// SessionSettingsRepository defines operations for session settings data access.
-type SessionSettingsRepository interface {
-	GetByUUID(ctx context.Context, uuid string) (*domain.SessionSettings, error)
-	Upsert(ctx context.Context, s *domain.SessionSettings) error
-	Touch(ctx context.Context, uuid string) error
-	DeleteStale(ctx context.Context, days int) (int64, error)
-	ListAll(ctx context.Context) ([]domain.SessionSettings, error)
-	GetMostRecent(ctx context.Context) (*domain.SessionSettings, error)
-}
-
-// sessionSettingsRepository implements SessionSettingsRepository.
+// sessionSettingsRepository provides session settings data access.
 type sessionSettingsRepository struct {
 	repo *dbrepoManager.RepoManager
 }
 
-// NewSessionSettingsRepository creates a new SessionSettingsRepository.
-func NewSessionSettingsRepository(repo *dbrepoManager.RepoManager) SessionSettingsRepository {
+// NewSessionSettingsRepository creates a new session settings repository.
+// The returned value satisfies both middleware.SessionSettingsProvider and
+// routes.SessionSettingsStore via Go's implicit interface satisfaction.
+func NewSessionSettingsRepository(repo *dbrepoManager.RepoManager) *sessionSettingsRepository {
 	return &sessionSettingsRepository{repo: repo}
 }
 
@@ -124,29 +116,3 @@ func (r *sessionSettingsRepository) ListAll(ctx context.Context) ([]domain.Sessi
 	return rows, nil
 }
 
-// GetMostRecent returns the most recently updated session settings row, or nil if none exist.
-func (r *sessionSettingsRepository) GetMostRecent(ctx context.Context) (*domain.SessionSettings, error) {
-	query, args := dbrepo.NewSelect(tableName, selectCols).OrderBy("UpdatedAt DESC").Paginate(1, 0).Build()
-	var s domain.SessionSettings
-	err := r.repo.GetDB().GetContext(ctx, &s, query, args...)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get most recent session settings: %w", err)
-	}
-	return &s, nil
-}
-
-// DeleteStale removes session settings rows not updated in the given number of days.
-func (r *sessionSettingsRepository) DeleteStale(ctx context.Context, days int) (int64, error) {
-	w := dbrepo.NewWhere().And("UpdatedAt < datetime('now', @StaleInterval)",
-		sql.Named("StaleInterval", fmt.Sprintf("-%d days", days)),
-	)
-	query := fmt.Sprintf("DELETE FROM %s %s", tableName, w.String())
-	res, err := r.repo.GetDB().ExecContext(ctx, query, w.Args()...)
-	if err != nil {
-		return 0, fmt.Errorf("delete stale session settings: %w", err)
-	}
-	return res.RowsAffected()
-}

--- a/internal/routes/middleware/session_settings.go
+++ b/internal/routes/middleware/session_settings.go
@@ -3,14 +3,22 @@
 package middleware
 
 import (
+	"context"
 	"time"
 
 	"catgoose/dothog/internal/domain"
 	"catgoose/dothog/internal/logger"
-	"catgoose/dothog/internal/repository"
 
 	"github.com/labstack/echo/v4"
 )
+
+// SessionSettingsProvider is the subset of session-settings operations that
+// the middleware needs: look up, create-or-update, and touch a row.
+type SessionSettingsProvider interface {
+	GetByUUID(ctx context.Context, uuid string) (*domain.SessionSettings, error)
+	Upsert(ctx context.Context, s *domain.SessionSettings) error
+	Touch(ctx context.Context, uuid string) error
+}
 
 const (
 	settingsContextKey = "sessionSettings"
@@ -21,7 +29,7 @@ const (
 
 // SessionSettingsMiddleware loads the shared session settings row and stores
 // it on the echo context. All visitors share the same settings.
-func SessionSettingsMiddleware(repo repository.SessionSettingsRepository) echo.MiddlewareFunc {
+func SessionSettingsMiddleware(repo SessionSettingsProvider) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			ctx := c.Request().Context()

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -16,7 +16,7 @@ import (
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/routes/hypermedia"
 	// setup:feature:session_settings:start
-	"catgoose/dothog/internal/repository"
+	"catgoose/dothog/internal/domain"
 	// setup:feature:session_settings:end
 	corecomponents "catgoose/dothog/web/components/core"
 	"catgoose/dothog/web/views"
@@ -42,6 +42,17 @@ type AppRoutes interface {
 	SetHealthStats(fn health.StatsFunc)
 }
 
+// setup:feature:session_settings:start
+
+// SessionSettingsStore is the subset of session-settings operations that route
+// handlers need: listing all rows and upserting a single row.
+type SessionSettingsStore interface {
+	ListAll(ctx context.Context) ([]domain.SessionSettings, error)
+	Upsert(ctx context.Context, s *domain.SessionSettings) error
+}
+
+// setup:feature:session_settings:end
+
 // appRoutes implements AppRoutes
 type appRoutes struct {
 	e             *echo.Echo
@@ -51,7 +62,7 @@ type appRoutes struct {
 	startTime     time.Time
 	healthCfg     health.Config
 	// setup:feature:session_settings:start
-	settingsRepo repository.SessionSettingsRepository
+	settingsRepo SessionSettingsStore
 	// setup:feature:session_settings:end
 }
 
@@ -60,7 +71,7 @@ type appRoutes struct {
 // reporter may be nil; a default no-op reporter is used.
 func NewAppRoutes(ctx context.Context, e *echo.Echo, reqLogStore *promolog.Store, reporter IssueReporter,
 	// setup:feature:session_settings:start
-	settingsRepo repository.SessionSettingsRepository,
+	settingsRepo SessionSettingsStore,
 	// setup:feature:session_settings:end
 ) AppRoutes {
 	if reporter == nil {
@@ -205,7 +216,7 @@ func (ar *appRoutes) SetHealthStats(fn health.StatsFunc) {
 // InitEcho initializes Echo with global configurations
 func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 	// setup:feature:session_settings:start
-	settingsRepo repository.SessionSettingsRepository,
+	settingsRepo middleware.SessionSettingsProvider,
 	// setup:feature:session_settings:end
 	reqLogStore *promolog.Store,
 ) (*echo.Echo, error) {


### PR DESCRIPTION
## Summary
- Replace the 6-method `SessionSettingsRepository` interface with two small, consumer-defined interfaces: `middleware.SessionSettingsProvider` (GetByUUID, Upsert, Touch) and `routes.SessionSettingsStore` (ListAll, Upsert)
- Remove dead code: `DeleteStale` and `GetMostRecent` had no callers
- Constructor returns the concrete type; Go's implicit interface satisfaction wires everything together

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)