### PR TITLE
feat: add LinkSource interface with frecency tracking (closes #172)

### DIFF
--- a/internal/demo/db.go
+++ b/internal/demo/db.go
@@ -190,6 +190,9 @@ func (d *DB) initSchema() error {
 	if err := d.initErrorReports(); err != nil {
 		return fmt.Errorf("init error_reports: %w", err)
 	}
+	if err := d.initFrecency(); err != nil {
+		return fmt.Errorf("init page_visits: %w", err)
+	}
 	return nil
 }
 

--- a/internal/demo/frecency.go
+++ b/internal/demo/frecency.go
@@ -1,0 +1,105 @@
+// setup:feature:demo
+
+package demo
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// PageVisit represents a frecency-scored page visit record.
+type PageVisit struct {
+	Path      string
+	Title     string
+	Visits    int
+	LastVisit time.Time
+	Score     float64
+}
+
+func (d *DB) initFrecency() error {
+	_, err := d.db.Exec(`CREATE TABLE IF NOT EXISTS page_visits (
+		session_id TEXT NOT NULL,
+		path       TEXT NOT NULL,
+		title      TEXT NOT NULL DEFAULT '',
+		visits     INTEGER NOT NULL DEFAULT 1,
+		last_visit TEXT NOT NULL DEFAULT (datetime('now')),
+		PRIMARY KEY (session_id, path)
+	)`)
+	if err != nil {
+		return fmt.Errorf("create page_visits table: %w", err)
+	}
+	return nil
+}
+
+// RecordVisit upserts a page visit for the given session.
+func (d *DB) RecordVisit(ctx context.Context, sessionID, path, title string) error {
+	_, err := d.db.ExecContext(ctx,
+		`INSERT INTO page_visits (session_id, path, title, visits, last_visit)
+		 VALUES (?, ?, ?, 1, datetime('now'))
+		 ON CONFLICT(session_id, path) DO UPDATE SET
+		   visits = visits + 1,
+		   last_visit = datetime('now'),
+		   title = excluded.title`,
+		sessionID, path, title)
+	if err != nil {
+		return fmt.Errorf("record visit: %w", err)
+	}
+	return nil
+}
+
+// TopFrecent returns the top frecent pages for a session, scored by visits/recency.
+func (d *DB) TopFrecent(ctx context.Context, sessionID string, limit int) ([]PageVisit, error) {
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT path, title, visits, last_visit,
+		        CAST(visits AS REAL) / (julianday('now') - julianday(last_visit) + 1) AS score
+		 FROM page_visits
+		 WHERE session_id = ?
+		 ORDER BY score DESC
+		 LIMIT ?`,
+		sessionID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("top frecent: %w", err)
+	}
+	defer rows.Close()
+
+	var results []PageVisit
+	for rows.Next() {
+		var pv PageVisit
+		var lastVisit string
+		if err := rows.Scan(&pv.Path, &pv.Title, &pv.Visits, &lastVisit, &pv.Score); err != nil {
+			return nil, fmt.Errorf("scan frecent row: %w", err)
+		}
+		pv.LastVisit, _ = time.Parse("2006-01-02 15:04:05", lastVisit)
+		results = append(results, pv)
+	}
+	return results, rows.Err()
+}
+
+// PopularPages returns the most popular pages across all sessions.
+func (d *DB) PopularPages(ctx context.Context, limit int) ([]PageVisit, error) {
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT path, title, SUM(visits) AS total_visits, MAX(last_visit) AS last_visit,
+		        CAST(SUM(visits) AS REAL) / (julianday('now') - julianday(MAX(last_visit)) + 1) AS score
+		 FROM page_visits
+		 GROUP BY path
+		 ORDER BY score DESC
+		 LIMIT ?`,
+		limit)
+	if err != nil {
+		return nil, fmt.Errorf("popular pages: %w", err)
+	}
+	defer rows.Close()
+
+	var results []PageVisit
+	for rows.Next() {
+		var pv PageVisit
+		var lastVisit string
+		if err := rows.Scan(&pv.Path, &pv.Title, &pv.Visits, &lastVisit, &pv.Score); err != nil {
+			return nil, fmt.Errorf("scan popular row: %w", err)
+		}
+		pv.LastVisit, _ = time.Parse("2006-01-02 15:04:05", lastVisit)
+		results = append(results, pv)
+	}
+	return results, rows.Err()
+}

--- a/internal/routes/hypermedia/links.go
+++ b/internal/routes/hypermedia/links.go
@@ -2,6 +2,7 @@
 package hypermedia
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -37,7 +38,7 @@ func Link(source, rel, target, title string) {
 	if rel == "related" {
 		// Derive the inverse title from the source path
 		// e.g., "/demo/inventory" -> "Inventory"
-		inverseTitle := titleFromPath(source)
+		inverseTitle := TitleFromPath(source)
 		linksMap[target] = append(linksMap[target], LinkRelation{
 			Rel:   "related",
 			Href:  source,
@@ -196,9 +197,9 @@ func SortedPaths(links map[string][]LinkRelation) []string {
 	return paths
 }
 
-// titleFromPath extracts a title from the last segment of a URL path.
+// TitleFromPath extracts a title from the last segment of a URL path.
 // "/demo/inventory" -> "Inventory", "/admin/error-traces" -> "Error Traces"
-func titleFromPath(path string) string {
+func TitleFromPath(path string) string {
 	path = strings.TrimSuffix(path, "/")
 	idx := strings.LastIndex(path, "/")
 	if idx < 0 {
@@ -214,4 +215,78 @@ func titleFromPath(path string) string {
 		}
 	}
 	return strings.Join(words, " ")
+}
+
+// LinkSource provides link relations dynamically for a request.
+type LinkSource interface {
+	Links(ctx context.Context, path string) []LinkRelation
+}
+
+var (
+	sourcesMu sync.RWMutex
+	sources   []LinkSource
+)
+
+// RegisterLinkSource adds a dynamic link source.
+func RegisterLinkSource(src LinkSource) {
+	sourcesMu.Lock()
+	defer sourcesMu.Unlock()
+	sources = append(sources, src)
+}
+
+// AllSourceLinks collects links from all registered sources for a path.
+func AllSourceLinks(ctx context.Context, path string) []LinkRelation {
+	sourcesMu.RLock()
+	defer sourcesMu.RUnlock()
+
+	var all []LinkRelation
+	for _, src := range sources {
+		all = append(all, src.Links(ctx, path)...)
+	}
+	return all
+}
+
+// registrySource wraps the static link registry as a LinkSource.
+type registrySource struct{}
+
+func (registrySource) Links(_ context.Context, path string) []LinkRelation {
+	return LinksFor(path)
+}
+
+func init() {
+	RegisterLinkSource(registrySource{})
+}
+
+// FrecencyFunc returns top frecent pages for a session ID.
+type FrecencyFunc func(ctx context.Context, sessionID string, limit int) ([]LinkRelation, error)
+
+// FrecencySource is a LinkSource backed by session visit history.
+type FrecencySource struct {
+	Fn    FrecencyFunc
+	Limit int
+}
+
+func (f *FrecencySource) Links(ctx context.Context, path string) []LinkRelation {
+	sessionID, ok := ctx.Value(sessionIDKey{}).(string)
+	if !ok || sessionID == "" {
+		return nil
+	}
+	links, err := f.Fn(ctx, sessionID, f.Limit)
+	if err != nil {
+		return nil
+	}
+	var filtered []LinkRelation
+	for _, l := range links {
+		if l.Href != path {
+			filtered = append(filtered, l)
+		}
+	}
+	return filtered
+}
+
+type sessionIDKey struct{}
+
+// WithSessionID adds a session ID to the context for frecency tracking.
+func WithSessionID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, id)
 }

--- a/internal/routes/middleware/frecency.go
+++ b/internal/routes/middleware/frecency.go
@@ -1,0 +1,57 @@
+// setup:feature:demo
+
+package middleware
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+
+	"catgoose/dothog/internal/routes/hypermedia"
+
+	"github.com/labstack/echo/v4"
+)
+
+// VisitRecorder records page visits for frecency tracking.
+type VisitRecorder interface {
+	RecordVisit(ctx context.Context, sessionID, path, title string) error
+}
+
+// FrecencyMiddleware sets the session ID on the request context and records
+// page visits for full-page GET requests to valid routes.
+func FrecencyMiddleware(recorder VisitRecorder, validRoutes map[string]bool) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			sessionID := getSessionID(c)
+
+			// Set session ID on the Go context for downstream LinkSources.
+			ctx := hypermedia.WithSessionID(c.Request().Context(), sessionID)
+			c.SetRequest(c.Request().WithContext(ctx))
+
+			// Only record visits for full-page GET navigations to valid routes.
+			if c.Request().Method == http.MethodGet &&
+				c.Request().Header.Get("HX-Request") != "true" &&
+				validRoutes[c.Request().URL.Path] {
+
+				path := c.Request().URL.Path
+				title := hypermedia.TitleFromPath(path)
+				go func() {
+					_ = recorder.RecordVisit(context.Background(), sessionID, path, title)
+				}()
+			}
+
+			return next(c)
+		}
+	}
+}
+
+// getSessionID returns a stable session identifier. It tries a cookie first,
+// then falls back to a hash of IP + User-Agent.
+func getSessionID(c echo.Context) string {
+	if cookie, err := c.Cookie("dothog_sid"); err == nil && cookie.Value != "" {
+		return cookie.Value
+	}
+	h := sha256.Sum256([]byte(c.RealIP() + "|" + c.Request().UserAgent()))
+	return fmt.Sprintf("%x", h[:8])
+}

--- a/internal/routes/middleware/links.go
+++ b/internal/routes/middleware/links.go
@@ -14,7 +14,7 @@ func LinkRelationsMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			path := c.Request().URL.Path
-			links := hypermedia.LinksFor(path)
+			links := hypermedia.AllSourceLinks(c.Request().Context(), path)
 			if len(links) > 0 {
 				// Set RFC 8288 Link header
 				c.Response().Header().Set("Link", hypermedia.LinkHeader(links))

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -118,7 +118,13 @@ func (ar *appRoutes) InitRoutes() error {
 	// setup:feature:demo:start
 	ar.e.GET("/welcome", handler.HandleComponent(views.WelcomePage()))
 	ar.e.GET("/hypermedia", handler.HandleComponent(views.PatternsIndexPage()))
-	ar.e.GET("/demo", handler.HandleComponent(views.DemoIndexPage()))
+	ar.e.GET("/demo", func(c echo.Context) error {
+		var popular []demo.PageVisit
+		if ar.demoDB != nil {
+			popular, _ = ar.demoDB.PopularPages(c.Request().Context(), 10)
+		}
+		return handler.RenderBaseLayout(c, views.DemoIndexPage(popular))
+	})
 	// setup:feature:demo:end
 
 	// Health check endpoint — returns structured ops metadata.
@@ -185,6 +191,32 @@ func (ar *appRoutes) InitRoutes() error {
 	ar.initVendorContactRoutes(db, actLog, broker)
 	ar.initDashboardRoutes(db, board, queue, actLog)
 	ar.initAdminErrorReportsRoutes(db)
+
+	// Build valid routes map and register frecency tracking.
+	validRoutes := make(map[string]bool)
+	for _, r := range ar.e.Routes() {
+		if r.Method == http.MethodGet {
+			validRoutes[r.Path] = true
+		}
+	}
+	ar.e.Use(middleware.FrecencyMiddleware(db, validRoutes))
+
+	frecencyFn := func(ctx context.Context, sessionID string, limit int) ([]hypermedia.LinkRelation, error) {
+		pages, err := db.TopFrecent(ctx, sessionID, limit)
+		if err != nil {
+			return nil, err
+		}
+		links := make([]hypermedia.LinkRelation, len(pages))
+		for i, p := range pages {
+			title := p.Title
+			if title == "" {
+				title = hypermedia.TitleFromPath(p.Path)
+			}
+			links[i] = hypermedia.LinkRelation{Rel: "bookmark", Href: p.Path, Title: title}
+		}
+		return links, nil
+	}
+	hypermedia.RegisterLinkSource(&hypermedia.FrecencySource{Fn: frecencyFn, Limit: 5})
 	// setup:feature:demo:end
 	ar.e.RouteNotFound("/*", handler.HandleNotFound)
 	cfg, err := config.GetConfig()

--- a/web/assets/public/js/context-bar.js
+++ b/web/assets/public/js/context-bar.js
@@ -1,14 +1,19 @@
 // setup:feature:demo
 /**
- * Alpine.js component that populates the context bar from <link rel="related"> tags.
- * Reads link relations from the document head and renders them as navigation links.
+ * Alpine.js component that populates the context bar from <link> tags.
+ * Reads bookmark (frecent) and related link relations from the document head.
  * @returns {AlpineComponent}
  */
 function contextBar() {
   return {
-    links: [],
+    frecent: [],
+    related: [],
     init() {
-      this.links = Array.from(document.querySelectorAll('head link[rel="related"]'))
+      this.frecent = this.readLinks('bookmark');
+      this.related = this.readLinks('related');
+    },
+    readLinks(rel) {
+      return Array.from(document.querySelectorAll('head link[rel="' + rel + '"]'))
         .map(function(el) { return { href: el.getAttribute('href'), title: el.getAttribute('title') }; })
         .filter(function(l) { return l.href && l.title && l.href !== window.location.pathname; });
     }

--- a/web/components/core/context.templ
+++ b/web/components/core/context.templ
@@ -21,16 +21,26 @@ templ ContextStrip(crumbs []hypermedia.Breadcrumb) {
 	</div>
 }
 
-// ContextBar renders a horizontal strip of related page links.
-// Links are read from <link rel="related"> tags in the document head.
+// ContextBar renders a horizontal strip of frecent and related page links.
+// Links are read from <link rel="bookmark"> and <link rel="related"> tags in the document head.
 templ ContextBar() {
 	<div
 		x-data="contextBar()"
-		x-show="links.length > 0"
+		x-show="frecent.length > 0 || related.length > 0"
 		x-cloak
 		class="flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm"
 	>
-		<template x-for="link in links" :key="link.href">
+		<template x-for="link in frecent" :key="link.href">
+			<a
+				:href="link.href"
+				x-text="link.title"
+				class="link link-hover text-base-content/40 hover:text-base-content whitespace-nowrap text-xs"
+			></a>
+		</template>
+		<template x-if="frecent.length > 0 && related.length > 0">
+			<div class="w-px h-4 bg-base-300 shrink-0"></div>
+		</template>
+		<template x-for="link in related" :key="link.href">
 			<a
 				:href="link.href"
 				x-text="link.title"

--- a/web/components/core/context_templ.go
+++ b/web/components/core/context_templ.go
@@ -69,8 +69,8 @@ func ContextStrip(crumbs []hypermedia.Breadcrumb) templ.Component {
 	})
 }
 
-// ContextBar renders a horizontal strip of related page links.
-// Links are read from <link rel="related"> tags in the document head.
+// ContextBar renders a horizontal strip of frecent and related page links.
+// Links are read from <link rel="bookmark"> and <link rel="related"> tags in the document head.
 func ContextBar() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -92,7 +92,7 @@ func ContextBar() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"contextBar()\" x-show=\"links.length > 0\" x-cloak class=\"flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm\"><template x-for=\"link in links\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap\"></a></template></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"contextBar()\" x-show=\"frecent.length > 0 || related.length > 0\" x-cloak class=\"flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm\"><template x-for=\"link in frecent\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/40 hover:text-base-content whitespace-nowrap text-xs\"></a></template><template x-if=\"frecent.length > 0 && related.length > 0\"><div class=\"w-px h-4 bg-base-300 shrink-0\"></div></template><template x-for=\"link in related\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap\"></a></template></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -130,7 +130,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(hypermedia.FromNav(href, from)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 47, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 57, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -143,7 +143,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 50, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 60, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {

--- a/web/views/demo_index.templ
+++ b/web/views/demo_index.templ
@@ -2,13 +2,56 @@
 
 package views
 
+import (
+	"catgoose/dothog/internal/demo"
+	"catgoose/dothog/internal/routes/hypermedia"
+	"fmt"
+)
+
+func pageTitle(p demo.PageVisit) string {
+	if p.Title != "" {
+		return p.Title
+	}
+	return hypermedia.TitleFromPath(p.Path)
+}
+
+func clampOpacity(score float64) float64 {
+	// Map score to opacity range [0.5, 1.0]
+	o := 0.5 + (score * 0.1)
+	if o > 1.0 {
+		return 1.0
+	}
+	if o < 0.5 {
+		return 0.5
+	}
+	return o
+}
+
 // DemoIndexPage renders the /demo resource discovery page.
-templ DemoIndexPage() {
+templ DemoIndexPage(popular []demo.PageVisit) {
 	<div class="p-4 space-y-6 max-w-4xl mx-auto">
 		<div class="space-y-1">
 			<h1 class="text-2xl font-bold">Demo</h1>
 			<p class="text-sm text-base-content/60">Working examples of common application patterns built on the dothog stack.</p>
 		</div>
+
+		if len(popular) > 0 {
+			<div class="space-y-2">
+				<h2 class="text-sm font-semibold text-base-content/60">Popular Pages</h2>
+				<div class="flex flex-wrap gap-2">
+					for _, p := range popular {
+						<a
+							href={ templ.URL(p.Path) }
+							class="badge badge-outline badge-sm gap-1 hover:badge-primary transition-colors"
+							style={ fmt.Sprintf("opacity: %.2f", clampOpacity(p.Score)) }
+						>
+							{ pageTitle(p) }
+							<span class="text-base-content/40">{ fmt.Sprintf("%d", p.Visits) }</span>
+						</a>
+					}
+				</div>
+			</div>
+		}
 
 		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
 			@adminResourceCard("/demo/logging", "Logging", "Structured logging with promolog. Request traces, log levels, and context propagation.", "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z")

--- a/web/views/demo_index_templ.go
+++ b/web/views/demo_index_templ.go
@@ -10,8 +10,33 @@ package views
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
+import (
+	"catgoose/dothog/internal/demo"
+	"catgoose/dothog/internal/routes/hypermedia"
+	"fmt"
+)
+
+func pageTitle(p demo.PageVisit) string {
+	if p.Title != "" {
+		return p.Title
+	}
+	return hypermedia.TitleFromPath(p.Path)
+}
+
+func clampOpacity(score float64) float64 {
+	// Map score to opacity range [0.5, 1.0]
+	o := 0.5 + (score * 0.1)
+	if o > 1.0 {
+		return 1.0
+	}
+	if o < 0.5 {
+		return 0.5
+	}
+	return o
+}
+
 // DemoIndexPage renders the /demo resource discovery page.
-func DemoIndexPage() templ.Component {
+func DemoIndexPage(popular []demo.PageVisit) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -32,7 +57,79 @@ func DemoIndexPage() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">Demo</h1><p class=\"text-sm text-base-content/60\">Working examples of common application patterns built on the dothog stack.</p></div><div class=\"grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">Demo</h1><p class=\"text-sm text-base-content/60\">Working examples of common application patterns built on the dothog stack.</p></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if len(popular) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"space-y-2\"><h2 class=\"text-sm font-semibold text-base-content/60\">Popular Pages</h2><div class=\"flex flex-wrap gap-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, p := range popular {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<a href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var2 templ.SafeURL
+				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(p.Path))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/demo_index.templ`, Line: 44, Col: 31}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" class=\"badge badge-outline badge-sm gap-1 hover:badge-primary transition-colors\" style=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var3 string
+				templ_7745c5c3_Var3, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(fmt.Sprintf("opacity: %.2f", clampOpacity(p.Score)))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/demo_index.templ`, Line: 46, Col: 66}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var4 string
+				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(pageTitle(p))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/demo_index.templ`, Line: 48, Col: 21}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " <span class=\"text-base-content/40\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var5 string
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", p.Visits))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/demo_index.templ`, Line: 49, Col: 71}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span></a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -84,7 +181,7 @@ func DemoIndexPage() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Add `LinkSource` interface and `AllSourceLinks` aggregator to `hypermedia/links.go` for composable, dynamic link relation sources
- Add `FrecencySource` backed by session visit history with frecency scoring (visits / recency)
- Create `frecency.go` store with `RecordVisit`, `TopFrecent`, and `PopularPages` queries against a new `page_visits` SQLite table
- Add `FrecencyMiddleware` that sets session ID on context and records page visits for full-page GET navigations
- Update `LinkRelationsMiddleware` to use `AllSourceLinks` instead of static `LinksFor`
- Update Alpine.js `contextBar()` to read both `rel="bookmark"` (frecent) and `rel="related"` links with a visual divider
- Update `DemoIndexPage` to show popular pages as score-weighted badges
- Export `TitleFromPath` for reuse by frecency components

## Test plan

- [ ] Visit several demo pages, then check that the context bar shows frecent bookmarks alongside related links
- [ ] Verify the divider renders between frecent and related sections
- [ ] Confirm `/demo` page shows popular pages badges after some navigation
- [ ] Verify `go build ./...` passes cleanly
- [ ] Verify frecency data persists across page loads (SQLite-backed)