### PR TITLE
feat: add LinkSource interface with frecency tracking (closes #172)

### DIFF
--- a/internal/demo/db.go
+++ b/internal/demo/db.go
@@ -190,6 +190,9 @@ func (d *DB) initSchema() error {
 	if err := d.initErrorReports(); err != nil {
 		return fmt.Errorf("init error_reports: %w", err)
 	}
+	if err := d.initFrecency(); err != nil {
+		return fmt.Errorf("init frecency: %w", err)
+	}
 	return nil
 }
 

--- a/internal/demo/frecency.go
+++ b/internal/demo/frecency.go
@@ -1,0 +1,97 @@
+// setup:feature:demo
+
+package demo
+
+import (
+	"context"
+)
+
+// PageVisit tracks visit frequency and recency for a page.
+type PageVisit struct {
+	Path      string
+	Title     string
+	Visits    int
+	LastVisit string
+	Score     float64
+}
+
+// initFrecency creates the page_visits table.
+func (d *DB) initFrecency() error {
+	_, err := d.db.Exec(`CREATE TABLE IF NOT EXISTS page_visits (
+		session_id TEXT    NOT NULL,
+		path       TEXT    NOT NULL,
+		title      TEXT    NOT NULL DEFAULT '',
+		visits     INTEGER NOT NULL DEFAULT 1,
+		last_visit TEXT    NOT NULL DEFAULT (datetime('now')),
+		PRIMARY KEY (session_id, path)
+	)`)
+	return err
+}
+
+// RecordVisit upserts a page visit for a session.
+func (d *DB) RecordVisit(ctx context.Context, sessionID, path, title string) error {
+	_, err := d.db.ExecContext(ctx, `
+		INSERT INTO page_visits (session_id, path, title, visits, last_visit)
+		VALUES (?, ?, ?, 1, datetime('now'))
+		ON CONFLICT (session_id, path) DO UPDATE SET
+			visits = visits + 1,
+			last_visit = datetime('now'),
+			title = excluded.title
+	`, sessionID, path, title)
+	return err
+}
+
+// TopFrecent returns the top N most frecent pages for a session.
+// Score is visits / (days_since_last_visit + 1), so recent frequent pages rank highest.
+func (d *DB) TopFrecent(ctx context.Context, sessionID string, limit int) ([]PageVisit, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT path, title, visits, last_visit,
+		       CAST(visits AS REAL) / (julianday('now') - julianday(last_visit) + 1) AS score
+		FROM page_visits
+		WHERE session_id = ?
+		ORDER BY score DESC
+		LIMIT ?
+	`, sessionID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []PageVisit
+	for rows.Next() {
+		var pv PageVisit
+		if err := rows.Scan(&pv.Path, &pv.Title, &pv.Visits, &pv.LastVisit, &pv.Score); err != nil {
+			return nil, err
+		}
+		results = append(results, pv)
+	}
+	return results, rows.Err()
+}
+
+// PopularPages returns the top N most popular pages across all sessions.
+func (d *DB) PopularPages(ctx context.Context, limit int) ([]PageVisit, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT path, title,
+		       SUM(visits) as total_visits,
+		       MAX(last_visit) as latest,
+		       CAST(SUM(visits) AS REAL) / (julianday('now') - julianday(MAX(last_visit)) + 1) AS score
+		FROM page_visits
+		GROUP BY path
+		ORDER BY score DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []PageVisit
+	for rows.Next() {
+		var pv PageVisit
+		if err := rows.Scan(&pv.Path, &pv.Title, &pv.Visits, &pv.LastVisit, &pv.Score); err != nil {
+			return nil, err
+		}
+		results = append(results, pv)
+	}
+	return results, rows.Err()
+}

--- a/internal/routes/frecency.go
+++ b/internal/routes/frecency.go
@@ -1,0 +1,63 @@
+// setup:feature:demo
+
+package routes
+
+import (
+	"context"
+	"net/http"
+
+	"catgoose/dothog/internal/demo"
+	"catgoose/dothog/internal/routes/handler"
+	"catgoose/dothog/internal/routes/hypermedia"
+	"catgoose/dothog/internal/routes/middleware"
+	"catgoose/dothog/web/views"
+
+	"github.com/labstack/echo/v4"
+)
+
+// initFrecency wires the frecency link source and visit recording middleware.
+func (ar *appRoutes) initFrecency(db *demo.DB) {
+	// Build a set of tracked GET routes for visit recording.
+	validRoutes := make(map[string]bool)
+	for _, r := range ar.e.Routes() {
+		if r.Method == http.MethodGet && r.Path != "" && r.Path != "/*" {
+			validRoutes[r.Path] = true
+		}
+	}
+
+	// Register the frecency middleware (sets session ID on context, records visits).
+	ar.e.Use(middleware.FrecencyMiddleware(db, validRoutes))
+
+	// Bridge demo.DB.TopFrecent → hypermedia.LinkRelation slice.
+	frecencyFn := func(ctx context.Context, sessionID string, limit int) ([]hypermedia.LinkRelation, error) {
+		visits, err := db.TopFrecent(ctx, sessionID, limit)
+		if err != nil {
+			return nil, err
+		}
+		links := make([]hypermedia.LinkRelation, len(visits))
+		for i, v := range visits {
+			links[i] = hypermedia.LinkRelation{
+				Rel:   "bookmark",
+				Href:  v.Path,
+				Title: v.Title,
+			}
+		}
+		return links, nil
+	}
+
+	hypermedia.RegisterLinkSource(&hypermedia.FrecencySource{
+		Fn:    frecencyFn,
+		Limit: 5,
+	})
+}
+
+// handleDemoIndex renders the /demo page with popular pages from the DB.
+func (ar *appRoutes) handleDemoIndex(c echo.Context) error {
+	var popular []demo.PageVisit
+	if ar.demoDB != nil {
+		if pp, err := ar.demoDB.PopularPages(c.Request().Context(), 5); err == nil {
+			popular = pp
+		}
+	}
+	return handler.RenderBaseLayout(c, views.DemoIndexPage(popular...))
+}

--- a/internal/routes/hypermedia/links.go
+++ b/internal/routes/hypermedia/links.go
@@ -2,6 +2,7 @@
 package hypermedia
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -36,7 +37,7 @@ func Link(source, rel, target, title string) {
 	if rel == "related" {
 		// Derive the inverse title from the source path
 		// e.g., "/demo/inventory" -> "Inventory"
-		inverseTitle := titleFromPath(source)
+		inverseTitle := TitleFromPath(source)
 		linksMap[target] = append(linksMap[target], LinkRelation{
 			Rel:   "related",
 			Href:  source,
@@ -101,9 +102,88 @@ func LinkHeader(links []LinkRelation) string {
 	return strings.Join(parts, ", ")
 }
 
-// titleFromPath extracts a title from the last segment of a URL path.
+// LinkSource provides link relations dynamically for a request.
+type LinkSource interface {
+	// Links returns link relations relevant to the given path.
+	// The context carries request-scoped values such as the session ID.
+	Links(ctx context.Context, path string) []LinkRelation
+}
+
+var (
+	sourcesMu sync.RWMutex
+	sources   []LinkSource
+)
+
+// RegisterLinkSource adds a dynamic link source to the global set.
+func RegisterLinkSource(src LinkSource) {
+	sourcesMu.Lock()
+	defer sourcesMu.Unlock()
+	sources = append(sources, src)
+}
+
+// AllSourceLinks collects links from all registered sources for a path.
+func AllSourceLinks(ctx context.Context, path string) []LinkRelation {
+	sourcesMu.RLock()
+	defer sourcesMu.RUnlock()
+
+	var all []LinkRelation
+	for _, src := range sources {
+		all = append(all, src.Links(ctx, path)...)
+	}
+	return all
+}
+
+// registrySource wraps the static link registry as a LinkSource.
+type registrySource struct{}
+
+func (registrySource) Links(_ context.Context, path string) []LinkRelation {
+	return LinksFor(path)
+}
+
+func init() {
+	RegisterLinkSource(registrySource{})
+}
+
+// FrecencyFunc returns top frecent pages for a session ID as link relations.
+type FrecencyFunc func(ctx context.Context, sessionID string, limit int) ([]LinkRelation, error)
+
+// FrecencySource is a LinkSource backed by session visit history.
+type FrecencySource struct {
+	Fn    FrecencyFunc
+	Limit int
+}
+
+// Links returns frecent bookmark links for the current session, excluding
+// the page being viewed.
+func (f *FrecencySource) Links(ctx context.Context, path string) []LinkRelation {
+	sessionID, ok := ctx.Value(sessionIDKey{}).(string)
+	if !ok || sessionID == "" {
+		return nil
+	}
+	links, err := f.Fn(ctx, sessionID, f.Limit)
+	if err != nil {
+		return nil
+	}
+	var filtered []LinkRelation
+	for _, l := range links {
+		if l.Href != path {
+			filtered = append(filtered, l)
+		}
+	}
+	return filtered
+}
+
+// sessionIDKey is the context key for the session ID used by frecency.
+type sessionIDKey struct{}
+
+// WithSessionID adds a session ID to the context for frecency tracking.
+func WithSessionID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, id)
+}
+
+// TitleFromPath extracts a title from the last segment of a URL path.
 // "/demo/inventory" -> "Inventory", "/admin/error-traces" -> "Error Traces"
-func titleFromPath(path string) string {
+func TitleFromPath(path string) string {
 	path = strings.TrimSuffix(path, "/")
 	idx := strings.LastIndex(path, "/")
 	if idx < 0 {

--- a/internal/routes/middleware/frecency.go
+++ b/internal/routes/middleware/frecency.go
@@ -1,0 +1,65 @@
+// setup:feature:demo
+
+package middleware
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+
+	"catgoose/dothog/internal/routes/hypermedia"
+
+	"github.com/labstack/echo/v4"
+)
+
+// VisitRecorder records page visits for frecency tracking.
+type VisitRecorder interface {
+	RecordVisit(ctx context.Context, sessionID, path, title string) error
+}
+
+// FrecencyMiddleware records page visits and sets the session ID on the
+// request context so the FrecencySource can read it downstream.
+// Only records full page loads (not HTMX partial requests) for tracked routes.
+func FrecencyMiddleware(recorder VisitRecorder, validRoutes map[string]bool) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			path := c.Request().URL.Path
+
+			// Set session ID on context for the FrecencySource to read.
+			sessionID := deriveSessionID(c)
+			if sessionID != "" {
+				ctx := hypermedia.WithSessionID(c.Request().Context(), sessionID)
+				c.SetRequest(c.Request().WithContext(ctx))
+			}
+
+			// Only record full page loads for tracked routes.
+			isHTMX := c.Request().Header.Get("HX-Request") == "true"
+			if !isHTMX && sessionID != "" && c.Request().Method == http.MethodGet && validRoutes[path] {
+				// Record in a goroutine — don't block the response.
+				// Use a detached context since the request context will be
+				// cancelled after the response is sent.
+				sid := sessionID
+				p := path
+				title := hypermedia.TitleFromPath(path)
+				go func() {
+					_ = recorder.RecordVisit(context.Background(), sid, p, title)
+				}()
+			}
+
+			return next(c)
+		}
+	}
+}
+
+// deriveSessionID builds a stable, anonymous session identifier from the
+// request. For the demo (no auth), this hashes IP + User-Agent.
+func deriveSessionID(c echo.Context) string {
+	ip := c.RealIP()
+	if ip == "" {
+		return ""
+	}
+	ua := c.Request().UserAgent()
+	h := sha256.Sum256([]byte(ip + "|" + ua))
+	return hex.EncodeToString(h[:8])
+}

--- a/internal/routes/middleware/links.go
+++ b/internal/routes/middleware/links.go
@@ -7,14 +7,15 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// LinkRelationsMiddleware looks up registered link relations for the
-// current request path and stores them on the context for template rendering.
-// It also emits an RFC 8288 Link HTTP header.
+// LinkRelationsMiddleware collects link relations from all registered
+// LinkSource implementations and stores them on the context for template
+// rendering. It also emits an RFC 8288 Link HTTP header.
 func LinkRelationsMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			path := c.Request().URL.Path
-			links := hypermedia.LinksFor(path)
+			ctx := c.Request().Context()
+			links := hypermedia.AllSourceLinks(ctx, path)
 			if len(links) > 0 {
 				// Set RFC 8288 Link header
 				c.Response().Header().Set("Link", hypermedia.LinkHeader(links))

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -118,7 +118,7 @@ func (ar *appRoutes) InitRoutes() error {
 	// setup:feature:demo:start
 	ar.e.GET("/welcome", handler.HandleComponent(views.WelcomePage()))
 	ar.e.GET("/hypermedia", handler.HandleComponent(views.PatternsIndexPage()))
-	ar.e.GET("/demo", handler.HandleComponent(views.DemoIndexPage()))
+	ar.e.GET("/demo", ar.handleDemoIndex)
 	// setup:feature:demo:end
 
 	// Health check endpoint — returns structured ops metadata.
@@ -185,6 +185,7 @@ func (ar *appRoutes) InitRoutes() error {
 	ar.initVendorContactRoutes(db, actLog, broker)
 	ar.initDashboardRoutes(db, board, queue, actLog)
 	ar.initAdminErrorReportsRoutes(db)
+	ar.initFrecency(db)
 	// setup:feature:demo:end
 	ar.e.RouteNotFound("/*", handler.HandleNotFound)
 	cfg, err := config.GetConfig()

--- a/web/assets/public/js/context-bar.js
+++ b/web/assets/public/js/context-bar.js
@@ -1,14 +1,21 @@
 // setup:feature:demo
 /**
- * Alpine.js component that populates the context bar from <link rel="related"> tags.
- * Reads link relations from the document head and renders them as navigation links.
+ * Alpine.js component that populates the context bar from <link> tags.
+ * Reads link relations from the document head and renders them.
+ * - rel="bookmark" — frecent (user's frequently visited pages) — left side
+ * - rel="related" — declared related pages — right side
  * @returns {AlpineComponent}
  */
 function contextBar() {
   return {
-    links: [],
+    frecent: [],
+    related: [],
     init() {
-      this.links = Array.from(document.querySelectorAll('head link[rel="related"]'))
+      this.frecent = this.readLinks('bookmark');
+      this.related = this.readLinks('related');
+    },
+    readLinks(rel) {
+      return Array.from(document.querySelectorAll('head link[rel="' + rel + '"]'))
         .map(function(el) { return { href: el.getAttribute('href'), title: el.getAttribute('title') }; })
         .filter(function(l) { return l.href && l.title && l.href !== window.location.pathname; });
     }

--- a/web/components/core/context.templ
+++ b/web/components/core/context.templ
@@ -21,16 +21,30 @@ templ ContextStrip(crumbs []hypermedia.Breadcrumb) {
 	</div>
 }
 
-// ContextBar renders a horizontal strip of related page links.
-// Links are read from <link rel="related"> tags in the document head.
+// ContextBar renders a horizontal strip of context links.
+// Frecent links (rel="bookmark") appear on the left; related links
+// (rel="related") appear on the right, separated by a divider.
 templ ContextBar() {
 	<div
 		x-data="contextBar()"
-		x-show="links.length > 0"
+		x-show="frecent.length > 0 || related.length > 0"
 		x-cloak
 		class="flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm"
 	>
-		<template x-for="link in links" :key="link.href">
+		<!-- Frecent links (left) -->
+		<template x-for="link in frecent" :key="link.href">
+			<a
+				:href="link.href"
+				x-text="link.title"
+				class="link link-hover text-base-content/40 hover:text-base-content whitespace-nowrap text-xs"
+			></a>
+		</template>
+		<!-- Divider -->
+		<template x-if="frecent.length > 0 && related.length > 0">
+			<div class="w-px h-4 bg-base-300 shrink-0"></div>
+		</template>
+		<!-- Related links (right) -->
+		<template x-for="link in related" :key="link.href">
 			<a
 				:href="link.href"
 				x-text="link.title"

--- a/web/components/core/context_templ.go
+++ b/web/components/core/context_templ.go
@@ -69,8 +69,9 @@ func ContextStrip(crumbs []hypermedia.Breadcrumb) templ.Component {
 	})
 }
 
-// ContextBar renders a horizontal strip of related page links.
-// Links are read from <link rel="related"> tags in the document head.
+// ContextBar renders a horizontal strip of context links.
+// Frecent links (rel="bookmark") appear on the left; related links
+// (rel="related") appear on the right, separated by a divider.
 func ContextBar() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -92,7 +93,7 @@ func ContextBar() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"contextBar()\" x-show=\"links.length > 0\" x-cloak class=\"flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm\"><template x-for=\"link in links\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap\"></a></template></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"contextBar()\" x-show=\"frecent.length > 0 || related.length > 0\" x-cloak class=\"flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm\"><!-- Frecent links (left) --><template x-for=\"link in frecent\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/40 hover:text-base-content whitespace-nowrap text-xs\"></a></template><!-- Divider --><template x-if=\"frecent.length > 0 && related.length > 0\"><div class=\"w-px h-4 bg-base-300 shrink-0\"></div></template><!-- Related links (right) --><template x-for=\"link in related\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap\"></a></template></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -130,7 +131,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(hypermedia.FromNav(href, from)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 47, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 61, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -143,7 +144,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 50, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 64, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {

--- a/web/views/demo_index.templ
+++ b/web/views/demo_index.templ
@@ -2,13 +2,31 @@
 
 package views
 
+import "catgoose/dothog/internal/demo"
+
+// PopularLink holds a page path and title for the popular pages section.
+type PopularLink struct {
+	Href  string
+	Title string
+}
+
 // DemoIndexPage renders the /demo resource discovery page.
-templ DemoIndexPage() {
+// popular is an optional list of the most-visited pages across all sessions.
+templ DemoIndexPage(popular ...demo.PageVisit) {
 	<div class="p-4 space-y-6 max-w-4xl mx-auto">
 		<div class="space-y-1">
 			<h1 class="text-2xl font-bold">Demo</h1>
 			<p class="text-sm text-base-content/60">Working examples of common application patterns built on the dothog stack.</p>
 		</div>
+
+		if len(popular) > 0 {
+			<div class="flex items-center gap-2 text-sm">
+				<span class="text-base-content/40 font-medium">Popular:</span>
+				for _, p := range popular {
+					<a href={ templ.URL(p.Path) } class="link link-hover text-base-content/60 hover:text-base-content text-sm">{ p.Title }</a>
+				}
+			</div>
+		}
 
 		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
 			@adminResourceCard("/demo/logging", "Logging", "Structured logging with promolog. Request traces, log levels, and context propagation.", "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z")

--- a/web/views/demo_index_templ.go
+++ b/web/views/demo_index_templ.go
@@ -10,8 +10,17 @@ package views
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
+import "catgoose/dothog/internal/demo"
+
+// PopularLink holds a page path and title for the popular pages section.
+type PopularLink struct {
+	Href  string
+	Title string
+}
+
 // DemoIndexPage renders the /demo resource discovery page.
-func DemoIndexPage() templ.Component {
+// popular is an optional list of the most-visited pages across all sessions.
+func DemoIndexPage(popular ...demo.PageVisit) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -32,7 +41,53 @@ func DemoIndexPage() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">Demo</h1><p class=\"text-sm text-base-content/60\">Working examples of common application patterns built on the dothog stack.</p></div><div class=\"grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">Demo</h1><p class=\"text-sm text-base-content/60\">Working examples of common application patterns built on the dothog stack.</p></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if len(popular) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"flex items-center gap-2 text-sm\"><span class=\"text-base-content/40 font-medium\">Popular:</span> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, p := range popular {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<a href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var2 templ.SafeURL
+				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(p.Path))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/demo_index.templ`, Line: 26, Col: 32}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" class=\"link link-hover text-base-content/60 hover:text-base-content text-sm\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var3 string
+				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(p.Title)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/demo_index.templ`, Line: 26, Col: 121}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -84,7 +139,7 @@ func DemoIndexPage() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Adds a `LinkSource` interface to the hypermedia package for composable, dynamic link aggregation
- Wraps the existing static link registry as a `registrySource` (zero behavior change for existing links)
- Implements `FrecencySource` that tracks page visits per session in SQLite and surfaces top-frecent pages as `rel="bookmark"` links
- Adds visit recording middleware that derives an anonymous session ID and records full page loads
- Updates the context bar (Alpine.js + templ) to show frecent links on the left, related links on the right, with a divider
- Shows popular pages on the `/demo` index page

## Test plan

- [ ] Visit several demo pages, then navigate to another page — verify frecent links appear in the context bar (left side, smaller text)
- [ ] Verify existing `rel="related"` links still appear on the right side of the context bar
- [ ] Visit `/demo` — verify popular pages section appears after accumulating some visits
- [ ] Verify HTMX partial requests do NOT trigger visit recording (only full page loads)
- [ ] Confirm `go build ./...` passes cleanly