### PR TITLE
feat: named ring groups with grouped context bar

### DIFF
--- a/internal/routes/hypermedia/links.go
+++ b/internal/routes/hypermedia/links.go
@@ -13,6 +13,7 @@ type LinkRelation struct {
 	Rel   string // IANA link relation (e.g., "related", "collection", "up")
 	Href  string // Target URL
 	Title string // Human-readable label
+	Group string // Optional group name (e.g., ring name) for UI grouping
 }
 
 // linkRegistry stores registered link relations keyed by source path.
@@ -114,8 +115,8 @@ func Rel(path, title string) RelEntry {
 }
 
 // Ring registers symmetric rel="related" links between all members.
-// Every member links to every other member.
-func Ring(members ...RelEntry) {
+// Every member links to every other member. The name is used for UI grouping.
+func Ring(name string, members ...RelEntry) {
 	linksMu.Lock()
 	defer linksMu.Unlock()
 
@@ -129,6 +130,7 @@ func Ring(members ...RelEntry) {
 					Rel:   "related",
 					Href:  b.Path,
 					Title: b.Title,
+					Group: name,
 				})
 			}
 		}

--- a/internal/routes/routes_admin_core.go
+++ b/internal/routes/routes_admin_core.go
@@ -30,13 +30,13 @@ func (ar *appRoutes) initAdminCoreRoutes() {
 		hypermedia.Rel("/admin/system", "System"),
 		hypermedia.Rel("/admin/config", "Config"),
 	)
-	hypermedia.Ring(
+	hypermedia.Ring("Admin Ops",
 		hypermedia.Rel("/admin/health", "Health"),
 		hypermedia.Rel("/admin/error-traces", "Error Traces"),
 		hypermedia.Rel("/admin/sessions", "Sessions"),
 		hypermedia.Rel("/admin/settings", "Control Panel"),
 	)
-	hypermedia.Ring(
+	hypermedia.Ring("System",
 		hypermedia.Rel("/admin/system", "System"),
 		hypermedia.Rel("/admin/config", "Config"),
 		hypermedia.Rel("/admin/health", "Health"),

--- a/internal/routes/routes_admin_error_reports.go
+++ b/internal/routes/routes_admin_error_reports.go
@@ -20,7 +20,7 @@ const errorReportsBase = "/admin/error-reports"
 type errorReportRoutes struct{ db *demo.DB }
 
 func (ar *appRoutes) initAdminErrorReportsRoutes(db *demo.DB) {
-	hypermedia.Ring(
+	hypermedia.Ring("Admin Ops",
 		hypermedia.Rel("/admin/error-reports", "Error Reports"),
 		hypermedia.Rel("/admin/health", "Health"),
 		hypermedia.Rel("/admin/error-traces", "Error Traces"),

--- a/internal/routes/routes_dashboard.go
+++ b/internal/routes/routes_dashboard.go
@@ -27,7 +27,7 @@ func (ar *appRoutes) initDashboardRoutes(db *demo.DB, board *demo.KanbanBoard, q
 		hypermedia.Rel("/demo/vendors", "Vendors"),
 		hypermedia.Rel("/demo/feed", "Feed"),
 	)
-	hypermedia.Ring(
+	hypermedia.Ring("Dashboard",
 		hypermedia.Rel("/demo/inventory", "Inventory"),
 		hypermedia.Rel("/demo/people", "People"),
 		hypermedia.Rel("/demo/kanban", "Kanban"),

--- a/internal/routes/routes_hypermedia.go
+++ b/internal/routes/routes_hypermedia.go
@@ -60,7 +60,7 @@ func (ar *appRoutes) initHypermediaRoutes() {
 	hypermedia.Link("/hypermedia/crud", "related", "/hypermedia/state", "State")
 	hypermedia.Link("/hypermedia/crud", "related", "/hypermedia/errors", "Errors")
 
-	hypermedia.Ring(
+	hypermedia.Ring("Components",
 		hypermedia.Rel("/hypermedia/components", "Components"),
 		hypermedia.Rel("/hypermedia/components2", "Components 2"),
 		hypermedia.Rel("/hypermedia/components3", "Components 3"),

--- a/internal/routes/routes_inventory.go
+++ b/internal/routes/routes_inventory.go
@@ -21,13 +21,13 @@ const inventoryBase = "/demo/inventory"
 type inventoryRoutes struct{ db *demo.DB }
 
 func (ar *appRoutes) initInventoryRoutes(db *demo.DB) {
-	hypermedia.Ring(
+	hypermedia.Ring("Data",
 		hypermedia.Rel("/demo/inventory", "Inventory"),
 		hypermedia.Rel("/demo/catalog", "Catalog"),
 		hypermedia.Rel("/demo/bulk", "Bulk Ops"),
+		hypermedia.Rel("/demo/people", "People"),
+		hypermedia.Rel("/demo/vendors", "Vendors"),
 	)
-	hypermedia.Link("/demo/inventory", "related", "/demo/people", "People")
-	hypermedia.Link("/demo/inventory", "related", "/demo/vendors", "Vendors")
 
 	d := &inventoryRoutes{db: db}
 	ar.e.GET(inventoryBase, d.handleInventoryPage)

--- a/internal/routes/routes_kanban.go
+++ b/internal/routes/routes_kanban.go
@@ -20,7 +20,7 @@ type kanbanRoutes struct {
 }
 
 func (ar *appRoutes) initKanbanRoutes(board *demo.KanbanBoard, actLog *demo.ActivityLog, broker *ssebroker.SSEBroker) {
-	hypermedia.Ring(
+	hypermedia.Ring("Workflow",
 		hypermedia.Rel("/demo/kanban", "Kanban"),
 		hypermedia.Rel("/demo/approvals", "Approvals"),
 		hypermedia.Rel("/demo/feed", "Feed"),

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -13,6 +13,7 @@ import (
 	"catgoose/dothog/internal/logger"
 	"github.com/catgoose/promolog"
 	"catgoose/dothog/internal/routes/handler"
+	"catgoose/dothog/internal/routes/hypermedia"
 	"catgoose/dothog/internal/shared"
 	"catgoose/dothog/internal/ssebroker"
 	"catgoose/dothog/web/views"
@@ -23,6 +24,12 @@ import (
 const loggingBase = "/demo/logging"
 
 func (ar *appRoutes) initLoggingRoutes() {
+	hypermedia.Ring("Utility",
+		hypermedia.Rel("/demo/logging", "Logging"),
+		hypermedia.Rel("/demo/canvas", "Canvas"),
+		hypermedia.Rel("/demo/settings", "Settings"),
+		hypermedia.Rel("/demo/repository", "Repository"),
+	)
 	// setup:feature:sse:start
 	broker := ssebroker.NewSSEBroker()
 

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -29,8 +29,6 @@ type peopleRoutes struct {
 }
 
 func (ar *appRoutes) initPeopleRoutes(db *demo.DB, broker *ssebroker.SSEBroker, actLog *demo.ActivityLog) {
-	hypermedia.Link("/demo/people", "related", "/demo/vendors", "Vendors")
-
 	p := &peopleRoutes{db: db, broker: broker, actLog: actLog}
 	ar.e.GET(peopleBase, p.handlePeoplePage)
 	ar.e.GET(peopleBase+"/list", p.handlePeopleList)

--- a/web/assets/public/js/context-bar.js
+++ b/web/assets/public/js/context-bar.js
@@ -1,16 +1,39 @@
 // setup:feature:demo
 /**
  * Alpine.js component that populates the context bar from <link rel="related"> tags.
- * Reads link relations from the document head and renders them as navigation links.
+ * Reads link relations from the document head, groups them by data-group attribute,
+ * and renders them as navigation links with group labels.
  * @returns {AlpineComponent}
  */
 function contextBar() {
   return {
-    links: [],
+    groups: [],
     init() {
-      this.links = Array.from(document.querySelectorAll('head link[rel="related"]'))
-        .map(function(el) { return { href: el.getAttribute('href'), title: el.getAttribute('title') }; })
+      var links = Array.from(document.querySelectorAll('head link[rel="related"]'))
+        .map(function(el) {
+          return {
+            href: el.getAttribute('href'),
+            title: el.getAttribute('title'),
+            group: el.getAttribute('data-group') || ''
+          };
+        })
         .filter(function(l) { return l.href && l.title && l.href !== window.location.pathname; });
+
+      // Group links by their group name, preserving order
+      var seen = {};
+      var groups = [];
+      for (var i = 0; i < links.length; i++) {
+        var key = links[i].group;
+        if (!seen[key]) {
+          seen[key] = { name: key, links: [] };
+          groups.push(seen[key]);
+        }
+        seen[key].links.push(links[i]);
+      }
+      this.groups = groups;
+    },
+    hasLinks() {
+      return this.groups.length > 0;
     }
   };
 }

--- a/web/components/core/context.templ
+++ b/web/components/core/context.templ
@@ -21,21 +21,31 @@ templ ContextStrip(crumbs []hypermedia.Breadcrumb) {
 	</div>
 }
 
-// ContextBar renders a horizontal strip of related page links.
+// ContextBar renders a horizontal strip of related page links grouped by ring name.
 // Links are read from <link rel="related"> tags in the document head.
 templ ContextBar() {
 	<div
 		x-data="contextBar()"
-		x-show="links.length > 0"
+		x-show="hasLinks()"
 		x-cloak
 		class="flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm"
 	>
-		<template x-for="link in links" :key="link.href">
-			<a
-				:href="link.href"
-				x-text="link.title"
-				class="link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap"
-			></a>
+		<template x-for="(group, idx) in groups" :key="group.name">
+			<div class="contents">
+				<template x-if="idx > 0">
+					<div class="w-px h-4 bg-base-300 shrink-0"></div>
+				</template>
+				<template x-if="group.name">
+					<span class="text-base-content/30 text-xs font-medium whitespace-nowrap" x-text="group.name"></span>
+				</template>
+				<template x-for="link in group.links" :key="link.href">
+					<a
+						:href="link.href"
+						x-text="link.title"
+						class="link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap"
+					></a>
+				</template>
+			</div>
 		</template>
 	</div>
 }

--- a/web/components/core/context_templ.go
+++ b/web/components/core/context_templ.go
@@ -69,7 +69,7 @@ func ContextStrip(crumbs []hypermedia.Breadcrumb) templ.Component {
 	})
 }
 
-// ContextBar renders a horizontal strip of related page links.
+// ContextBar renders a horizontal strip of related page links grouped by ring name.
 // Links are read from <link rel="related"> tags in the document head.
 func ContextBar() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -92,7 +92,7 @@ func ContextBar() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"contextBar()\" x-show=\"links.length > 0\" x-cloak class=\"flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm\"><template x-for=\"link in links\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap\"></a></template></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"contextBar()\" x-show=\"hasLinks()\" x-cloak class=\"flex items-center justify-center gap-3 overflow-x-auto px-4 py-1.5 bg-base-200/50 border-b border-base-300 text-sm\"><template x-for=\"(group, idx) in groups\" :key=\"group.name\"><div class=\"contents\"><template x-if=\"idx > 0\"><div class=\"w-px h-4 bg-base-300 shrink-0\"></div></template><template x-if=\"group.name\"><span class=\"text-base-content/30 text-xs font-medium whitespace-nowrap\" x-text=\"group.name\"></span></template><template x-for=\"link in group.links\" :key=\"link.href\"><a :href=\"link.href\" x-text=\"link.title\" class=\"link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap\"></a></template></div></template></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -130,7 +130,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(hypermedia.FromNav(href, from)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 47, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 57, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -143,7 +143,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 50, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 60, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -90,7 +90,11 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string, 
 		// setup:feature:demo:start
 		<link rel="manifest" href="/public/images/site.webmanifest"/>
 		for _, link := range links {
-			<link rel={ link.Rel } href={ link.Href } title={ link.Title }/>
+			if link.Group != "" {
+				<link rel={ link.Rel } href={ link.Href } title={ link.Title } data-group={ link.Group }/>
+			} else {
+				<link rel={ link.Rel } href={ link.Href } title={ link.Title }/>
+			}
 		}
 		// setup:feature:demo:end
 		<title>{ appName }</title>

--- a/web/views/index_templ.go
+++ b/web/views/index_templ.go
@@ -190,74 +190,133 @@ func header(csrfToken string, devMode bool, appName string, extraCSS []string, l
 			return templ_7745c5c3_Err
 		}
 		for _, link := range links {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<link rel=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(link.Rel)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 93, Col: 23}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" href=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var8 templ.SafeURL
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(link.Href)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 93, Col: 42}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" title=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(link.Title)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 93, Col: 63}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
+			if link.Group != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<link rel=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(link.Rel)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 94, Col: 24}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var8 templ.SafeURL
+				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(link.Href)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 94, Col: 43}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var9 string
+				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(link.Title)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 94, Col: 64}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" data-group=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var10 string
+				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(link.Group)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 94, Col: 90}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<link rel=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var11 string
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(link.Rel)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 96, Col: 24}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 templ.SafeURL
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(link.Href)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 96, Col: 43}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(link.Title)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 96, Col: 64}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<title>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<title>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(appName)
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(appName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 96, Col: 18}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 100, Col: 18}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</title>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</title>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if devMode {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<script src=\"/public/js/dev-logging.js\"></script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<script src=\"/public/js/dev-logging.js\"></script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<script>\n\t\t\t/**\n\t\t\t * Restore persisted debug toggles from localStorage on every page load.\n\t\t\t * The admin settings page writes { \"htmx-log\": true, ... } to dothog_debug.\n\t\t\t * Waits for DOMContentLoaded so htmx/hyperscript are available.\n\t\t\t */\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tvar state;\n\t\t\t\ttry { state = JSON.parse(localStorage.getItem('dothog_debug')) || {}; } catch(e) { return; }\n\t\t\t\tif (state['htmx-log'] && typeof htmx !== 'undefined') { htmx.logAll(); }\n\t\t\t\tif (state['htmx-events'] && typeof htmx !== 'undefined') {\n\t\t\t\t\twindow._htmxDbg = function(e) {\n\t\t\t\t\t\tconsole.debug('%c[htmx:' + e.type.replace('htmx:','') + ']', 'color:#38bdf8;font-weight:bold', e.detail);\n\t\t\t\t\t};\n\t\t\t\t\tvar evts = ['htmx:beforeRequest','htmx:afterRequest','htmx:beforeSwap','htmx:afterSwap','htmx:oobErrorNoTarget','htmx:sseMessage','htmx:sseError'];\n\t\t\t\t\tevts.forEach(function(t) { document.body.addEventListener(t, window._htmxDbg); });\n\t\t\t\t\twindow._htmxDbgEvts = evts;\n\t\t\t\t}\n\t\t\t\tif (state['hs-beep']) {\n\t\t\t\t\twindow._hsDbg = function(e) { console.debug('%c[_hs:beep]', 'color:#a78bfa;font-weight:bold', e.detail); };\n\t\t\t\t\tdocument.body.addEventListener('hyperscript:beep', window._hsDbg);\n\t\t\t\t}\n\t\t\t\tif (state['alpine-events']) {\n\t\t\t\t\twindow._alpineDbg = function(e) { console.debug('%c[alpine:' + e.type + ']', 'color:#34d399;font-weight:bold', e.detail); };\n\t\t\t\t\tdocument.addEventListener('alpine:initialized', window._alpineDbg);\n\t\t\t\t\tdocument.addEventListener('alpine:init', window._alpineDbg);\n\t\t\t\t}\n\t\t\t});\n\t\t</script><script defer>\n\t\t\t/**\n\t\t\t * Listen for server-sent theme-change events and apply them to the\n\t\t\t * document so all open browsers stay in sync.\n\t\t\t * @listens theme-change\n\t\t\t */\n\t\t\t(function() {\n\t\t\t\t/** @type {EventSource} */\n\t\t\t\tvar es = new EventSource(\"/sse/theme\");\n\t\t\t\tes.addEventListener(\"theme-change\", function(/** @type {MessageEvent} */ e) {\n\t\t\t\t\tdocument.documentElement.dataset.theme = e.data;\n\t\t\t\t});\n\t\t\t})();\n\t\t</script><script>\n\t\t\tif ('serviceWorker' in navigator) {\n\t\t\t\tnavigator.serviceWorker.register('/sw.js').catch(function(err) {\n\t\t\t\t\tconsole.warn('ServiceWorker registration failed:', err);\n\t\t\t\t});\n\t\t\t}\n\t\t</script></head>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<script>\n\t\t\t/**\n\t\t\t * Restore persisted debug toggles from localStorage on every page load.\n\t\t\t * The admin settings page writes { \"htmx-log\": true, ... } to dothog_debug.\n\t\t\t * Waits for DOMContentLoaded so htmx/hyperscript are available.\n\t\t\t */\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tvar state;\n\t\t\t\ttry { state = JSON.parse(localStorage.getItem('dothog_debug')) || {}; } catch(e) { return; }\n\t\t\t\tif (state['htmx-log'] && typeof htmx !== 'undefined') { htmx.logAll(); }\n\t\t\t\tif (state['htmx-events'] && typeof htmx !== 'undefined') {\n\t\t\t\t\twindow._htmxDbg = function(e) {\n\t\t\t\t\t\tconsole.debug('%c[htmx:' + e.type.replace('htmx:','') + ']', 'color:#38bdf8;font-weight:bold', e.detail);\n\t\t\t\t\t};\n\t\t\t\t\tvar evts = ['htmx:beforeRequest','htmx:afterRequest','htmx:beforeSwap','htmx:afterSwap','htmx:oobErrorNoTarget','htmx:sseMessage','htmx:sseError'];\n\t\t\t\t\tevts.forEach(function(t) { document.body.addEventListener(t, window._htmxDbg); });\n\t\t\t\t\twindow._htmxDbgEvts = evts;\n\t\t\t\t}\n\t\t\t\tif (state['hs-beep']) {\n\t\t\t\t\twindow._hsDbg = function(e) { console.debug('%c[_hs:beep]', 'color:#a78bfa;font-weight:bold', e.detail); };\n\t\t\t\t\tdocument.body.addEventListener('hyperscript:beep', window._hsDbg);\n\t\t\t\t}\n\t\t\t\tif (state['alpine-events']) {\n\t\t\t\t\twindow._alpineDbg = function(e) { console.debug('%c[alpine:' + e.type + ']', 'color:#34d399;font-weight:bold', e.detail); };\n\t\t\t\t\tdocument.addEventListener('alpine:initialized', window._alpineDbg);\n\t\t\t\t\tdocument.addEventListener('alpine:init', window._alpineDbg);\n\t\t\t\t}\n\t\t\t});\n\t\t</script><script defer>\n\t\t\t/**\n\t\t\t * Listen for server-sent theme-change events and apply them to the\n\t\t\t * document so all open browsers stay in sync.\n\t\t\t * @listens theme-change\n\t\t\t */\n\t\t\t(function() {\n\t\t\t\t/** @type {EventSource} */\n\t\t\t\tvar es = new EventSource(\"/sse/theme\");\n\t\t\t\tes.addEventListener(\"theme-change\", function(/** @type {MessageEvent} */ e) {\n\t\t\t\t\tdocument.documentElement.dataset.theme = e.data;\n\t\t\t\t});\n\t\t\t})();\n\t\t</script><script>\n\t\t\tif ('serviceWorker' in navigator) {\n\t\t\t\tnavigator.serviceWorker.register('/sw.js').catch(function(err) {\n\t\t\t\t\tconsole.warn('ServiceWorker registration failed:', err);\n\t\t\t\t});\n\t\t\t}\n\t\t</script></head>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -282,12 +341,12 @@ func Layout(content templ.Component) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var11 == nil {
-			templ_7745c5c3_Var11 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div id=\"base-content\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div id=\"base-content\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -295,7 +354,7 @@ func Layout(content templ.Component) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -320,25 +379,25 @@ func ThemeChanged(theme string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var12 == nil {
-			templ_7745c5c3_Var12 = templ.NopComponent
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<span class=\"hidden\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<span class=\"hidden\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var13 string
-		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 170, Col: 29}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/index.templ`, Line: 174, Col: 29}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Ring() now takes a name as the first argument — used for UI grouping in the context bar
- LinkRelation has a Group field, emitted as `data-group` on `<link>` tags
- Context bar Alpine component groups links by ring name, shows group labels with dividers between groups
- Added complete demo link coverage:
  - **Data** ring: inventory, catalog, bulk, people, vendors
  - **Workflow** ring: kanban, approvals, feed
  - **Utility** ring: logging, canvas, settings, repository
  - **Dashboard** ring: inventory, people, kanban, approvals, vendors, feed
  - **Admin Ops** ring: health, error-traces, sessions, control panel, error-reports
  - **System** ring: system, config, health, error-traces
  - **Components** ring: components, components2, components3

## Test plan

- [ ] Visit `/demo/logging` — should show Utility group (Canvas, Settings, Repository)
- [ ] Visit `/demo/inventory` — should show Data group (Catalog, Bulk, People, Vendors) + Dashboard group
- [ ] Visit `/admin/health` — should show Admin Ops group + System group
- [ ] Groups display with labels and dividers between them