### PR TITLE
feat: add navigator.sendBeacon for client logging

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,7 +106,7 @@ func buildConfig() (*AppConfig, error) {
 	// setup:feature:csrf:start
 	cfg.CSRFRotatePerRequest = envBool("CSRF_ROTATE_PER_REQUEST", false)
 	cfg.CSRFPerRequestPaths = envList("CSRF_PER_REQUEST_PATHS")
-	cfg.CSRFExemptPaths = []string{"/login", "/callback", "/logout", "/report-issue"}
+	cfg.CSRFExemptPaths = []string{"/login", "/callback", "/logout", "/report-issue", "/log/beacon"}
 	// setup:feature:csrf:end
 
 	// setup:feature:graph:start

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -23,6 +23,28 @@ import (
 const loggingBase = "/demo/logging"
 
 func (ar *appRoutes) initLoggingRoutes() {
+	// Client beacon endpoint — fire-and-forget analytics via navigator.sendBeacon.
+	ar.e.POST("/log/beacon", func(c echo.Context) error {
+		var entry struct {
+			Event     string         `json:"event"`
+			Path      string         `json:"path"`
+			Referrer  string         `json:"referrer"`
+			Timestamp string         `json:"timestamp"`
+			Data      map[string]any `json:"data"`
+		}
+		if err := c.Bind(&entry); err != nil {
+			return c.NoContent(http.StatusBadRequest)
+		}
+		logger.WithContext(c.Request().Context()).Info("Client beacon",
+			"event", entry.Event,
+			"path", entry.Path,
+			"referrer", entry.Referrer,
+			"client_timestamp", entry.Timestamp,
+			"data", entry.Data,
+		)
+		return c.NoContent(http.StatusNoContent)
+	})
+
 	// setup:feature:sse:start
 	broker := ssebroker.NewSSEBroker()
 

--- a/web/assets/public/js/beacon.js
+++ b/web/assets/public/js/beacon.js
@@ -1,0 +1,34 @@
+// setup:feature:demo
+/**
+ * Lightweight client analytics via navigator.sendBeacon.
+ * Logs page views and HTMX navigation events without blocking the user.
+ * Fire-and-forget — guaranteed to complete even during page unload.
+ */
+(function() {
+  var endpoint = '/log/beacon';
+
+  function send(event, data) {
+    var payload = JSON.stringify({
+      event: event,
+      path: window.location.pathname,
+      referrer: document.referrer || '',
+      timestamp: new Date().toISOString(),
+      data: data || {}
+    });
+    navigator.sendBeacon(endpoint, new Blob([payload], { type: 'application/json' }));
+  }
+
+  // Log initial page load
+  send('page_view');
+
+  // Log HTMX navigations (hx-boost page transitions)
+  document.body.addEventListener('htmx:pushedIntoHistory', function(e) {
+    send('navigation', { to: e.detail.path });
+  });
+
+  // Log page unload with time spent
+  var loadTime = Date.now();
+  window.addEventListener('pagehide', function() {
+    send('page_leave', { duration_ms: Date.now() - loadTime });
+  });
+})();

--- a/web/assets/public/js/sw.js
+++ b/web/assets/public/js/sw.js
@@ -41,6 +41,7 @@ const PRECACHE_URLS = [
   '/public/js/htmx.alpine-morph.js',
   '/public/js/context-bar.js',
   '/public/js/history-breadcrumbs.js',
+  '/public/js/beacon.js',
 ];
 
 self.addEventListener('install', (event) => {

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -80,6 +80,7 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 		<script defer src="/public/js/offline-indicator.js"></script>
 		// setup:feature:offline:end
 		// setup:feature:demo:start
+		<script defer src="/public/js/beacon.js"></script>
 		<script defer src="/public/js/history-breadcrumbs.js"></script>
 		// setup:feature:demo:end
 		<script defer src="/public/js/alpine.min.js"></script>


### PR DESCRIPTION
## Summary
- Add `beacon.js` — lightweight client analytics using `navigator.sendBeacon` for fire-and-forget page view, navigation, and page leave tracking
- Add `POST /log/beacon` endpoint in `routes_logging.go` that accepts JSON payloads and logs them via the structured logger
- Exempt `/log/beacon` from CSRF since `sendBeacon` cannot include CSRF tokens
- Add `beacon.js` to service worker precache list and `index.templ` head (inside demo feature gate)

Closes #218

## Test plan
- [ ] Verify `beacon.js` loads on page view (check Network tab for `/log/beacon` POST)
- [ ] Navigate between pages — confirm `navigation` events are sent
- [ ] Close/navigate away — confirm `page_leave` event fires with duration
- [ ] Check server logs for structured `Client beacon` entries
- [ ] Verify CSRF does not block the beacon POST
- [ ] Confirm `go build ./...` passes