### PR TITLE
feat: add Vary header and CSS performance/typography enhancements

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -266,6 +266,13 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 	e.Use(middleware.LinkRelationsMiddleware())
 	// setup:feature:demo:end
 
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Response().Header().Set("Vary", "HX-Request")
+			return next(c)
+		}
+	})
+
 	static := e.Group("/public", func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			c.Response().Header().Set("Cache-Control", "public, max-age=31536000, immutable")

--- a/web/styles/input.css
+++ b/web/styles/input.css
@@ -42,6 +42,27 @@
   [role="button"]:not(:disabled) {
     cursor: pointer;
   }
+
+  /* Performance: skip rendering off-screen table rows and feed items */
+  tbody tr,
+  .feed-item {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 44px;
+  }
+
+  /* Typography: balanced headings, no orphan words in paragraphs */
+  h1, h2, h3 {
+    text-wrap: balance;
+  }
+
+  p {
+    text-wrap: pretty;
+  }
+
+  /* Theming: brand all native form controls */
+  :root {
+    accent-color: var(--color-primary);
+  }
 }
 
 @custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
## Summary

- **Vary: HX-Request header (#213):** Adds middleware in `InitEcho()` that sets `Vary: HX-Request` on every response, ensuring caches correctly distinguish full-page vs. HTMX partial responses.
- **CSS enhancements (#223):** Adds `content-visibility: auto` on table rows and feed items for off-screen rendering performance, `text-wrap: balance` on headings, `text-wrap: pretty` on paragraphs, and `accent-color` set to the DaisyUI primary color for native form controls.

Closes #213, closes #223

## Test plan

- [ ] Verify `Vary: HX-Request` header is present on responses (check with browser dev tools or curl)
- [ ] Verify table rows and feed items use `content-visibility: auto` in computed styles
- [ ] Verify headings use balanced text wrapping and paragraphs use pretty wrapping
- [ ] Verify native checkboxes/radios/range inputs use the primary theme color
- [ ] Run `go build ./...` — passes