### PR TITLE
fix: address philosophy violations in offline-first code

### DIFF
--- a/internal/routes/routes_sync.go
+++ b/internal/routes/routes_sync.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"catgoose/dothog/internal/logger"
+	"catgoose/dothog/internal/routes/middleware"
 
 	"github.com/labstack/echo/v4"
 )
@@ -19,7 +20,8 @@ func (ar *appRoutes) handleSync(c echo.Context) error {
 	var req SyncRequest
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{
-			"error": "invalid sync request",
+			"error":      "invalid sync request",
+			"request_id": middleware.GetRequestID(c),
 		})
 	}
 

--- a/internal/routes/sync_version.go
+++ b/internal/routes/sync_version.go
@@ -9,6 +9,15 @@ import (
 	"strconv"
 )
 
+// knownTables is the set of tables that support version-based sync.
+// This is the single source of truth for SQL table name validation —
+// no regex needed when we can enumerate the valid values.
+var knownTables = map[string]bool{
+	"Tasks":  true,
+	"Items":  true,
+	"People": true,
+}
+
 // VersionChecker looks up the current version of a row by table and ID.
 type VersionChecker interface {
 	CurrentVersion(ctx context.Context, table string, id int) (int, error)
@@ -28,9 +37,8 @@ func NewSQLVersionChecker(db *sql.DB) *SQLVersionChecker {
 
 // CurrentVersion returns the current version of a row, or -1 if not found.
 func (vc *SQLVersionChecker) CurrentVersion(ctx context.Context, table string, id int) (int, error) {
-	// Validate table name to prevent SQL injection (only allow alphanumeric + underscore)
-	if !isValidTableName(table) {
-		return 0, fmt.Errorf("invalid table name: %s", table)
+	if !knownTables[table] {
+		return 0, fmt.Errorf("unknown table: %s", table)
 	}
 
 	var version int
@@ -43,12 +51,6 @@ func (vc *SQLVersionChecker) CurrentVersion(ctx context.Context, table string, i
 		return 0, fmt.Errorf("check version for %s/%d: %w", table, id, err)
 	}
 	return version, nil
-}
-
-var validTableRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
-
-func isValidTableName(name string) bool {
-	return validTableRe.MatchString(name)
 }
 
 // parseResourceURL extracts a table name hint and row ID from a sync operation URL.

--- a/internal/routes/sync_version_test.go
+++ b/internal/routes/sync_version_test.go
@@ -43,11 +43,11 @@ func TestParseResourceURL_CreateURL(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestIsValidTableName(t *testing.T) {
-	assert.True(t, isValidTableName("Tasks"))
-	assert.True(t, isValidTableName("Items"))
-	assert.True(t, isValidTableName("my_table"))
-	assert.False(t, isValidTableName("Tasks; DROP TABLE"))
-	assert.False(t, isValidTableName(""))
-	assert.False(t, isValidTableName("123"))
+func TestKnownTables(t *testing.T) {
+	assert.True(t, knownTables["Tasks"])
+	assert.True(t, knownTables["Items"])
+	assert.True(t, knownTables["People"])
+	assert.False(t, knownTables["Unknown"])
+	assert.False(t, knownTables[""])
+	assert.False(t, knownTables["Tasks; DROP TABLE"])
 }

--- a/web/assets/public/js/offline-indicator.js
+++ b/web/assets/public/js/offline-indicator.js
@@ -12,6 +12,11 @@ function offlineIndicator() {
     _interval: null,
     _wasOffline: false,
 
+    /**
+     * Initialize the offline indicator. Registers online/offline event listeners,
+     * starts the /health heartbeat, and listens for pending count updates from
+     * the service worker.
+     */
     init() {
       window.addEventListener('online', () => {
         this.online = true;
@@ -38,6 +43,9 @@ function offlineIndicator() {
       this._interval = setInterval(() => this.checkHealth(), 30000);
     },
 
+    /**
+     * Clean up the health check interval when the component is destroyed.
+     */
     destroy() {
       if (this._interval) {
         clearInterval(this._interval);

--- a/web/assets/public/sw.js
+++ b/web/assets/public/sw.js
@@ -15,6 +15,11 @@ const CACHE_NAME = 'dothog-v1';
 // Connectivity state — updated by the main thread via postMessage
 self._isOnline = true;
 
+/**
+ * Handle messages from the main thread.
+ * SET_ONLINE_STATUS updates the connectivity flag used by fetch interception.
+ * GET_PENDING_COUNT responds with the current queue size.
+ */
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SET_ONLINE_STATUS') {
     self._isOnline = event.data.online;
@@ -53,6 +58,12 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
+/**
+ * Intercept all fetch requests.
+ * - Non-GET mutations when offline: queue to IndexedDB, return synthetic response.
+ * - Static assets (/public/): cache-first (immutable).
+ * - HTML/HTMX requests: network-first with cache fallback.
+ */
 self.addEventListener('fetch', (event) => {
   const { request } = event;
 


### PR DESCRIPTION
## Summary
- Add request ID to sync endpoint error response for traceability
- Add JSDoc comments to service worker `message` and `fetch` event listeners
- Add JSDoc comments to Alpine `init()` and `destroy()` lifecycle methods
- Replace regex-based table name validation with explicit `knownTables` whitelist

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/routes/ -run TestHandleSync` passes
- [x] `go test ./internal/routes/ -run TestParseResourceURL` passes
- [x] `go test ./internal/routes/ -run TestKnownTables` passes
- [x] `go vet ./...` passes

Closes #116