### PR TITLE
feat: add Server-Timing middleware for DevTools performance visibility

### DIFF
--- a/internal/routes/middleware/server_timing.go
+++ b/internal/routes/middleware/server_timing.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ServerTimingMiddleware measures request processing time and emits
+// a Server-Timing HTTP header visible in browser DevTools.
+func ServerTimingMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			start := time.Now()
+			err := next(c)
+			dur := time.Since(start).Milliseconds()
+			c.Response().Header().Set("Server-Timing",
+				fmt.Sprintf("total;dur=%d;desc=\"Total\"", dur))
+			return err
+		}
+	}
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -217,6 +217,7 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 ) (*echo.Echo, error) {
 	e := echo.New()
 
+	e.Use(middleware.ServerTimingMiddleware())
 	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
 	e.Use(echoMiddleware.RequestLogger())
 	e.Use(echoMiddleware.Recover())


### PR DESCRIPTION
## Summary

- Adds `ServerTimingMiddleware` that measures full request processing time and emits a `Server-Timing` HTTP header (`total;dur=<ms>;desc="Total"`)
- Registered as the first middleware in `InitEcho()` so it captures time spent in all subsequent middleware and handlers
- The header is visible in browser DevTools Network tab under the Timing section

Closes #214

## Test plan

- [ ] Run `go build ./...` — passes
- [ ] Make a request and verify the `Server-Timing` response header is present with a `total` metric
- [ ] Open browser DevTools → Network → select a request → Timing tab shows Server Timing section