### PR TITLE
fix: add missing postgres and sqlite3 driver imports to scaffold

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,8 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
+require github.com/lib/pq v1.12.0 // indirect
+
 require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"catgoose/dothog/internal/config"
 	dialect "github.com/catgoose/fraggle"
+	_ "github.com/catgoose/fraggle/driver/postgres"
+	_ "github.com/catgoose/fraggle/driver/sqlite"
 	// setup:feature:session_settings:start
 	"catgoose/dothog/internal/database"
 	// setup:feature:session_settings:end


### PR DESCRIPTION
## Summary
- Adds blank imports for `fraggle/driver/postgres` and `fraggle/driver/sqlite` to the scaffold's main.go
- Prevents runtime `sql: unknown driver` crashes in derived apps

Closes #92