### PR TITLE
fix: skip Echo gzip when behind templ proxy

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"os"
 	"time"
 	// setup:feature:auth:start
 	"github.com/catgoose/crooner"
@@ -246,7 +247,12 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 	e.Use(echoMiddleware.RequestLogger())
 	e.Use(echoMiddleware.Recover())
 	e.Use(echoMiddleware.Secure())
-	e.Use(echoMiddleware.Gzip())
+	// Skip gzip when running behind the templ proxy (mage watch).
+	// Echo's chunked gzip responses cause h2 framing errors through
+	// the templ-proxy → Caddy chain. Caddy handles compression instead.
+	if os.Getenv("TEMPL_PROXY") == "" {
+		e.Use(echoMiddleware.Gzip())
+	}
 
 	// setup:feature:auth:start
 	if cfg != nil && !cfg.CroonerDisabled && cfg.CroonerConfig != nil {

--- a/magefile.go
+++ b/magefile.go
@@ -451,6 +451,9 @@ func EnvCheck() error {
 
 // Watch runs Tailwind, Templ, Air, and Caddy in watch mode
 func Watch() error {
+	// Signal to the Go server that it's behind the templ proxy chain.
+	// Echo skips gzip middleware when this is set — Caddy handles compression.
+	os.Setenv("TEMPL_PROXY", "true")
 	errc := make(chan error, 4)
 
 	go func() {


### PR DESCRIPTION
## Summary

- Echo's gzip middleware produces chunked responses that cause h2 framing errors (`unexpected EOF`) when proxied through templ proxy → Caddy
- `mage watch` now sets `TEMPL_PROXY=true` env var before starting the dev server
- Echo skips gzip middleware when `TEMPL_PROXY` is set — Caddy handles compression instead
- Gzip is still active in all other modes (production, direct dev, jor1 deploys)

## Root cause

The templ proxy passes Echo's chunked gzip responses to Caddy, which translates them to HTTP/2 DATA frames. The connection closes before Caddy finishes reading, causing `reading: unexpected EOF` and empty responses to the browser.