### PR TITLE
feat: add BroadcastChannel for cross-tab theme sync

### DIFF
--- a/web/assets/public/js/broadcast.js
+++ b/web/assets/public/js/broadcast.js
@@ -1,0 +1,23 @@
+// setup:feature:demo
+/**
+ * BroadcastChannel for cross-tab synchronization.
+ * When one tab changes state (theme, auth), all other tabs update.
+ * No server round-trip needed for tab-to-tab communication.
+ */
+(function() {
+  if (!('BroadcastChannel' in window)) return;
+
+  var channel = new BroadcastChannel('dothog');
+
+  channel.onmessage = function(event) {
+    var msg = event.data;
+
+    // Theme sync: another tab changed the theme
+    if (msg.type === 'theme-change') {
+      document.documentElement.dataset.theme = msg.theme;
+    }
+  };
+
+  // Expose for other scripts to use
+  window.dothogChannel = channel;
+})();

--- a/web/assets/public/js/sw.js
+++ b/web/assets/public/js/sw.js
@@ -41,6 +41,7 @@ const PRECACHE_URLS = [
   '/public/js/htmx.alpine-morph.js',
   '/public/js/context-bar.js',
   '/public/js/history-breadcrumbs.js',
+  '/public/js/broadcast.js',
 ];
 
 self.addEventListener('install', (event) => {

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -80,6 +80,7 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 		<script defer src="/public/js/offline-indicator.js"></script>
 		// setup:feature:offline:end
 		// setup:feature:demo:start
+		<script defer src="/public/js/broadcast.js"></script>
 		<script defer src="/public/js/history-breadcrumbs.js"></script>
 		// setup:feature:demo:end
 		<script defer src="/public/js/alpine.min.js"></script>
@@ -146,6 +147,7 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 				var es = new EventSource("/sse/theme");
 				es.addEventListener("theme-change", function(/** @type {MessageEvent} */ e) {
 					document.documentElement.dataset.theme = e.data;
+					if (window.dothogChannel) window.dothogChannel.postMessage({ type: 'theme-change', theme: e.data });
 				});
 			})();
 		</script>

--- a/web/views/settings_app.templ
+++ b/web/views/settings_app.templ
@@ -98,7 +98,7 @@ templ themeDropdown(currentTheme string) {
 					data-theme={ theme }
 					class="btn btn-ghost btn-sm w-full justify-start gap-2 rounded-none"
 					popovertarget="theme-picker" popovertargetaction="hide"
-					x-on:click={ "current = '" + theme + "'; document.documentElement.dataset.theme = '" + theme + "'; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=" + theme + "' })" }
+					x-on:click={ "current = '" + theme + "'; document.documentElement.dataset.theme = '" + theme + "'; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=" + theme + "' }); if (window.dothogChannel) window.dothogChannel.postMessage({ type: 'theme-change', theme: '" + theme + "' })" }
 				>
 					<span class="flex gap-0.5">
 						<span class="w-2 h-4 rounded-sm bg-primary"></span>


### PR DESCRIPTION
## Summary

- Adds `broadcast.js` using `BroadcastChannel` API for cross-tab synchronization
- Theme picker in settings broadcasts theme changes to all open tabs instantly (no server round-trip)
- SSE theme-change listener also broadcasts to sibling tabs that may lack their own SSE connection
- New script added to service worker precache list

Closes #219