### PR TITLE
feat: mobile form UX attributes and View Transitions CSS

### DIFF
--- a/web/components/core/filter.templ
+++ b/web/components/core/filter.templ
@@ -99,6 +99,7 @@ templ searchFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) 
 		<input
 			type="search"
 			autocomplete="off"
+			enterkeyhint="search"
 			name={ field.Name }
 			value={ field.Value }
 			placeholder={ field.Placeholder }

--- a/web/styles/input.css
+++ b/web/styles/input.css
@@ -45,3 +45,12 @@
 }
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* View Transitions: animated page navigation for hx-boost */
+@view-transition {
+    navigation: auto;
+}
+
+main {
+    view-transition-name: main-content;
+}

--- a/web/views/hypermedia_components.templ
+++ b/web/views/hypermedia_components.templ
@@ -107,7 +107,7 @@ templ ComponentsPage(data ComponentsPageData) {
 					hx-on::after-request="this.reset()"
 					class="flex gap-2 mt-2"
 				>
-					<input type="text" name="chat-msg" placeholder="Type a message…" class="input input-sm flex-1" autocomplete="off"/>
+					<input type="text" name="chat-msg" placeholder="Type a message…" class="input input-sm flex-1" autocomplete="off" enterkeyhint="send"/>
 					<button type="submit" class="btn btn-sm btn-primary">Send</button>
 				</form>
 			</div>

--- a/web/views/inventory.templ
+++ b/web/views/inventory.templ
@@ -168,10 +168,10 @@ templ InventoryEditRow(item demo.Item, isNew bool, saveURL, cancelURL string) {
 			</select>
 		</td>
 		<td>
-			<input type="number" name="price" step="0.01" class="input input-sm w-24" value={ fmt.Sprintf("%.2f", item.Price) }/>
+			<input type="number" name="price" step="0.01" class="input input-sm w-24" value={ fmt.Sprintf("%.2f", item.Price) } inputmode="decimal"/>
 		</td>
 		<td>
-			<input type="number" name="stock" class="input input-sm w-20" value={ strconv.Itoa(item.Stock) }/>
+			<input type="number" name="stock" class="input input-sm w-20" value={ strconv.Itoa(item.Stock) } inputmode="numeric"/>
 		</td>
 		<td>
 			<input type="checkbox" name="active" value="true" class="toggle toggle-sm" checked?={ item.Active }/>

--- a/web/views/people.templ
+++ b/web/views/people.templ
@@ -113,27 +113,27 @@ templ PersonEditForm(p demo.Person) {
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
 					<div>
 						<label class="label label-text text-xs">First Name</label>
-						<input type="text" name="first_name" class="input input-sm w-full" value={ p.FirstName }/>
+						<input type="text" name="first_name" class="input input-sm w-full" value={ p.FirstName } autocomplete="given-name"/>
 					</div>
 					<div>
 						<label class="label label-text text-xs">Last Name</label>
-						<input type="text" name="last_name" class="input input-sm w-full" value={ p.LastName }/>
+						<input type="text" name="last_name" class="input input-sm w-full" value={ p.LastName } autocomplete="family-name"/>
 					</div>
 					<div>
 						<label class="label label-text text-xs">Email</label>
-						<input type="email" name="email" class="input input-sm w-full" value={ p.Email }/>
+						<input type="email" name="email" class="input input-sm w-full" value={ p.Email } inputmode="email" autocomplete="email"/>
 					</div>
 					<div>
 						<label class="label label-text text-xs">Phone</label>
-						<input type="text" name="phone" class="input input-sm w-full" value={ p.Phone }/>
+						<input type="text" name="phone" class="input input-sm w-full" value={ p.Phone } inputmode="tel" autocomplete="tel"/>
 					</div>
 					<div>
 						<label class="label label-text text-xs">City</label>
-						<input type="text" name="city" class="input input-sm w-full" value={ p.City }/>
+						<input type="text" name="city" class="input input-sm w-full" value={ p.City } autocomplete="address-level2"/>
 					</div>
 					<div>
 						<label class="label label-text text-xs">State</label>
-						<input type="text" name="state" class="input input-sm w-full" value={ p.State }/>
+						<input type="text" name="state" class="input input-sm w-full" value={ p.State } autocomplete="address-level1"/>
 					</div>
 					<div>
 						<label class="label label-text text-xs">Department</label>

--- a/web/views/vendors_contacts.templ
+++ b/web/views/vendors_contacts.templ
@@ -112,7 +112,7 @@ templ ContactEditForm(c demo.Contact) {
 		<div class="grid grid-cols-2 gap-2">
 			<div>
 				<label class="label label-text text-xs">Name</label>
-				<input type="text" name="name" class="input input-xs w-full" value={ c.Name }/>
+				<input type="text" name="name" class="input input-xs w-full" value={ c.Name } autocomplete="name"/>
 			</div>
 			<div>
 				<label class="label label-text text-xs">Role</label>
@@ -120,11 +120,11 @@ templ ContactEditForm(c demo.Contact) {
 			</div>
 			<div>
 				<label class="label label-text text-xs">Email</label>
-				<input type="email" name="email" class="input input-xs w-full" value={ c.Email }/>
+				<input type="email" name="email" class="input input-xs w-full" value={ c.Email } inputmode="email" autocomplete="email"/>
 			</div>
 			<div>
 				<label class="label label-text text-xs">Phone</label>
-				<input type="text" name="phone" class="input input-xs w-full" value={ c.Phone }/>
+				<input type="text" name="phone" class="input input-xs w-full" value={ c.Phone } inputmode="tel" autocomplete="tel"/>
 			</div>
 		</div>
 		<div class="flex gap-2 mt-2">


### PR DESCRIPTION
## Summary
- Add `inputmode`, `enterkeyhint`, and `autocomplete` attributes to form inputs across people, vendor contacts, inventory, filter, and chat forms for improved mobile keyboard/autofill UX
- Add `@view-transition` CSS rule and `view-transition-name` on `main` for animated page navigation with hx-boost (htmx globalViewTransitions was already enabled)

Closes #224, closes #225

## Test plan
- [ ] Verify mobile keyboard shows correct layout for email, phone, numeric inputs
- [ ] Verify search inputs show "search" action key on mobile
- [ ] Verify chat input shows "send" action key on mobile
- [ ] Verify browser autofill suggestions appear for name, email, phone, city fields
- [ ] Verify page transitions animate smoothly on supported browsers