### PR TITLE
fix: update tests for error controls refactor and embed sw.js

### DIFF
--- a/internal/routes/middleware/error_handler_test.go
+++ b/internal/routes/middleware/error_handler_test.go
@@ -90,8 +90,7 @@ func TestHTTPErrorHandler_EchoHTTPError_NonHTMX(t *testing.T) {
 	body := rec.Body.String()
 	require.Contains(t, body, "bad request", "expected error message in HTML body")
 	require.Contains(t, body, "<!doctype html>", "expected full HTML page for non-HTMX")
-	require.Contains(t, body, "Go Back", "expected Back control in error page")
-	require.Contains(t, body, "Go Home", "expected Home control in error page")
+	require.Contains(t, body, "Close", "expected Dismiss control in error page")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/routes/middleware/helpers_test.go
+++ b/internal/routes/middleware/helpers_test.go
@@ -35,10 +35,10 @@ func TestBadRequest(t *testing.T) {
 
 	err := BadRequest(c, "invalid input")
 
-	var he *echo.HTTPError
+	var he *hypermedia.HTTPError
 	require.ErrorAs(t, err, &he)
-	require.Equal(t, http.StatusBadRequest, he.Code)
-	require.Equal(t, "invalid input", he.Message)
+	require.Equal(t, http.StatusBadRequest, he.EC.StatusCode)
+	require.Equal(t, "invalid input", he.EC.Message)
 }
 
 func TestUnauthorized(t *testing.T) {
@@ -46,10 +46,10 @@ func TestUnauthorized(t *testing.T) {
 
 	err := Unauthorized(c, "login required")
 
-	var he *echo.HTTPError
+	var he *hypermedia.HTTPError
 	require.ErrorAs(t, err, &he)
-	require.Equal(t, http.StatusUnauthorized, he.Code)
-	require.Equal(t, "login required", he.Message)
+	require.Equal(t, http.StatusUnauthorized, he.EC.StatusCode)
+	require.Equal(t, "login required", he.EC.Message)
 }
 
 func TestForbidden(t *testing.T) {
@@ -57,10 +57,10 @@ func TestForbidden(t *testing.T) {
 
 	err := Forbidden(c, "access denied")
 
-	var he *echo.HTTPError
+	var he *hypermedia.HTTPError
 	require.ErrorAs(t, err, &he)
-	require.Equal(t, http.StatusForbidden, he.Code)
-	require.Equal(t, "access denied", he.Message)
+	require.Equal(t, http.StatusForbidden, he.EC.StatusCode)
+	require.Equal(t, "access denied", he.EC.Message)
 }
 
 func TestNotFound(t *testing.T) {
@@ -68,10 +68,10 @@ func TestNotFound(t *testing.T) {
 
 	err := NotFound(c, "resource missing")
 
-	var he *echo.HTTPError
+	var he *hypermedia.HTTPError
 	require.ErrorAs(t, err, &he)
-	require.Equal(t, http.StatusNotFound, he.Code)
-	require.Equal(t, "resource missing", he.Message)
+	require.Equal(t, http.StatusNotFound, he.EC.StatusCode)
+	require.Equal(t, "resource missing", he.EC.Message)
 }
 
 func TestInternalServerError(t *testing.T) {
@@ -79,10 +79,10 @@ func TestInternalServerError(t *testing.T) {
 
 	err := InternalServerError(c, "something broke")
 
-	var he *echo.HTTPError
+	var he *hypermedia.HTTPError
 	require.ErrorAs(t, err, &he)
-	require.Equal(t, http.StatusInternalServerError, he.Code)
-	require.Equal(t, "something broke", he.Message)
+	require.Equal(t, http.StatusInternalServerError, he.EC.StatusCode)
+	require.Equal(t, "something broke", he.EC.Message)
 }
 
 func TestServiceUnavailable(t *testing.T) {
@@ -90,10 +90,10 @@ func TestServiceUnavailable(t *testing.T) {
 
 	err := ServiceUnavailable(c, "try again later")
 
-	var he *echo.HTTPError
+	var he *hypermedia.HTTPError
 	require.ErrorAs(t, err, &he)
-	require.Equal(t, http.StatusServiceUnavailable, he.Code)
-	require.Equal(t, "try again later", he.Message)
+	require.Equal(t, http.StatusServiceUnavailable, he.EC.StatusCode)
+	require.Equal(t, "try again later", he.EC.Message)
 }
 
 func TestHypermediaError(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ import (
 	"github.com/catgoose/dio"
 )
 
-//go:embed web/assets/public/css/* web/assets/public/js/* all:web/assets/public/images
+//go:embed web/assets/public/css/* web/assets/public/js/* all:web/assets/public/images web/assets/public/sw.js
 var staticAssets embed.FS
 
 var staticFS = must(fs.Sub(staticAssets, "web/assets/public"))


### PR DESCRIPTION
## Summary
- Updated middleware helper tests (`helpers_test.go`) to assert on `*hypermedia.HTTPError` instead of `*echo.HTTPError`, matching the error controls refactor from PR #160
- Fixed `error_handler_test.go` non-HTMX 400 assertion to expect "Close" (DismissButton) instead of "Go Back"/"Go Home", matching `ErrorControlsForStatus` default-case output
- Added `web/assets/public/sw.js` to the embed directive in `main.go` so the service worker is included in the binary

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./internal/routes/middleware/ -v` — all 38 tests pass
- [x] `go test ./internal/routes/handler/ -v` — all 6 tests pass