### PR TITLE
refactor: use ErrorControlsForStatus dispatcher in error middleware

### DIFF
--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -231,39 +231,15 @@ func HandleError(c echo.Context, statusCode int, message string, err error) erro
 // status code so that every error response is a navigable hypermedia state.
 func HandleHypermediaError(c echo.Context, statusCode int, message string, err error, controls ...hypermedia.Control) error {
 	if len(controls) == 0 {
-		requestID := middleware.GetRequestID(c)
-		controls = defaultControls(statusCode, requestID)
+		opts := hypermedia.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
+		controls = hypermedia.ErrorControlsForStatus(statusCode, opts)
+		if statusCode >= 500 {
+			requestID := middleware.GetRequestID(c)
+			controls = append(controls, hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID))
+		}
 	}
 	ec := middleware.HypermediaError(c, statusCode, message, err, controls...)
 	return hypermedia.NewHTTPError(ec)
-}
-
-// defaultControls returns recovery controls appropriate for the given HTTP status code.
-// Every error path includes a Report Issue button so users can easily report problems.
-func defaultControls(statusCode int, requestID string) []hypermedia.Control {
-	back := hypermedia.BackButton(hypermedia.LabelGoBack)
-	home := hypermedia.GoHomeButton(hypermedia.LabelGoHome, "/", hypermedia.TargetBody)
-	dismiss := hypermedia.DismissButton(hypermedia.LabelDismiss)
-	report := hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID)
-
-	switch {
-	case statusCode == http.StatusBadRequest || statusCode == http.StatusUnprocessableEntity:
-		return []hypermedia.Control{dismiss, report}
-	case statusCode == http.StatusNotFound:
-		return []hypermedia.Control{back, home, report}
-	case statusCode == http.StatusUnauthorized:
-		return []hypermedia.Control{
-			hypermedia.RedirectLink(hypermedia.LabelLogIn, "/login"),
-			home,
-			report,
-		}
-	case statusCode == http.StatusForbidden:
-		return []hypermedia.Control{back, home, report}
-	case statusCode >= 500:
-		return []hypermedia.Control{dismiss, home, report}
-	default:
-		return []hypermedia.Control{dismiss, report}
-	}
 }
 
 // HandleNotFound renders a full-page 404 within the base layout for direct

--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -31,6 +31,12 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 	)
 	log.Error("Request error", "error", err)
 
+	opts := hypermedia.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
+	controls := hypermedia.ErrorControlsForStatus(statusCode, opts)
+	if statusCode >= 500 {
+		controls = append(controls, hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID))
+	}
+
 	if c.Request().Header.Get("HX-Request") == "true" {
 		ec := hypermedia.ErrorContext{
 			StatusCode: statusCode,
@@ -39,9 +45,7 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 			Route:      c.Request().URL.Path,
 			RequestID:  requestID,
 			Closable:   true,
-			Controls: []hypermedia.Control{
-				hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
-			},
+			Controls:   controls,
 		}
 		return response.New(c).
 			Status(statusCode).
@@ -58,11 +62,7 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 		Route:      c.Request().URL.Path,
 		RequestID:  requestID,
 		Theme:      errorPageTheme(c),
-		Controls: []hypermedia.Control{
-			hypermedia.BackButton("Go Back"),
-			hypermedia.GoHomeButton("Go Home", "/", "body"),
-			hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
-		},
+		Controls:   controls,
 	}
 	c.Response().Status = statusCode
 	return corecomponents.ErrorPage(ec).Render(c.Request().Context(), c.Response())

--- a/internal/routes/middleware/errors.go
+++ b/internal/routes/middleware/errors.go
@@ -11,40 +11,64 @@ import (
 // Errors middleware package provides helper methods for returning HTTP respones
 // from echo contexts
 
+// errorOpts returns the default ErrorControlOpts for convenience error helpers.
+func errorOpts() hypermedia.ErrorControlOpts {
+	return hypermedia.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
+}
+
+// newError builds a hypermedia.HTTPError with controls dispatched from ErrorControlsForStatus.
+// For 500+ errors, a ReportIssueButton is appended.
+func newError(c echo.Context, statusCode int, message string) error {
+	requestID := GetRequestID(c)
+	controls := hypermedia.ErrorControlsForStatus(statusCode, errorOpts())
+	if statusCode >= 500 {
+		controls = append(controls, hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID))
+	}
+	ec := hypermedia.ErrorContext{
+		StatusCode: statusCode,
+		Message:    message,
+		Route:      c.Request().URL.Path,
+		RequestID:  requestID,
+		Closable:   true,
+		Controls:   controls,
+	}
+	return hypermedia.NewHTTPError(ec)
+}
+
 // BadRequest returns a 400 Bad Request error
 // Use for invalid input, missing required parameters, or malformed requests
 func BadRequest(c echo.Context, message string) error {
-	return echo.NewHTTPError(http.StatusBadRequest, message)
+	return newError(c, http.StatusBadRequest, message)
 }
 
 // Unauthorized returns a 401 Unauthorized error
 // Use when authentication is required but not provided or invalid
 func Unauthorized(c echo.Context, message string) error {
-	return echo.NewHTTPError(http.StatusUnauthorized, message)
+	return newError(c, http.StatusUnauthorized, message)
 }
 
 // Forbidden returns a 403 Forbidden error
 // Use when authentication is valid but the user lacks permission for the resource
 func Forbidden(c echo.Context, message string) error {
-	return echo.NewHTTPError(http.StatusForbidden, message)
+	return newError(c, http.StatusForbidden, message)
 }
 
 // NotFound returns a 404 Not Found error
 // Use when the requested resource doesn't exist
 func NotFound(c echo.Context, message string) error {
-	return echo.NewHTTPError(http.StatusNotFound, message)
+	return newError(c, http.StatusNotFound, message)
 }
 
 // InternalServerError returns a 500 Internal Server Error
 // Use for unexpected server errors, database failures, or unhandled exceptions
 func InternalServerError(c echo.Context, message string) error {
-	return echo.NewHTTPError(http.StatusInternalServerError, message)
+	return newError(c, http.StatusInternalServerError, message)
 }
 
 // ServiceUnavailable returns a 503 Service Unavailable error
 // Use when the service is temporarily unavailable or overloaded
 func ServiceUnavailable(c echo.Context, message string) error {
-	return echo.NewHTTPError(http.StatusServiceUnavailable, message)
+	return newError(c, http.StatusServiceUnavailable, message)
 }
 
 // HypermediaError builds a hypermedia.ErrorContext populated with request metadata


### PR DESCRIPTION
## Summary
- **error_handler.go**: Replace hardcoded BackButton/GoHomeButton/ReportIssueButton lists in `handleError()` with `ErrorControlsForStatus(statusCode, opts)` dispatcher; ReportIssueButton now appended only for 500+ errors
- **errors.go**: Add shared `errorOpts()` helper and `newError()` builder; convenience helpers (BadRequest, NotFound, etc.) now return `hypermedia.NewHTTPError` with controls from `ErrorControlsForStatus` instead of plain `echo.NewHTTPError`
- **handler.go**: Replace inline `defaultControls()` function in `HandleHypermediaError` with `ErrorControlsForStatus` delegation; ReportIssueButton conditionally added for 500+ only

Closes #156

## Test plan
- [ ] Verify `go build ./...` passes (confirmed locally)
- [ ] Trigger 400/404/401/403/500/503 errors and confirm correct controls render
- [ ] Confirm ReportIssueButton appears only on 500+ errors
- [ ] Verify HTMX and non-HTMX error paths both render correctly
- [ ] Confirm convenience helpers (BadRequest, NotFound, etc.) now route through the middleware error handler with proper controls