### PR TITLE
fix: add @capacitor/ios dependency required by cap add ios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "agent-a7e22257",
+  "name": "agent-ab295ce6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "@capacitor/cli": "^8.3.0",
-        "@capacitor/core": "^8.3.0"
+        "@capacitor/core": "^8.3.0",
+        "@capacitor/ios": "^8.3.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -56,6 +57,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/ios": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.0.tgz",
+      "integrity": "sha512-5Rtwv8SITKlYTt8lAZG+khnVIdzPtqbocH3eP+JkEmX1vpSMwx4TOKtT8OBz8gpQ+pUJDRp7DBYOv3U6l/obCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^8.3.0"
       }
     },
     "node_modules/@ionic/cli-framework-output": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@capacitor/cli": "^8.3.0",
-    "@capacitor/core": "^8.3.0"
+    "@capacitor/core": "^8.3.0",
+    "@capacitor/ios": "^8.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `@capacitor/ios` as a dependency to fix CI failure where `cap add ios` could not find the ios platform

## Test plan
- CI should now pass the `cap add ios` step without the "Could not find the ios platform" error