### PR TITLE
fix: add typescript devDependency required by Capacitor config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a952d16a",
+  "name": "agent-a7e22257",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13,7 +13,8 @@
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.19",
         "daisyui": "^5.0.0",
-        "playwright": "^1.50.0"
+        "playwright": "^1.50.0",
+        "typescript": "^6.0.2"
       }
     },
     "node_modules/@capacitor/cli": {
@@ -1095,6 +1096,20 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
     "daisyui": "^5.0.0",
-    "playwright": "^1.50.0"
+    "playwright": "^1.50.0",
+    "typescript": "^6.0.2"
   },
   "dependencies": {
     "@capacitor/cli": "^8.3.0",


### PR DESCRIPTION
## Summary
- Adds `typescript` as a devDependency to fix iOS CI build failure
- Capacitor requires TypeScript installed to parse `capacitor.config.ts`

## Test plan
- [ ] Verify iOS CI build no longer fails with "Could not find installation of TypeScript" error