### PR TITLE
fix: replace Go module path when syncing to harmony

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -339,8 +339,12 @@ jobs:
           rm -f .github/workflows/screenshots.yml
           rm -f MANIFESTO.md
 
-          # Scrub binary name references
-          sed -i 's/dothog/harmony/g' .github/workflows/*.yml Dockerfile
+          # Replace Go module path in all source files
+          find . -name '*.go' -exec sed -i 's|catgoose/dothog|catgoose/harmony|g' {} +
+          sed -i 's|catgoose/dothog|catgoose/harmony|g' go.mod
+
+          # Scrub binary name references (workflows, Dockerfile, and files with literal "dothog")
+          sed -i 's/dothog/harmony/g' .github/workflows/*.yml Dockerfile magefile.go internal/logger/logger.go
 
       - name: Push to harmony
         run: |


### PR DESCRIPTION
## Summary

The `sync-harmony` job was only running `sed -i 's/dothog/harmony/g'` on workflow files and Dockerfile. This left `go.mod` and all Go source imports as `catgoose/dothog`, causing harmony's test output to show dothog module paths.

Now adds two steps before the binary name scrub:
1. `find . -name '*.go' -exec sed -i 's|catgoose/dothog|catgoose/harmony|g' {} +` — all Go imports
2. `sed -i 's|catgoose/dothog|catgoose/harmony|g' go.mod` — module declaration

Also extends the binary name scrub to cover `magefile.go` (`binaryName = "dothog"`) and `internal/logger/logger.go` (`appLogFile = "dothog.log"`).

## Test plan

- [ ] After next pipeline run, verify harmony's `go.mod` says `module catgoose/harmony`
- [ ] Verify `go test ./...` output in harmony shows `catgoose/harmony` paths