### PR TITLE
feat: add Hub links on discovery pages and composable context bar sections

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -116,6 +116,34 @@ func (ar *appRoutes) InitRoutes() error {
 	})
 	// setup:feature:session_settings:end
 	// setup:feature:demo:start
+	hypermedia.Hub("/demo", "Demo",
+		hypermedia.Rel("/demo/inventory", "Inventory"),
+		hypermedia.Rel("/demo/catalog", "Catalog"),
+		hypermedia.Rel("/demo/people", "People"),
+		hypermedia.Rel("/demo/kanban", "Kanban"),
+		hypermedia.Rel("/demo/approvals", "Approvals"),
+		hypermedia.Rel("/demo/vendors", "Vendors"),
+		hypermedia.Rel("/demo/feed", "Feed"),
+		hypermedia.Rel("/demo/canvas", "Canvas"),
+		hypermedia.Rel("/demo/settings", "Settings"),
+		hypermedia.Rel("/demo/bulk", "Bulk"),
+		hypermedia.Rel("/demo/logging", "Logging"),
+		hypermedia.Rel("/demo/repository", "Repository"),
+		hypermedia.Rel("/dashboard", "Dashboard"),
+	)
+	hypermedia.Hub("/hypermedia", "Hypermedia",
+		hypermedia.Rel("/hypermedia/controls", "Controls"),
+		hypermedia.Rel("/hypermedia/crud", "CRUD"),
+		hypermedia.Rel("/hypermedia/lists", "Lists"),
+		hypermedia.Rel("/hypermedia/interactions", "Interactions"),
+		hypermedia.Rel("/hypermedia/state", "State"),
+		hypermedia.Rel("/hypermedia/errors", "Errors"),
+		hypermedia.Rel("/hypermedia/components", "Components"),
+		hypermedia.Rel("/hypermedia/components2", "Components 2"),
+		hypermedia.Rel("/hypermedia/components3", "Components 3"),
+		hypermedia.Rel("/hypermedia/realtime", "Realtime"),
+		hypermedia.Rel("/hypermedia/links", "Links"),
+	)
 	ar.e.GET("/welcome", handler.HandleComponent(views.WelcomePage()))
 	ar.e.GET("/hypermedia", handler.HandleComponent(views.PatternsIndexPage()))
 	ar.e.GET("/demo", func(c echo.Context) error {

--- a/internal/routes/routes_admin_core.go
+++ b/internal/routes/routes_admin_core.go
@@ -21,6 +21,15 @@ import (
 )
 
 func (ar *appRoutes) initAdminCoreRoutes() {
+	hypermedia.Hub("/admin", "Admin",
+		hypermedia.Rel("/admin/health", "Health"),
+		hypermedia.Rel("/admin/sessions", "Sessions"),
+		hypermedia.Rel("/admin/settings", "Control Panel"),
+		hypermedia.Rel("/admin/error-traces", "Error Traces"),
+		hypermedia.Rel("/admin/error-reports", "Error Reports"),
+		hypermedia.Rel("/admin/system", "System"),
+		hypermedia.Rel("/admin/config", "Config"),
+	)
 	hypermedia.Ring(
 		hypermedia.Rel("/admin/health", "Health"),
 		hypermedia.Rel("/admin/error-traces", "Error Traces"),

--- a/internal/routes/routes_dashboard.go
+++ b/internal/routes/routes_dashboard.go
@@ -27,6 +27,14 @@ func (ar *appRoutes) initDashboardRoutes(db *demo.DB, board *demo.KanbanBoard, q
 		hypermedia.Rel("/demo/vendors", "Vendors"),
 		hypermedia.Rel("/demo/feed", "Feed"),
 	)
+	hypermedia.Ring(
+		hypermedia.Rel("/demo/inventory", "Inventory"),
+		hypermedia.Rel("/demo/people", "People"),
+		hypermedia.Rel("/demo/kanban", "Kanban"),
+		hypermedia.Rel("/demo/approvals", "Approvals"),
+		hypermedia.Rel("/demo/vendors", "Vendors"),
+		hypermedia.Rel("/demo/feed", "Feed"),
+	)
 
 	d := &dashboardRoutes{db: db, board: board, queue: queue, actLog: actLog}
 	ar.e.GET("/dashboard", d.handleDashboard)

--- a/web/assets/public/js/context-bar.js
+++ b/web/assets/public/js/context-bar.js
@@ -1,16 +1,18 @@
 // setup:feature:demo
 /**
- * Alpine.js component that populates the context bar from <link> tags.
- * Reads bookmark (frecent) and related link relations from the document head.
+ * Alpine.js component for the composable context bar.
+ * Reads <link> tags from <head> grouped by rel type and renders them as sections.
+ * Each section has a rel type, alignment, and visual style.
  * @returns {AlpineComponent}
  */
 function contextBar() {
   return {
-    frecent: [],
-    related: [],
+    sections: [],
     init() {
-      this.frecent = this.readLinks('bookmark');
-      this.related = this.readLinks('related');
+      this.sections = [
+        { rel: 'bookmark', links: this.readLinks('bookmark'), style: 'frecent' },
+        { rel: 'related',  links: this.readLinks('related'),  style: 'related' },
+      ].filter(function(s) { return s.links.length > 0; });
     },
     readLinks(rel) {
       return Array.from(document.querySelectorAll('head link[rel="' + rel + '"]'))

--- a/web/components/core/context.templ
+++ b/web/components/core/context.templ
@@ -23,29 +23,28 @@ templ ContextStrip(crumbs []hypermedia.Breadcrumb) {
 
 // ContextBar renders a horizontal strip of frecent and related page links.
 // Links are read from <link rel="bookmark"> and <link rel="related"> tags in the document head.
+// Sections are composable: each rel type renders as a distinct group with a divider between them.
 templ ContextBar() {
 	<div
 		x-data="contextBar()"
-		x-show="frecent.length > 0 || related.length > 0"
+		x-show="sections.length > 0"
 		x-cloak
 		class="flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm"
 	>
-		<template x-for="link in frecent" :key="link.href">
-			<a
-				:href="link.href"
-				x-text="link.title"
-				class="link link-hover text-base-content/40 hover:text-base-content whitespace-nowrap text-xs"
-			></a>
-		</template>
-		<template x-if="frecent.length > 0 && related.length > 0">
-			<div class="w-px h-4 bg-base-300 shrink-0"></div>
-		</template>
-		<template x-for="link in related" :key="link.href">
-			<a
-				:href="link.href"
-				x-text="link.title"
-				class="link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap"
-			></a>
+		<template x-for="(section, idx) in sections" :key="section.rel">
+			<div class="contents">
+				<template x-if="idx > 0">
+					<div class="w-px h-4 bg-base-300 shrink-0"></div>
+				</template>
+				<template x-for="link in section.links" :key="link.href">
+					<a
+						:href="link.href"
+						x-text="link.title"
+						class="link link-hover whitespace-nowrap"
+						:class="section.style === 'frecent' ? 'text-base-content/40 hover:text-base-content text-xs' : 'text-base-content/60 hover:text-base-content'"
+					></a>
+				</template>
+			</div>
 		</template>
 	</div>
 }

--- a/web/components/core/context_templ.go
+++ b/web/components/core/context_templ.go
@@ -71,6 +71,7 @@ func ContextStrip(crumbs []hypermedia.Breadcrumb) templ.Component {
 
 // ContextBar renders a horizontal strip of frecent and related page links.
 // Links are read from <link rel="bookmark"> and <link rel="related"> tags in the document head.
+// Sections are composable: each rel type renders as a distinct group with a divider between them.
 func ContextBar() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -92,7 +93,7 @@ func ContextBar() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"contextBar()\" x-show=\"frecent.length > 0 || related.length > 0\" x-cloak class=\"flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm\"><template x-for=\"link in frecent\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/40 hover:text-base-content whitespace-nowrap text-xs\"></a></template><template x-if=\"frecent.length > 0 && related.length > 0\"><div class=\"w-px h-4 bg-base-300 shrink-0\"></div></template><template x-for=\"link in related\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap\"></a></template></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"contextBar()\" x-show=\"sections.length > 0\" x-cloak class=\"flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm\"><template x-for=\"(section, idx) in sections\" :key=\"section.rel\"><div class=\"contents\"><template x-if=\"idx > 0\"><div class=\"w-px h-4 bg-base-300 shrink-0\"></div></template><template x-for=\"link in section.links\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover whitespace-nowrap\" :class=\"section.style === 'frecent' ? 'text-base-content/40 hover:text-base-content text-xs' : 'text-base-content/60 hover:text-base-content'\"></a></template></div></template></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -130,7 +131,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(hypermedia.FromNav(href, from)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 57, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 56, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -143,7 +144,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 60, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 59, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Add Hub declarations for `/demo`, `/hypermedia`, and `/admin` discovery pages so each index page links to all its children and each child links back to the index
- Add Ring for dashboard children (`/demo/inventory`, `/demo/people`, `/demo/kanban`, `/demo/approvals`, `/demo/vendors`, `/demo/feed`) so siblings link to each other
- Refactor context bar Alpine component and templ template into a composable section container that renders grouped link sections with dividers between them

Closes #178