### PR TITLE
feat: add offline write queue with IndexedDB storage (Phase 3)

### DIFF
--- a/web/assets/public/js/offline-indicator.js
+++ b/web/assets/public/js/offline-indicator.js
@@ -10,8 +10,21 @@ function offlineIndicator() {
     _interval: null,
 
     init() {
-      window.addEventListener('online', () => { this.online = true; });
-      window.addEventListener('offline', () => { this.online = false; });
+      window.addEventListener('online', () => {
+        this.online = true;
+        this.notifyServiceWorker(true);
+      });
+      window.addEventListener('offline', () => {
+        this.online = false;
+        this.notifyServiceWorker(false);
+      });
+
+      // Listen for pending count updates from the service worker
+      navigator.serviceWorker?.addEventListener('message', (event) => {
+        if (event.data?.type === 'PENDING_COUNT') {
+          this.pending = event.data.count;
+        }
+      });
 
       // Heartbeat: verify actual server reachability (navigator.onLine can be wrong)
       this._interval = setInterval(() => this.checkHealth(), 30000);
@@ -31,9 +44,22 @@ function offlineIndicator() {
       try {
         const res = await fetch('/health', { method: 'HEAD', cache: 'no-store' });
         this.online = res.ok;
+        this.notifyServiceWorker(res.ok);
       } catch {
         this.online = false;
+        this.notifyServiceWorker(false);
       }
+    },
+
+    /**
+     * Notify the service worker of connectivity changes.
+     * @param {boolean} online
+     */
+    notifyServiceWorker(online) {
+      navigator.serviceWorker?.controller?.postMessage({
+        type: 'SET_ONLINE_STATUS',
+        online,
+      });
     },
   };
 }

--- a/web/assets/public/js/sync.js
+++ b/web/assets/public/js/sync.js
@@ -1,0 +1,135 @@
+/**
+ * Sync manager for offline write queuing.
+ * Uses IndexedDB for local storage — works in service workers, main thread,
+ * and regular browsers without Capacitor.
+ */
+
+const DB_NAME = 'dothog_sync';
+const QUEUE_STORE = 'sync_queue';
+
+/**
+ * Open the sync database.
+ * @returns {Promise<IDBDatabase>}
+ */
+function openSyncDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(QUEUE_STORE)) {
+        const store = db.createObjectStore(QUEUE_STORE, {
+          keyPath: 'id',
+          autoIncrement: true,
+        });
+        store.createIndex('status', 'status', { unique: false });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Queue an offline write operation.
+ * @param {Object} op
+ * @param {string} op.method - HTTP method (POST, PUT, DELETE)
+ * @param {string} op.url - Request URL
+ * @param {string} op.body - Form-encoded body
+ * @param {string} op.contentType - Content-Type header value
+ * @param {number|null} op.version - Row version for conflict detection
+ * @returns {Promise<void>}
+ */
+async function queueWrite(op) {
+  const db = await openSyncDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(QUEUE_STORE, 'readwrite');
+    tx.objectStore(QUEUE_STORE).add({
+      method: op.method,
+      url: op.url,
+      body: op.body,
+      contentType: op.contentType || 'application/x-www-form-urlencoded',
+      version: op.version || null,
+      createdAt: new Date().toISOString(),
+      status: 'pending',
+    });
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/**
+ * Get the count of pending writes in the queue.
+ * @returns {Promise<number>}
+ */
+async function getPendingCount() {
+  const db = await openSyncDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(QUEUE_STORE, 'readonly');
+    const idx = tx.objectStore(QUEUE_STORE).index('status');
+    const req = idx.count(IDBKeyRange.only('pending'));
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Get all pending operations for sync.
+ * @returns {Promise<Array>}
+ */
+async function getPendingOperations() {
+  const db = await openSyncDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(QUEUE_STORE, 'readonly');
+    const idx = tx.objectStore(QUEUE_STORE).index('status');
+    const req = idx.getAll(IDBKeyRange.only('pending'));
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Update the status of a queued operation.
+ * @param {number} id - Queue entry ID
+ * @param {string} status - New status (syncing, synced, conflict, rejected)
+ * @returns {Promise<void>}
+ */
+async function updateStatus(id, status) {
+  const db = await openSyncDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(QUEUE_STORE, 'readwrite');
+    const store = tx.objectStore(QUEUE_STORE);
+    const req = store.get(id);
+    req.onsuccess = () => {
+      const entry = req.result;
+      if (entry) {
+        entry.status = status;
+        store.put(entry);
+      }
+      tx.oncomplete = () => resolve();
+    };
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/**
+ * Remove all synced entries from the queue.
+ * @returns {Promise<void>}
+ */
+async function clearSynced() {
+  const db = await openSyncDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(QUEUE_STORE, 'readwrite');
+    const store = tx.objectStore(QUEUE_STORE);
+    const idx = store.index('status');
+    const req = idx.openCursor(IDBKeyRange.only('synced'));
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) {
+        cursor.delete();
+        cursor.continue();
+      }
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/web/assets/public/sw.js
+++ b/web/assets/public/sw.js
@@ -3,11 +3,27 @@
  * Strategy: network-first with cache fallback.
  *
  * - GET requests: try server first, cache response, fall back to cache
- * - POST/PUT/DELETE: pass through when online (Phase 3 adds offline queue)
+ * - POST/PUT/DELETE: queue to IndexedDB when offline, pass through when online
  * - Static assets (/public/): cache-first (they're immutable with long max-age)
  */
 
+importScripts('/public/js/sync.js');
+
 const CACHE_NAME = 'dothog-v1';
+
+// Connectivity state — updated by the main thread via postMessage
+self._isOnline = true;
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SET_ONLINE_STATUS') {
+    self._isOnline = event.data.online;
+  }
+  if (event.data && event.data.type === 'GET_PENDING_COUNT') {
+    getPendingCount().then((count) => {
+      event.source.postMessage({ type: 'PENDING_COUNT', count });
+    });
+  }
+});
 
 // Static assets to pre-cache on install
 const PRECACHE_URLS = [
@@ -39,8 +55,11 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const { request } = event;
 
-  // Only handle GET requests — mutations pass through (Phase 3 will intercept offline writes)
+  // Mutations: queue offline, pass through online
   if (request.method !== 'GET') {
+    if (!self._isOnline) {
+      event.respondWith(handleOfflineWrite(request));
+    }
     return;
   }
 
@@ -126,6 +145,48 @@ function buildCacheKey(request) {
     return new Request(url.toString(), { method: 'GET' });
   }
   return request;
+}
+
+/**
+ * Handle a mutation request when offline.
+ * Queues the write to IndexedDB and returns a synthetic "pending" response.
+ * @param {Request} request
+ * @returns {Promise<Response>}
+ */
+async function handleOfflineWrite(request) {
+  const body = await request.text();
+
+  await queueWrite({
+    method: request.method,
+    url: new URL(request.url).pathname + new URL(request.url).search,
+    body: body,
+    contentType: request.headers.get('Content-Type'),
+  });
+
+  const count = await getPendingCount();
+
+  // Notify all clients of the new pending count
+  const clients = await self.clients.matchAll();
+  for (const client of clients) {
+    client.postMessage({ type: 'PENDING_COUNT', count });
+  }
+
+  // Return a synthetic HTML response that HTMX can swap
+  const html = `<div class="badge badge-warning badge-sm gap-1">
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+  </svg>
+  Saved (pending sync)
+</div>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html',
+      'HX-Trigger': JSON.stringify({ pendingSync: count }),
+      'HX-Reswap': 'innerHTML',
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Phase 3 of the offline-first iOS plan (#101).

- **`sync.js`** — IndexedDB-based write queue (chosen over Capacitor SQLite because IndexedDB works in service workers)
- **Service worker** extended to intercept POST/PUT/DELETE when offline, queue to IndexedDB, and return a synthetic "Saved (pending sync)" HTML fragment that HTMX swaps normally
- **Offline indicator** updated to receive pending count from service worker via `postMessage` and push connectivity state back

## How it works

```
Online:   POST /tasks → Service Worker → Server → HTML response
Offline:  POST /tasks → Service Worker → IndexedDB queue → "Saved (pending sync)" fragment
```

The service worker tracks connectivity state via messages from the main thread. When offline, mutations queue silently. The pending count badge updates in real-time.

## What's next

Phase 4 (#105) adds the server-side `/sync` endpoint that flushes this queue when connectivity returns.

## Test plan

- [x] `go build ./...` passes
- [ ] Submit a form while offline — see "Saved (pending sync)"
- [ ] Submit multiple forms — pending count increases
- [ ] Pending data persists across app restarts (IndexedDB)
- [ ] Going back online doesn't auto-sync yet (that's Phase 4 client-side integration)