### PR TITLE
fix: exclude integration tests from release workflow

### DIFF
--- a/.github/harmony/release.yml
+++ b/.github/harmony/release.yml
@@ -111,7 +111,7 @@ jobs:
         run: go tool templ generate
 
       - name: Run tests
-        run: go test ./...
+        run: go test -timeout 10m $(go list ./... | grep -v /tests)
 
       - name: Build all platforms
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         run: go tool templ generate
 
       - name: Run tests
-        run: go test ./...
+        run: go test -timeout 10m $(go list ./... | grep -v /tests)
 
       - name: Build all platforms
         run: |


### PR DESCRIPTION
## Summary
- Release workflow ran `go test ./...` (default 10m timeout) which included integration tests that need 15m
- Pipeline already runs integration tests with proper timeout before release triggers, so no need to re-run
- Excludes `./tests/` package from both dothog and harmony release workflows

Closes the release CI timeout failure.