### PR TITLE
feat: add internal JSON API for error traces

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,9 @@ type AppConfig struct {
 	// setup:feature:graph:start
 	GraphUserCacheRefreshHour int
 	// setup:feature:graph:end
+
+	// Internal API
+	InternalAPIKey string
 }
 
 func buildConfig() (*AppConfig, error) {
@@ -112,6 +115,9 @@ func buildConfig() (*AppConfig, error) {
 	// setup:feature:graph:start
 	cfg.GraphUserCacheRefreshHour = envInt("GRAPH_USERCACHE_REFRESH_HOUR", 5)
 	// setup:feature:graph:end
+
+	// Internal API
+	cfg.InternalAPIKey = env("INTERNAL_API_KEY", "")
 
 	return cfg, nil
 }

--- a/internal/routes/middleware/api_auth.go
+++ b/internal/routes/middleware/api_auth.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// InternalAPIAuth returns middleware that validates requests against a
+// pre-shared API key. The key is checked in the X-API-Key header.
+// If apiKey is empty, the middleware rejects all requests (API disabled).
+func InternalAPIAuth(apiKey string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if apiKey == "" {
+				return c.JSON(http.StatusServiceUnavailable, map[string]string{
+					"error": "internal API not configured",
+				})
+			}
+
+			provided := c.Request().Header.Get("X-API-Key")
+			if subtle.ConstantTimeCompare([]byte(provided), []byte(apiKey)) != 1 {
+				return c.JSON(http.StatusUnauthorized, map[string]string{
+					"error": "invalid or missing API key",
+				})
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/internal/routes/middleware/api_auth_test.go
+++ b/internal/routes/middleware/api_auth_test.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternalAPIAuth_ValidKey(t *testing.T) {
+	e := echo.New()
+	mw := InternalAPIAuth("test-secret-key")
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", http.NoBody)
+	req.Header.Set("X-API-Key", "test-secret-key")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestInternalAPIAuth_MissingKey(t *testing.T) {
+	e := echo.New()
+	mw := InternalAPIAuth("test-secret-key")
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestInternalAPIAuth_WrongKey(t *testing.T) {
+	e := echo.New()
+	mw := InternalAPIAuth("test-secret-key")
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", http.NoBody)
+	req.Header.Set("X-API-Key", "wrong-key")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestInternalAPIAuth_EmptyConfigKey(t *testing.T) {
+	e := echo.New()
+	mw := InternalAPIAuth("")
+	handler := mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", http.NoBody)
+	req.Header.Set("X-API-Key", "anything")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -206,6 +206,7 @@ func (ar *appRoutes) InitRoutes() error {
 	if err != nil {
 		return fmt.Errorf("handler init: %w", err)
 	}
+	ar.initAPIRoutes(cfg.InternalAPIKey)
 	handler.InitRouteSet(ar.e, cfg.AppName)
 	ar.healthCfg.Name = cfg.AppName
 	return nil

--- a/internal/routes/routes_api.go
+++ b/internal/routes/routes_api.go
@@ -1,0 +1,90 @@
+package routes
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"catgoose/dothog/internal/routes/middleware"
+
+	"github.com/catgoose/promolog"
+	"github.com/labstack/echo/v4"
+)
+
+// APITraceSummary is the JSON representation of a trace for the internal API.
+type APITraceSummary struct {
+	RequestID  string    `json:"request_id"`
+	CreatedAt  time.Time `json:"created_at"`
+	StatusCode int       `json:"status_code"`
+	Method     string    `json:"method"`
+	Route      string    `json:"route"`
+	ErrorChain string    `json:"error_chain"`
+	RemoteIP   string    `json:"remote_ip"`
+	UserID     string    `json:"user_id,omitempty"`
+}
+
+// APITraceListResponse is the response envelope for the trace list endpoint.
+type APITraceListResponse struct {
+	Traces []APITraceSummary `json:"traces"`
+	Total  int               `json:"total"`
+}
+
+func (ar *appRoutes) initAPIRoutes(apiKey string) {
+	if ar.reqLogStore == nil {
+		return
+	}
+
+	api := ar.e.Group("/api", middleware.InternalAPIAuth(apiKey))
+	api.GET("/error-traces", ar.handleAPIErrorTraces)
+}
+
+func (ar *appRoutes) handleAPIErrorTraces(c echo.Context) error {
+	limit := 50
+	if l, err := strconv.Atoi(c.QueryParam("limit")); err == nil && l > 0 && l <= 500 {
+		limit = l
+	}
+
+	f := promolog.TraceFilter{
+		Q:       c.QueryParam("q"),
+		Status:  c.QueryParam("status"),
+		Method:  c.QueryParam("method"),
+		Sort:    "CreatedAt",
+		Dir:     "desc",
+		Page:    1,
+		PerPage: limit,
+	}
+
+	// Optional "since" filter — ISO 8601 timestamp
+	if since := c.QueryParam("since"); since != "" {
+		// Pass through as search query — the store's search covers created_at.
+		// For proper date filtering, the store would need a dedicated field.
+		// For now, this endpoint returns the most recent traces up to limit.
+		_ = since // TODO: add date range filtering to promolog.TraceFilter
+	}
+
+	traces, total, err := ar.reqLogStore.ListTraces(c.Request().Context(), f)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "failed to query traces",
+		})
+	}
+
+	apiTraces := make([]APITraceSummary, len(traces))
+	for i, t := range traces {
+		apiTraces[i] = APITraceSummary{
+			RequestID:  t.RequestID,
+			CreatedAt:  t.CreatedAt,
+			StatusCode: t.StatusCode,
+			Method:     t.Method,
+			Route:      t.Route,
+			ErrorChain: t.ErrorChain,
+			RemoteIP:   t.RemoteIP,
+			UserID:     t.UserID,
+		}
+	}
+
+	return c.JSON(http.StatusOK, APITraceListResponse{
+		Traces: apiTraces,
+		Total:  total,
+	})
+}

--- a/internal/routes/routes_api_test.go
+++ b/internal/routes/routes_api_test.go
@@ -1,0 +1,118 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	dialect "github.com/catgoose/fraggle"
+	"github.com/catgoose/promolog"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testAPIKey = "test-secret-key"
+
+func newTestAPIRoutes(t *testing.T) (*echo.Echo, *appRoutes) {
+	t.Helper()
+
+	db, _, err := dialect.OpenSQLite(context.Background(), ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	store := promolog.NewStore(db)
+	require.NoError(t, store.InitSchema())
+
+	e := echo.New()
+	ar := &appRoutes{
+		e:           e,
+		ctx:         context.Background(),
+		reqLogStore: store,
+	}
+	ar.initAPIRoutes(testAPIKey)
+	return e, ar
+}
+
+func apiRequest(t *testing.T, e *echo.Echo, apiKey string, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestAPIErrorTraces_ValidKey(t *testing.T) {
+	e, _ := newTestAPIRoutes(t)
+	rec := apiRequest(t, e, testAPIKey, "/api/error-traces")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APITraceListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotNil(t, resp.Traces)
+	assert.Equal(t, 0, resp.Total)
+}
+
+func TestAPIErrorTraces_MissingKey(t *testing.T) {
+	e, _ := newTestAPIRoutes(t)
+	rec := apiRequest(t, e, "", "/api/error-traces")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestAPIErrorTraces_WrongKey(t *testing.T) {
+	e, _ := newTestAPIRoutes(t)
+	rec := apiRequest(t, e, "wrong-key", "/api/error-traces")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestAPIErrorTraces_DisabledWhenNoKey(t *testing.T) {
+	db, _, err := dialect.OpenSQLite(context.Background(), ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	store := promolog.NewStore(db)
+	require.NoError(t, store.InitSchema())
+
+	e := echo.New()
+	ar := &appRoutes{
+		e:           e,
+		ctx:         context.Background(),
+		reqLogStore: store,
+	}
+	ar.initAPIRoutes("") // empty key = disabled
+
+	rec := apiRequest(t, e, "anything", "/api/error-traces")
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestAPIErrorTraces_LimitParam(t *testing.T) {
+	e, ar := newTestAPIRoutes(t)
+
+	// Seed a few traces
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		ar.reqLogStore.Promote(ctx, promolog.ErrorTrace{
+			RequestID:  "test-" + string(rune('a'+i)),
+			StatusCode: 500,
+			Method:     "GET",
+			Route:      "/test",
+			ErrorChain: "test error",
+		})
+	}
+
+	rec := apiRequest(t, e, testAPIKey, "/api/error-traces?limit=2")
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp APITraceListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp.Traces, 2)
+	assert.Equal(t, 5, resp.Total)
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/error-traces` endpoint returning JSON traces for vopts dashboard consumption
- Auth via `X-API-Key` header checked against `INTERNAL_API_KEY` env var using constant-time comparison
- API returns 503 when no key is configured (disabled by default)
- Supports query params: `limit` (1-500, default 50), `q`, `status`, `method` for filtering

## Details

Internal-only endpoint for aggregating error traces across dothog-derived apps on the same host. Pre-shared key auth is sufficient since traffic stays behind TLS on localhost.

- `InternalAPIKey` field added to `AppConfig`, read from `INTERNAL_API_KEY` env var
- `InternalAPIAuth` middleware in `internal/routes/middleware/api_auth.go` uses `crypto/subtle.ConstantTimeCompare` to prevent timing attacks
- Response envelope: `{ "traces": [...], "total": N }`

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Middleware tests: valid key (200), missing key (401), wrong key (401), empty config key (503)
- [x] Route tests: valid key returns traces, missing/wrong key rejected, disabled when no key, limit param respected

Closes #124