### PR TITLE
fix: reuse existing CI failure issue instead of creating duplicates

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -145,19 +145,37 @@ jobs:
     needs: [build-simulator]
     runs-on: ubuntu-latest
     steps:
-      - name: Create issue on pipeline failure
+      - name: Notify CI failure
         run: |
-          gh issue create \
-            --repo "${{ github.repository }}" \
-            --title "Pipeline failure: ${{ github.workflow }} (#${{ github.run_number }})" \
-            --label "ci" \
-            --body "$(cat <<EOF
-          **Workflow:** \`${{ github.workflow }}\`
+          BODY="**Workflow:** \`${{ github.workflow }}\`
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Branch:** \`${{ github.ref_name }}\`
           **Commit:** \`${{ github.sha }}\`
-          **Triggered by:** ${{ github.actor }}
-          EOF
-          )"
+          **Triggered by:** ${{ github.actor }}"
+
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "ci" \
+            --state all \
+            --limit 1 \
+            --json number,state \
+            --jq '.[0]')
+
+          if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "Pipeline failure: ${{ github.workflow }}" \
+              --label "ci" \
+              --body "$BODY"
+          else
+            NUMBER=$(echo "$EXISTING" | jq -r '.number')
+            STATE=$(echo "$EXISTING" | jq -r '.state')
+            if [ "$STATE" = "CLOSED" ]; then
+              gh issue reopen "$NUMBER" --repo "${{ github.repository }}"
+            fi
+            gh issue comment "$NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body "$BODY"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -359,19 +359,37 @@ jobs:
     needs: [update-deps, go-test, e2e-test, docs, screenshots, publish-screenshots, sync-harmony]
     runs-on: ubuntu-latest
     steps:
-      - name: Create issue on pipeline failure
+      - name: Notify CI failure
         run: |
-          gh issue create \
-            --repo "${{ github.repository }}" \
-            --title "Pipeline failure: ${{ github.workflow }} (#${{ github.run_number }})" \
-            --label "ci" \
-            --body "$(cat <<EOF
-          **Workflow:** \`${{ github.workflow }}\`
+          BODY="**Workflow:** \`${{ github.workflow }}\`
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Branch:** \`${{ github.ref_name }}\`
           **Commit:** \`${{ github.sha }}\`
-          **Triggered by:** ${{ github.actor }}
-          EOF
-          )"
+          **Triggered by:** ${{ github.actor }}"
+
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "ci" \
+            --state all \
+            --limit 1 \
+            --json number,state \
+            --jq '.[0]')
+
+          if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "Pipeline failure: ${{ github.workflow }}" \
+              --label "ci" \
+              --body "$BODY"
+          else
+            NUMBER=$(echo "$EXISTING" | jq -r '.number')
+            STATE=$(echo "$EXISTING" | jq -r '.state')
+            if [ "$STATE" = "CLOSED" ]; then
+              gh issue reopen "$NUMBER" --repo "${{ github.repository }}"
+            fi
+            gh issue comment "$NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body "$BODY"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,19 +223,37 @@ jobs:
     needs: [check, release, docker]
     runs-on: ubuntu-latest
     steps:
-      - name: Create issue on pipeline failure
+      - name: Notify CI failure
         run: |
-          gh issue create \
-            --repo "${{ github.repository }}" \
-            --title "Pipeline failure: ${{ github.workflow }} (#${{ github.run_number }})" \
-            --label "ci" \
-            --body "$(cat <<EOF
-          **Workflow:** \`${{ github.workflow }}\`
+          BODY="**Workflow:** \`${{ github.workflow }}\`
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Branch:** \`${{ github.ref_name }}\`
           **Commit:** \`${{ github.sha }}\`
-          **Triggered by:** ${{ github.actor }}
-          EOF
-          )"
+          **Triggered by:** ${{ github.actor }}"
+
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "ci" \
+            --state all \
+            --limit 1 \
+            --json number,state \
+            --jq '.[0]')
+
+          if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "Pipeline failure: ${{ github.workflow }}" \
+              --label "ci" \
+              --body "$BODY"
+          else
+            NUMBER=$(echo "$EXISTING" | jq -r '.number')
+            STATE=$(echo "$EXISTING" | jq -r '.state')
+            if [ "$STATE" = "CLOSED" ]; then
+              gh issue reopen "$NUMBER" --repo "${{ github.repository }}"
+            fi
+            gh issue comment "$NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body "$BODY"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Search for existing CI failure issue (label: ci) before creating a new one
- Reopen and comment on closed issues instead of creating duplicates
- Comment on open issues with new failure details

Closes #198