### PR TITLE
feat: add capacitor, offline, sync feature flags to setup tool

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,3 +1,4 @@
+// setup:feature:capacitor
 import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {

--- a/internal/routes/sync_types.go
+++ b/internal/routes/sync_types.go
@@ -1,3 +1,4 @@
+// setup:feature:sync
 package routes
 
 import "time"

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -37,16 +37,68 @@ const (
 	FeatureDemo             = "demo"
 	FeatureSessionSettings  = "session_settings"
 	FeatureAlpine           = "alpine"
+	FeatureCapacitor        = "capacitor"
+	FeatureOffline          = "offline"
+	FeatureSync             = "sync"
 )
 
 // AllFeatures lists every selectable feature tag.
 // "database" is always included (implied by the base template) and is not user-selectable.
-var AllFeatures = []string{FeatureAuth, FeatureGraph, FeatureDatabase, FeatureMSSQL, FeaturePostgres, FeatureSSE, FeatureCaddy, FeatureAvatar, FeatureDemo, FeatureSessionSettings, FeatureAlpine}
+var AllFeatures = []string{FeatureAuth, FeatureGraph, FeatureDatabase, FeatureMSSQL, FeaturePostgres, FeatureSSE, FeatureCaddy, FeatureAvatar, FeatureDemo, FeatureSessionSettings, FeatureAlpine, FeatureCapacitor, FeatureOffline, FeatureSync}
 
 // ImplicitFeatures are always selected and not presented to the user.
 // "database" is implicit because SQLite is the base database engine.
 // "alpine" is implicit because Alpine.js is the standard client-side state layer.
 var ImplicitFeatures = []string{FeatureDatabase, FeatureAlpine}
+
+// featureDeps maps a feature to the features it implies.
+// sync -> offline -> capacitor.
+var featureDeps = map[string][]string{
+	FeatureSync:    {FeatureOffline},
+	FeatureOffline: {FeatureCapacitor},
+}
+
+// ExpandFeatureDeps adds any transitive dependencies implied by the
+// selected features. For example, selecting "sync" pulls in "offline"
+// and "capacitor".
+func ExpandFeatureDeps(features []string) []string {
+	have := make(map[string]bool, len(features))
+	for _, f := range features {
+		have[f] = true
+	}
+	changed := true
+	for changed {
+		changed = false
+		for f := range have {
+			for _, dep := range featureDeps[f] {
+				if !have[dep] {
+					have[dep] = true
+					changed = true
+				}
+			}
+		}
+	}
+	out := make([]string, 0, len(have))
+	for _, f := range AllFeatures {
+		if have[f] {
+			out = append(out, f)
+		}
+	}
+	// Preserve any features not in AllFeatures (shouldn't happen, but safe).
+	for f := range have {
+		found := false
+		for _, af := range AllFeatures {
+			if af == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			out = append(out, f)
+		}
+	}
+	return out
+}
 
 // Options configures the template setup run.
 type Options struct {
@@ -359,8 +411,9 @@ func removeOptionalContent(dir string, opts Options) error {
 	// Build set of features being removed (empty when Features is nil — legacy mode)
 	removeTags := make(map[string]bool)
 	if opts.Features != nil {
+		expanded := ExpandFeatureDeps(opts.Features)
 		keep := make(map[string]bool)
-		for _, f := range opts.Features {
+		for _, f := range expanded {
 			keep[f] = true
 		}
 		// Implicit features are always kept
@@ -384,6 +437,10 @@ func removeOptionalContent(dir string, opts Options) error {
 	}
 	if removeTags[FeatureCaddy] {
 		_ = os.Remove(filepath.Join(dir, "config", "Caddyfile"))
+	}
+	if removeTags[FeatureCapacitor] {
+		_ = os.Remove(filepath.Join(dir, "capacitor.config.ts"))
+		_ = os.Remove(filepath.Join(dir, "tsconfig.json"))
 	}
 	// Alpine.js is always included (implicit feature); no removal needed.
 

--- a/magefile.go
+++ b/magefile.go
@@ -888,6 +888,8 @@ func CaddyStart() error {
 	return sh.Run("caddy", "run", "--config", tmpCaddyfile)
 }
 
+// setup:feature:capacitor:start
+
 // IosDeps installs Capacitor iOS dependencies (requires macOS with Xcode).
 func IosDeps() error {
 	if runtime.GOOS != "darwin" {
@@ -926,3 +928,5 @@ func IosRun() error {
 	mg.Deps(IosSync)
 	return sh.Run("npx", "cap", "run", "ios")
 }
+
+// setup:feature:capacitor:end

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
+// setup:feature:capacitor
 {
   "compilerOptions": {
     "target": "es2022",

--- a/web/assets/public/js/offline-indicator.js
+++ b/web/assets/public/js/offline-indicator.js
@@ -1,3 +1,4 @@
+// setup:feature:offline
 /**
  * Alpine.js data component for offline status detection.
  * Uses navigator.onLine and periodic /health pings to determine connectivity.

--- a/web/assets/public/js/sync.js
+++ b/web/assets/public/js/sync.js
@@ -1,3 +1,4 @@
+// setup:feature:sync
 /**
  * Sync manager for offline write queuing.
  * Uses IndexedDB for local storage — works in service workers, main thread,

--- a/web/assets/public/sw.js
+++ b/web/assets/public/sw.js
@@ -1,3 +1,4 @@
+// setup:feature:offline
 /**
  * Service worker for offline-first HTML caching.
  * Strategy: network-first with cache fallback.

--- a/web/components/core/offline_indicator.templ
+++ b/web/components/core/offline_indicator.templ
@@ -1,3 +1,4 @@
+// setup:feature:offline
 package components
 
 // OfflineIndicator renders a connectivity status badge.

--- a/web/views/app_nav_layout.templ
+++ b/web/views/app_nav_layout.templ
@@ -43,7 +43,9 @@ templ AppNavLayout(content templ.Component, items []hypermedia.NavItem, promoted
 				<div id="report-modal-container"></div>
 				<div id="report-email-container"></div>
 				@settingsModal(theme)
+				// setup:feature:offline:start
 				@components.OfflineIndicator()
+				// setup:feature:offline:end
 			</div>
 		</body>
 	</html>

--- a/web/views/app_nav_layout_templ.go
+++ b/web/views/app_nav_layout_templ.go
@@ -128,10 +128,12 @@ func AppNavLayout(content templ.Component, items []hypermedia.NavItem, promoted 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		// setup:feature:offline:start
 		templ_7745c5c3_Err = components.OfflineIndicator().Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		// setup:feature:offline:end
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/web/views/conflicts.templ
+++ b/web/views/conflicts.templ
@@ -1,3 +1,4 @@
+// setup:feature:sync
 package views
 
 import (

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -44,7 +44,9 @@ templ Index(layoutContent templ.Component, menuContent templ.Component, csrfToke
 			<div id="report-modal-container"></div>
 			<div id="report-email-container"></div>
 			@settingsModal(theme)
+			// setup:feature:offline:start
 			@components.OfflineIndicator()
+			// setup:feature:offline:end
 		</body>
 	</html>
 }
@@ -83,7 +85,9 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 		// setup:feature:sse:start
 		<script defer src="/public/js/htmx.ext.sse.js"></script>
 		// setup:feature:sse:end
+		// setup:feature:offline:start
 		<script defer src="/public/js/offline-indicator.js"></script>
+		// setup:feature:offline:end
 		<link rel="stylesheet" href="/public/css/tailwind.css" type="text/css"/>
 		<link rel="stylesheet" href="/public/css/daisyui.css" type="text/css"/>
 		for _, href := range extraCSS {
@@ -149,6 +153,7 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 		</script>
 		// setup:feature:session_settings:end
 		// setup:feature:sse:end
+		// setup:feature:offline:start
 		<script>
 			if ('serviceWorker' in navigator) {
 				navigator.serviceWorker.register('/public/sw.js').catch(function(err) {
@@ -156,6 +161,7 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 				});
 			}
 		</script>
+		// setup:feature:offline:end
 	</head>
 }
 

--- a/web/views/index_templ.go
+++ b/web/views/index_templ.go
@@ -107,10 +107,12 @@ func Index(layoutContent templ.Component, menuContent templ.Component, csrfToken
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		// setup:feature:offline:start
 		templ_7745c5c3_Err = components.OfflineIndicator().Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		// setup:feature:offline:end
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err


### PR DESCRIPTION
## Summary

- Add `capacitor`, `offline`, and `sync` as feature flags to the setup tool with dependency chain: `sync` -> `offline` -> `capacitor`
- Add `setup:feature:` markers to all capacitor/offline/sync files so they are correctly stripped when features are deselected
- Add `ExpandFeatureDeps` function to automatically include transitive dependencies (e.g., selecting `sync` auto-includes `offline` and `capacitor`)

Refs #101

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/setup/...` passes (unit tests)
- [x] All feature-combo integration tests pass (`TestSetup_FeaturesAll`, `TestSetup_FeaturesNone`, `TestSetup_FeaturesAuthOnly`, `TestSetup_FeaturesMSSQL`, `TestSetup_FeaturesSSECaddy`, `TestSetup_FeaturesDemo`)
- [ ] Verify new features appear in interactive setup selector
- [ ] Verify selecting `sync` alone pulls in `offline` and `capacitor`
- [ ] Verify disabling `capacitor` removes `capacitor.config.ts`, `tsconfig.json`, and mage iOS targets