### PR TITLE
fix: correct xcodebuild output path in iOS workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -59,25 +59,23 @@ jobs:
             -scheme App \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'generic/platform=iOS Simulator' \
-            -derivedDataPath build \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -derivedDataPath ../../build/ios-derived \
             CODE_SIGNING_ALLOWED=NO \
-            | tail -20
+            build \
+            2>&1 | tail -30
 
       - name: Package simulator app
         run: |
-          # Find the .app bundle
-          APP_PATH=$(find ios/App/build -name "App.app" -type d | head -1)
+          APP_PATH=$(find build/ios-derived -name "*.app" -type d | head -1)
           if [ -z "$APP_PATH" ]; then
-            echo "ERROR: App.app not found"
-            find ios/App/build -name "*.app" -type d
+            echo "ERROR: .app bundle not found. Build output:"
+            find build/ios-derived -type d -maxdepth 5 || true
             exit 1
           fi
           echo "Found app at: $APP_PATH"
-          # Zip it for download
           cd "$(dirname "$APP_PATH")"
           zip -r "$GITHUB_WORKSPACE/dothog-simulator.zip" "$(basename "$APP_PATH")"
-          echo "Packaged: dothog-simulator.zip"
           ls -lh "$GITHUB_WORKSPACE/dothog-simulator.zip"
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- Use `-derivedDataPath ../../build/ios-derived` (repo root relative) instead of `-derivedDataPath build` (relative to `ios/App`) so the build output path is predictable from the package step
- Use concrete simulator destination (`platform=iOS Simulator,name=iPhone 16`) instead of `generic/platform=iOS Simulator`
- Search `build/ios-derived` for `*.app` instead of `ios/App/build` for `App.app`
- Add explicit `build` action and better error diagnostics on failure

## Context
The iOS CI was failing with:
```
find: ios/App/build: No such file or directory
ERROR: App.app not found
```

The `xcodebuild -derivedDataPath build` was relative to `ios/App`, but the package step searched from the repo root using `ios/App/build` — and the actual `.app` output is nested deeper under `Build/Products/Debug-iphonesimulator/`. Moving derived data to a repo-root-relative path and searching with `find` resolves both issues.