### PR TITLE
feat: add Fastlane config and iOS CI/CD workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,73 @@
+name: iOS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: 'Fastlane lane to run'
+        required: true
+        default: 'build_debug'
+        type: choice
+        options:
+          - build_debug
+          - beta
+
+# Only allow one iOS build at a time
+concurrency:
+  group: ios-build
+  cancel-in-progress: true
+
+jobs:
+  ios:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Generate templ files
+        run: go tool templ generate
+
+      - name: Build Go binary
+        run: go build -o dothog .
+
+      - name: Sync Capacitor
+        run: npx cap sync ios
+
+      - name: Install CocoaPods
+        run: cd ios/App && pod install
+        continue-on-error: true  # pods may already be installed via cap sync
+
+      - name: Run Fastlane
+        run: cd ios/App && bundle exec fastlane ${{ github.event.inputs.lane }}
+        env:
+          # For beta lane (TestFlight uploads), set these secrets:
+          # MATCH_GIT_URL: private repo URL for code signing certs
+          # MATCH_PASSWORD: encryption password for match
+          # APP_STORE_CONNECT_API_KEY_ID: API key ID
+          # APP_STORE_CONNECT_API_ISSUER_ID: Issuer ID
+          # APP_STORE_CONNECT_API_KEY: Base64-encoded .p8 key
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.ASC_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,14 @@ android/
 
 # Capacitor build artifacts
 capacitor.config.d.ts
+
+# Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+
+# Ruby / Bundler
+Gemfile.lock
+vendor/bundle/
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,7 @@
+# App identifier and Apple ID for Fastlane
+# These are placeholders — replace with actual values when configuring for a project.
+app_identifier("com.catgoose.dothog")
+# apple_id("your@email.com")
+
+# For App Store Connect API key authentication (recommended for CI):
+# See: https://docs.fastlane.tools/app-store-connect-api/

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,41 @@
+# Fastfile for iOS builds via Capacitor
+# See: https://docs.fastlane.tools
+
+default_platform(:ios)
+
+platform :ios do
+  desc "Build and upload to TestFlight"
+  lane :beta do
+    setup_ci if ENV["CI"]
+
+    # Match handles code signing via a private git repo of certificates/profiles
+    match(
+      type: "appstore",
+      readonly: is_ci,
+    )
+
+    build_app(
+      workspace: "ios/App/App.xcworkspace",
+      scheme: "App",
+      export_method: "app-store",
+      clean: true,
+    )
+
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true,
+    )
+  end
+
+  desc "Build for simulator (CI validation only)"
+  lane :build_debug do
+    build_app(
+      workspace: "ios/App/App.xcworkspace",
+      scheme: "App",
+      configuration: "Debug",
+      destination: "generic/platform=iOS Simulator",
+      skip_codesigning: true,
+      skip_archive: true,
+      derived_data_path: "build/ios",
+    )
+  end
+end

--- a/magefile.go
+++ b/magefile.go
@@ -929,4 +929,13 @@ func IosRun() error {
 	return sh.Run("npx", "cap", "run", "ios")
 }
 
+// IosBeta builds and uploads to TestFlight via Fastlane (requires macOS).
+func IosBeta() error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("iOS targets require macOS with Xcode installed")
+	}
+	mg.Deps(IosSync)
+	return sh.Run("bundle", "exec", "fastlane", "beta")
+}
+
 // setup:feature:capacitor:end


### PR DESCRIPTION
## Summary

- Add two Fastlane lanes: `build_debug` (CI validation build for simulator, no code signing) and `beta` (production build with match code signing + TestFlight upload)
- Add GitHub Actions `ios.yml` workflow with manual trigger (`workflow_dispatch`) and lane selection
- Add `mage iosBeta` target for running the TestFlight build locally on macOS
- Add `Gemfile` for Bundler/Fastlane dependency management
- Add Fastlane artifacts and Ruby/Bundler paths to `.gitignore`

## Details

**Fastlane lanes:**
- `build_debug` - Builds for iOS Simulator with no code signing; useful for CI validation
- `beta` - Uses `match` for certificate/profile management, builds for App Store, uploads to TestFlight

**GitHub Actions workflow (`ios.yml`):**
- Triggered manually via `workflow_dispatch` with lane selection
- Runs on `macos-latest` with Go, Node 22, Ruby 3.3
- Full pipeline: npm ci, templ generate, go build, cap sync, pod install, fastlane

**Secrets needed for TestFlight (`beta` lane):**
- `MATCH_GIT_URL` - Private repo URL for code signing certificates
- `MATCH_PASSWORD` - Encryption password for match
- `ASC_KEY_ID` - App Store Connect API key ID
- `ASC_ISSUER_ID` - App Store Connect API issuer ID
- `ASC_API_KEY` - Base64-encoded .p8 key

**Note:** `fastlane/Appfile` contains placeholder values (`com.catgoose.dothog`) that should be replaced when configuring for a real project.

Refs #101