### PR TITLE
fix: use promolog Buffer.Snapshot() instead of direct field access

### DIFF
--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -121,7 +121,7 @@ func NewHTTPErrorHandler(reqLogStore *promolog.Store) func(err error, c echo.Con
 			if requestID != "" {
 				var entries []promolog.Entry
 				if buf := promolog.GetBuffer(c.Request().Context()); buf != nil {
-					entries = buf.Entries
+					entries = buf.Snapshot()
 				}
 				var userID string
 				// setup:feature:auth:start


### PR DESCRIPTION
## Summary
- Replaces `buf.Entries` (direct field access) with `buf.Snapshot()` (thread-safe copy)
- Prepares for upcoming promolog release where `Entries` will be unexported

Closes #111