### PR TITLE
fix: gate /admin/system and /admin/config to demo mode

### DIFF
--- a/internal/routes/routes_admin_core.go
+++ b/internal/routes/routes_admin_core.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	// setup:feature:demo:start
 	"fmt"
 	"runtime"
 	"runtime/pprof"
@@ -8,9 +9,11 @@ import (
 
 	"catgoose/dothog/internal/admininfo"
 	"catgoose/dothog/internal/config"
+	"catgoose/dothog/internal/version"
+	// setup:feature:demo:end
+
 	"catgoose/dothog/internal/health"
 	"catgoose/dothog/internal/routes/handler"
-	"catgoose/dothog/internal/version"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -20,15 +23,19 @@ func (ar *appRoutes) initAdminCoreRoutes() {
 	ar.e.GET("/admin", handler.HandleComponent(views.AdminIndexPage()))
 	ar.e.GET("/admin/health", ar.handleAdminHealth)
 	ar.e.GET("/admin/health/check", ar.handleAdminHealthCheck)
+	// setup:feature:demo:start
 	ar.e.GET("/admin/system", ar.handleSystemInfo)
 	ar.e.GET("/admin/system/check-update", ar.handleCheckUpdate)
 	ar.e.GET("/admin/config", ar.handleConfigInfo)
+	// setup:feature:demo:end
 	// setup:feature:session_settings:start
 	ar.e.GET("/admin/sessions", ar.handleSessionsPage)
 	ar.e.GET("/admin/sessions/table", ar.handleSessionsTable)
 	// setup:feature:session_settings:end
 }
 
+
+// setup:feature:demo:start
 
 func (ar *appRoutes) handleSystemInfo(c echo.Context) error {
 	var ms runtime.MemStats
@@ -108,6 +115,8 @@ func (ar *appRoutes) handleConfigInfo(c echo.Context) error {
 	return handler.RenderBaseLayout(c, views.AdminConfigPage(entries))
 }
 
+// setup:feature:demo:end
+
 // setup:feature:session_settings:start
 
 func (ar *appRoutes) handleSessionsPage(c echo.Context) error {
@@ -133,6 +142,8 @@ func (ar *appRoutes) handleSessionsTable(c echo.Context) error {
 }
 
 // setup:feature:session_settings:end
+
+// setup:feature:demo:start
 
 func formatUptime(d time.Duration) string {
 	days := int(d.Hours()) / 24
@@ -164,6 +175,8 @@ func defaultStr(s, fallback string) string {
 	}
 	return s
 }
+
+// setup:feature:demo:end
 
 func (ar *appRoutes) handleAdminHealth(c echo.Context) error {
 	h := health.Check(c.Request().Context(), ar.healthCfg)

--- a/web/views/admin_core.templ
+++ b/web/views/admin_core.templ
@@ -1,12 +1,16 @@
 package views
 
 import (
+	// setup:feature:demo:start
 	"fmt"
 	"strconv"
 
 	"catgoose/dothog/internal/admininfo"
 	"catgoose/dothog/internal/version"
+	// setup:feature:demo:end
 )
+
+// setup:feature:demo:start
 
 // AdminSystemPage displays runtime system information.
 templ AdminSystemPage(info admininfo.SystemInfo) {
@@ -155,6 +159,8 @@ templ AdminConfigPage(entries []admininfo.ConfigEntry) {
 		</div>
 	</div>
 }
+
+// setup:feature:demo:end
 
 // UserDashboardPage is a placeholder for application-specific user dashboards.
 // Override this page with your own content after running mage setup.

--- a/web/views/admin_index.templ
+++ b/web/views/admin_index.templ
@@ -11,8 +11,10 @@ templ AdminIndexPage() {
 
 		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
 			@adminResourceCard("/admin/health", "Health", "Live application health status, database connectivity, and uptime.", "M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z")
+			// setup:feature:demo:start
 			@adminResourceCard("/admin/system", "System", "Runtime information, memory usage, Go version, goroutines, and GC statistics.", "M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z")
 			@adminResourceCard("/admin/config", "Config", "Application configuration values. Secrets are redacted.", "M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z")
+			// setup:feature:demo:end
 			@adminResourceCard("/admin/error-traces", "Error Traces", "Captured error traces with request context for debugging.", "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z")
 			// setup:feature:session_settings:start
 			@adminResourceCard("/admin/sessions", "Sessions", "Active session settings. Theme preferences per session.", "M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z")


### PR DESCRIPTION
## Summary
- Wrap `/admin/system`, `/admin/system/check-update`, and `/admin/config` route registrations in `setup:feature:demo` blocks
- Wrap `handleSystemInfo`, `handleCheckUpdate`, `handleConfigInfo`, `formatUptime`, `maskSecret`, `defaultStr` handler functions in demo blocks
- Wrap demo-only imports (`fmt`, `runtime`, `runtime/pprof`, `time`, `admininfo`, `config`, `version`) in demo blocks in `routes_admin_core.go`
- Wrap System and Config cards in `admin_index.templ` in demo blocks
- Wrap `AdminSystemPage`, `systemStat`, `UpdateCheckResult`, `AdminConfigPage` templates and their imports in `admin_core.templ` in demo blocks

Closes #133, closes #134