### PR TITLE
fix: handle xcodeproj when xcworkspace doesn't exist

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -58,25 +58,44 @@ jobs:
           ls -la ios/App/App.xcworkspace || echo "WARNING: xcworkspace not found"
           ls -la ios/App/Podfile || echo "WARNING: Podfile not found"
 
-      - name: Install CocoaPods
+      - name: Install CocoaPods (if Podfile exists)
         run: |
-          cd ios/App
-          pod install --repo-update || echo "pod install failed, trying without repo-update..."
-          pod install || true
+          if [ -f ios/App/Podfile ]; then
+            cd ios/App
+            pod install --repo-update
+          else
+            echo "No Podfile found, skipping CocoaPods"
+          fi
 
       - name: Build for simulator
         run: |
           set -eo pipefail
           cd ios/App
-          xcodebuild \
-            -workspace App.xcworkspace \
-            -scheme App \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
-            -derivedDataPath "$GITHUB_WORKSPACE/build/ios-derived" \
-            CODE_SIGNING_ALLOWED=NO \
-            build
+
+          # Use workspace if CocoaPods created one, otherwise use project
+          if [ -d "App.xcworkspace" ]; then
+            echo "Building with workspace..."
+            xcodebuild \
+              -workspace App.xcworkspace \
+              -scheme App \
+              -configuration Debug \
+              -sdk iphonesimulator \
+              -destination 'platform=iOS Simulator,name=iPhone 16' \
+              -derivedDataPath "$GITHUB_WORKSPACE/build/ios-derived" \
+              CODE_SIGNING_ALLOWED=NO \
+              build
+          else
+            echo "Building with project..."
+            xcodebuild \
+              -project App.xcodeproj \
+              -scheme App \
+              -configuration Debug \
+              -sdk iphonesimulator \
+              -destination 'platform=iOS Simulator,name=iPhone 16' \
+              -derivedDataPath "$GITHUB_WORKSPACE/build/ios-derived" \
+              CODE_SIGNING_ALLOWED=NO \
+              build
+          fi
 
       - name: Package simulator app
         run: |


### PR DESCRIPTION
## Summary

- Make CocoaPods install conditional on Podfile existing (prevents failure when there's no Podfile)
- Detect whether `App.xcworkspace` or `App.xcodeproj` exists and use the correct xcodebuild flag
- Fixes `xcodebuild: error: 'App.xcworkspace' does not exist` when `npx cap add ios` generates only `.xcodeproj`

## Test plan

- [ ] Trigger iOS CI build and verify it passes without CocoaPods/Podfile
- [ ] Verify workspace path is used when Podfile and CocoaPods are present