### PR TITLE
fix: add CI failure notifications to release and iOS workflows

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,6 +5,10 @@ on:
     branches: [feat/capacitor, feat/ios-demo-build]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 concurrency:
   group: ios-build-${{ github.ref }}
   cancel-in-progress: true
@@ -135,3 +139,25 @@ jobs:
             For physical device builds, code signing certificates are required.
           files: dothog-simulator.zip
           prerelease: true
+
+  notify-failure:
+    if: ${{ failure() }}
+    needs: [build-simulator]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue on pipeline failure
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Pipeline failure: ${{ github.workflow }} (#${{ github.run_number }})" \
+            --label "ci" \
+            --body "$(cat <<EOF
+          **Workflow:** \`${{ github.workflow }}\`
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** \`${{ github.ref_name }}\`
+          **Commit:** \`${{ github.sha }}\`
+          **Triggered by:** ${{ github.actor }}
+          EOF
+          )"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: write
   packages: write
+  issues: write
 
 jobs:
   check:
@@ -216,3 +217,25 @@ jobs:
             APP_VERSION=${{ needs.release.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  notify-failure:
+    if: ${{ failure() }}
+    needs: [check, release, docker]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue on pipeline failure
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Pipeline failure: ${{ github.workflow }} (#${{ github.run_number }})" \
+            --label "ci" \
+            --body "$(cat <<EOF
+          **Workflow:** \`${{ github.workflow }}\`
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Branch:** \`${{ github.ref_name }}\`
+          **Commit:** \`${{ github.sha }}\`
+          **Triggered by:** ${{ github.actor }}
+          EOF
+          )"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Add `notify-failure` job to `release.yml` with `needs: [check, release, docker]`
- Add `notify-failure` job to `ios.yml` with `needs: [build-simulator]`
- Add `issues: write` permission to both workflows so the job can create issues on failure

Uses the same pattern as the existing `pipeline.yml` notify-failure job.