### PR TITLE
fix: read theme from echo context instead of hardcoding

### DIFF
--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -82,7 +82,10 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 		csrfToken = t
 	}
 	// setup:feature:csrf:end
-	theme := "light"
+	theme := "dark"
+	if t, ok := c.Get("theme").(string); ok && t != "" {
+		theme = t
+	}
 	// setup:feature:session_settings:start
 	theme = middleware.GetSessionSettings(c).Theme
 	// setup:feature:session_settings:end

--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -191,5 +191,8 @@ func errorPageTheme(c echo.Context) string {
 		return s.Theme
 	}
 	// setup:feature:session_settings:end
-	return "light"
+	if t, ok := c.Get("theme").(string); ok && t != "" {
+		return t
+	}
+	return "dark"
 }


### PR DESCRIPTION
## Summary
- Updates `getLayoutCtx` in handler.go and `errorPageTheme` in error_handler.go to check `c.Get("theme")` from echo context
- Falls back to `"dark"` instead of `"light"` when no theme is set
- Enables apps with per-account themes set via auth middleware

Closes #93