### PR TITLE
fix: context bars and history breadcrumbs dismiss persistence

### DIFF
--- a/web/assets/public/js/history-breadcrumbs.js
+++ b/web/assets/public/js/history-breadcrumbs.js
@@ -11,7 +11,6 @@ function historyBreadcrumbs() {
 
   return {
     trail: [],
-    hidden: localStorage.getItem('dothog_hide_history_crumbs') === 'true',
     init() {
       var history = JSON.parse(sessionStorage.getItem(KEY) || '[]');
       var current = window.location.pathname;
@@ -44,10 +43,6 @@ function historyBreadcrumbs() {
       }
 
       sessionStorage.setItem(KEY, JSON.stringify(history));
-    },
-    dismiss() {
-      this.hidden = true;
-      localStorage.setItem('dothog_hide_history_crumbs', 'true');
     }
   };
 }

--- a/web/components/core/context_bar.templ
+++ b/web/components/core/context_bar.templ
@@ -181,7 +181,9 @@ func hasItem(items []contextBarItem, href string) bool {
 // ContextBar renders a horizontal strip of related page links grouped by ring name.
 // Server-rendered with a stable ID so it can be updated via hx-swap-oob on navigation.
 templ ContextBar(links []hypermedia.LinkRelation, currentPath string) {
-	<div id="context-bar" x-data="{ hidden: localStorage.getItem('dothog_hide_context_bar') === 'true' }" x-show="!hidden" x-cloak>
+	<div id="context-bar"
+		_="init if localStorage.getItem('dothog_hide_context_bar') === 'true' then hide me"
+	>
 		if groups := contextBarGroups(links, currentPath); len(groups) > 0 {
 			<div class="relative border-b border-base-300">
 				<div class="flex items-center justify-center gap-3 overflow-x-auto px-8 py-1.5 bg-base-200/50 text-sm">
@@ -192,7 +194,10 @@ templ ContextBar(links []hypermedia.LinkRelation, currentPath string) {
 						}
 					}
 				</div>
-				<button @click="hidden = true; localStorage.setItem('dothog_hide_context_bar', 'true')" class="absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content">&#x2715;</button>
+				<button
+					_="on click set localStorage.dothog_hide_context_bar to 'true' then hide #context-bar"
+					class="absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content"
+				>&#x2715;</button>
 			</div>
 		}
 	</div>
@@ -201,7 +206,9 @@ templ ContextBar(links []hypermedia.LinkRelation, currentPath string) {
 // LocalContextBar renders a compact strip of the current page's immediate
 // ring siblings — the pages in the same ring group(s) as the current page.
 templ LocalContextBar(links []hypermedia.LinkRelation, currentPath string) {
-	<div id="local-context-bar" x-data="{ hidden: localStorage.getItem('dothog_hide_local_context_bar') === 'true' }" x-show="!hidden" x-cloak>
+	<div id="local-context-bar"
+		_="init if localStorage.getItem('dothog_hide_local_context_bar') === 'true' then hide me"
+	>
 		if groups := localGroups(links, currentPath); len(groups) > 0 {
 			<div class="relative border-b border-base-300">
 				<div class="flex items-center justify-center gap-3 overflow-x-auto px-8 py-1 bg-base-100/50 text-xs">
@@ -221,7 +228,10 @@ templ LocalContextBar(links []hypermedia.LinkRelation, currentPath string) {
 						}
 					}
 				</div>
-				<button @click="hidden = true; localStorage.setItem('dothog_hide_local_context_bar', 'true')" class="absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content">&#x2715;</button>
+				<button
+					_="on click set localStorage.dothog_hide_local_context_bar to 'true' then hide #local-context-bar"
+					class="absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content"
+				>&#x2715;</button>
 			</div>
 		}
 	</div>
@@ -278,8 +288,9 @@ func localGroups(links []hypermedia.LinkRelation, currentPath string) []contextB
 templ HistoryBreadcrumbs() {
 	<div id="history-breadcrumbs"
 		x-data="historyBreadcrumbs()"
-		x-show="!hidden && trail.length > 0"
+		x-show="trail.length > 0"
 		x-cloak
+		_="init if localStorage.getItem('dothog_hide_history_crumbs') === 'true' then hide me"
 	>
 		<div class="relative border-b border-base-300">
 			<div class="flex items-center gap-2 overflow-x-auto px-8 py-1 bg-base-100/30 text-xs">
@@ -294,7 +305,10 @@ templ HistoryBreadcrumbs() {
 				</template>
 				<span class="text-base-content/60 font-medium whitespace-nowrap" x-text="(document.querySelector('meta[name=page-title]') || {}).content || titleFromPath(window.location.pathname)"></span>
 			</div>
-			<button @click="dismiss()" class="absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content">&#x2715;</button>
+			<button
+				_="on click set localStorage.dothog_hide_history_crumbs to 'true' then hide #history-breadcrumbs"
+				class="absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content"
+			>&#x2715;</button>
 		</div>
 	</div>
 }

--- a/web/components/core/context_bar_templ.go
+++ b/web/components/core/context_bar_templ.go
@@ -209,7 +209,7 @@ func ContextBar(links []hypermedia.LinkRelation, currentPath string) templ.Compo
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"context-bar\" x-data=\"{ hidden: localStorage.getItem('dothog_hide_context_bar') === 'true' }\" x-show=\"!hidden\" x-cloak>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"context-bar\" _=\"init if localStorage.getItem('dothog_hide_context_bar') === 'true' then hide me\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -234,7 +234,7 @@ func ContextBar(links []hypermedia.LinkRelation, currentPath string) templ.Compo
 					}
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><button @click=\"hidden = true; localStorage.setItem('dothog_hide_context_bar', 'true')\" class=\"absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content\">&#x2715;</button></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><button _=\"on click set localStorage.dothog_hide_context_bar to 'true' then hide #context-bar\" class=\"absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content\">&#x2715;</button></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -270,7 +270,7 @@ func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"local-context-bar\" x-data=\"{ hidden: localStorage.getItem('dothog_hide_local_context_bar') === 'true' }\" x-show=\"!hidden\" x-cloak>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"local-context-bar\" _=\"init if localStorage.getItem('dothog_hide_local_context_bar') === 'true' then hide me\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -288,7 +288,7 @@ func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.
 					var templ_7745c5c3_Var3 string
 					templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(group.Name)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 210, Col: 84}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 217, Col: 84}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 					if templ_7745c5c3_Err != nil {
@@ -308,7 +308,7 @@ func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.
 						var templ_7745c5c3_Var4 templ.SafeURL
 						templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 214, Col: 38}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 221, Col: 38}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 						if templ_7745c5c3_Err != nil {
@@ -321,7 +321,7 @@ func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.
 						var templ_7745c5c3_Var5 string
 						templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(item.Title)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 214, Col: 144}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 221, Col: 144}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 						if templ_7745c5c3_Err != nil {
@@ -339,7 +339,7 @@ func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.
 						var templ_7745c5c3_Var6 templ.SafeURL
 						templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 216, Col: 38}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 223, Col: 38}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 						if templ_7745c5c3_Err != nil {
@@ -352,7 +352,7 @@ func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.
 						var templ_7745c5c3_Var7 string
 						templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(item.Title)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 216, Col: 140}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 223, Col: 140}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 						if templ_7745c5c3_Err != nil {
@@ -375,7 +375,7 @@ func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.
 					}
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><button @click=\"hidden = true; localStorage.setItem('dothog_hide_local_context_bar', 'true')\" class=\"absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content\">&#x2715;</button></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><button _=\"on click set localStorage.dothog_hide_local_context_bar to 'true' then hide #local-context-bar\" class=\"absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content\">&#x2715;</button></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -457,7 +457,7 @@ func HistoryBreadcrumbs() templ.Component {
 			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div id=\"history-breadcrumbs\" x-data=\"historyBreadcrumbs()\" x-show=\"!hidden && trail.length > 0\" x-cloak><div class=\"relative border-b border-base-300\"><div class=\"flex items-center gap-2 overflow-x-auto px-8 py-1 bg-base-100/30 text-xs\"><template x-for=\"(item, idx) in trail\" :key=\"item.path\"><div class=\"flex items-center gap-2\"><a :href=\"item.path\" x-text=\"item.title\" class=\"link link-hover text-base-content/40 hover:text-base-content whitespace-nowrap\"></a> <span class=\"text-base-content/20\">›</span></div></template><span class=\"text-base-content/60 font-medium whitespace-nowrap\" x-text=\"(document.querySelector('meta[name=page-title]') || {}).content || titleFromPath(window.location.pathname)\"></span></div><button @click=\"dismiss()\" class=\"absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content\">&#x2715;</button></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div id=\"history-breadcrumbs\" x-data=\"historyBreadcrumbs()\" x-show=\"trail.length > 0\" x-cloak _=\"init if localStorage.getItem('dothog_hide_history_crumbs') === 'true' then hide me\"><div class=\"relative border-b border-base-300\"><div class=\"flex items-center gap-2 overflow-x-auto px-8 py-1 bg-base-100/30 text-xs\"><template x-for=\"(item, idx) in trail\" :key=\"item.path\"><div class=\"flex items-center gap-2\"><a :href=\"item.path\" x-text=\"item.title\" class=\"link link-hover text-base-content/40 hover:text-base-content whitespace-nowrap\"></a> <span class=\"text-base-content/20\">›</span></div></template><span class=\"text-base-content/60 font-medium whitespace-nowrap\" x-text=\"(document.querySelector('meta[name=page-title]') || {}).content || titleFromPath(window.location.pathname)\"></span></div><button _=\"on click set localStorage.dothog_hide_history_crumbs to 'true' then hide #history-breadcrumbs\" class=\"absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs text-base-content/30 hover:text-base-content\">&#x2715;</button></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -494,7 +494,7 @@ func contextBarGroupItems(group contextBarGroup) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(group.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 304, Col: 87}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 318, Col: 87}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -514,7 +514,7 @@ func contextBarGroupItems(group contextBarGroup) templ.Component {
 				var templ_7745c5c3_Var11 templ.SafeURL
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 308, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 322, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -527,7 +527,7 @@ func contextBarGroupItems(group contextBarGroup) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(item.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 308, Col: 139}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 322, Col: 139}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -545,7 +545,7 @@ func contextBarGroupItems(group contextBarGroup) templ.Component {
 				var templ_7745c5c3_Var13 templ.SafeURL
 				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 310, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 324, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
@@ -558,7 +558,7 @@ func contextBarGroupItems(group contextBarGroup) templ.Component {
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(item.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 310, Col: 135}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context_bar.templ`, Line: 324, Col: 135}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {

--- a/web/views/settings_app.templ
+++ b/web/views/settings_app.templ
@@ -16,24 +16,48 @@ templ AppSettingsPage(currentTheme string, links []hypermedia.LinkRelation) {
 			</div>
 		</div>
 		<div class="card bg-base-100 shadow-sm border border-base-300">
-			<div class="card-body" x-data="{ showFull: localStorage.getItem('dothog_hide_context_bar') !== 'true', showLocal: localStorage.getItem('dothog_hide_local_context_bar') !== 'true', showHistory: localStorage.getItem('dothog_hide_history_crumbs') !== 'true' }">
+			<div class="card-body">
 				<details open>
 					<summary class="font-semibold text-lg cursor-pointer">Context Bars</summary>
 					<p class="text-sm text-base-content/70 mt-1">Toggle visibility of the navigation context bars.</p>
 					<div class="mt-2 space-y-2">
 						<label class="label cursor-pointer justify-start gap-3">
-							<input type="checkbox" class="toggle toggle-sm toggle-primary" x-model="showFull"
-								@change="localStorage.setItem('dothog_hide_context_bar', !showFull ? 'true' : 'false')"/>
+							<input type="checkbox" class="toggle toggle-sm toggle-primary"
+								_="init set my.checked to localStorage.getItem('dothog_hide_context_bar') !== 'true'
+								   on change
+								     if my.checked
+								       set localStorage.dothog_hide_context_bar to 'false'
+								       show #context-bar
+								     else
+								       set localStorage.dothog_hide_context_bar to 'true'
+								       hide #context-bar
+								     end"/>
 							<span class="label-text">Show full context bar</span>
 						</label>
 						<label class="label cursor-pointer justify-start gap-3">
-							<input type="checkbox" class="toggle toggle-sm toggle-primary" x-model="showLocal"
-								@change="localStorage.setItem('dothog_hide_local_context_bar', !showLocal ? 'true' : 'false')"/>
+							<input type="checkbox" class="toggle toggle-sm toggle-primary"
+								_="init set my.checked to localStorage.getItem('dothog_hide_local_context_bar') !== 'true'
+								   on change
+								     if my.checked
+								       set localStorage.dothog_hide_local_context_bar to 'false'
+								       show #local-context-bar
+								     else
+								       set localStorage.dothog_hide_local_context_bar to 'true'
+								       hide #local-context-bar
+								     end"/>
 							<span class="label-text">Show local context bar</span>
 						</label>
 						<label class="label cursor-pointer justify-start gap-3">
-							<input type="checkbox" class="toggle toggle-sm toggle-primary" x-model="showHistory"
-								@change="localStorage.setItem('dothog_hide_history_crumbs', !showHistory ? 'true' : 'false')"/>
+							<input type="checkbox" class="toggle toggle-sm toggle-primary"
+								_="init set my.checked to localStorage.getItem('dothog_hide_history_crumbs') !== 'true'
+								   on change
+								     if my.checked
+								       set localStorage.dothog_hide_history_crumbs to 'false'
+								       show #history-breadcrumbs
+								     else
+								       set localStorage.dothog_hide_history_crumbs to 'true'
+								       hide #history-breadcrumbs
+								     end"/>
 							<span class="label-text">Show history breadcrumbs</span>
 						</label>
 					</div>

--- a/web/views/settings_app_templ.go
+++ b/web/views/settings_app_templ.go
@@ -40,7 +40,7 @@ func AppSettingsPage(currentTheme string, links []hypermedia.LinkRelation) templ
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div></div><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\" x-data=\"{ showFull: localStorage.getItem('dothog_hide_context_bar') !== 'true', showLocal: localStorage.getItem('dothog_hide_local_context_bar') !== 'true', showHistory: localStorage.getItem('dothog_hide_history_crumbs') !== 'true' }\"><details open><summary class=\"font-semibold text-lg cursor-pointer\">Context Bars</summary><p class=\"text-sm text-base-content/70 mt-1\">Toggle visibility of the navigation context bars.</p><div class=\"mt-2 space-y-2\"><label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" class=\"toggle toggle-sm toggle-primary\" x-model=\"showFull\" @change=\"localStorage.setItem('dothog_hide_context_bar', !showFull ? 'true' : 'false')\"> <span class=\"label-text\">Show full context bar</span></label> <label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" class=\"toggle toggle-sm toggle-primary\" x-model=\"showLocal\" @change=\"localStorage.setItem('dothog_hide_local_context_bar', !showLocal ? 'true' : 'false')\"> <span class=\"label-text\">Show local context bar</span></label> <label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" class=\"toggle toggle-sm toggle-primary\" x-model=\"showHistory\" @change=\"localStorage.setItem('dothog_hide_history_crumbs', !showHistory ? 'true' : 'false')\"> <span class=\"label-text\">Show history breadcrumbs</span></label></div></details></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div></div><div class=\"card bg-base-100 shadow-sm border border-base-300\"><div class=\"card-body\"><details open><summary class=\"font-semibold text-lg cursor-pointer\">Context Bars</summary><p class=\"text-sm text-base-content/70 mt-1\">Toggle visibility of the navigation context bars.</p><div class=\"mt-2 space-y-2\"><label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" class=\"toggle toggle-sm toggle-primary\" _=\"init set my.checked to localStorage.getItem('dothog_hide_context_bar') !== 'true'\n\t\t\t\t\t\t\t\t   on change\n\t\t\t\t\t\t\t\t     if my.checked\n\t\t\t\t\t\t\t\t       set localStorage.dothog_hide_context_bar to 'false'\n\t\t\t\t\t\t\t\t       show #context-bar\n\t\t\t\t\t\t\t\t     else\n\t\t\t\t\t\t\t\t       set localStorage.dothog_hide_context_bar to 'true'\n\t\t\t\t\t\t\t\t       hide #context-bar\n\t\t\t\t\t\t\t\t     end\"> <span class=\"label-text\">Show full context bar</span></label> <label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" class=\"toggle toggle-sm toggle-primary\" _=\"init set my.checked to localStorage.getItem('dothog_hide_local_context_bar') !== 'true'\n\t\t\t\t\t\t\t\t   on change\n\t\t\t\t\t\t\t\t     if my.checked\n\t\t\t\t\t\t\t\t       set localStorage.dothog_hide_local_context_bar to 'false'\n\t\t\t\t\t\t\t\t       show #local-context-bar\n\t\t\t\t\t\t\t\t     else\n\t\t\t\t\t\t\t\t       set localStorage.dothog_hide_local_context_bar to 'true'\n\t\t\t\t\t\t\t\t       hide #local-context-bar\n\t\t\t\t\t\t\t\t     end\"> <span class=\"label-text\">Show local context bar</span></label> <label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" class=\"toggle toggle-sm toggle-primary\" _=\"init set my.checked to localStorage.getItem('dothog_hide_history_crumbs') !== 'true'\n\t\t\t\t\t\t\t\t   on change\n\t\t\t\t\t\t\t\t     if my.checked\n\t\t\t\t\t\t\t\t       set localStorage.dothog_hide_history_crumbs to 'false'\n\t\t\t\t\t\t\t\t       show #history-breadcrumbs\n\t\t\t\t\t\t\t\t     else\n\t\t\t\t\t\t\t\t       set localStorage.dothog_hide_history_crumbs to 'true'\n\t\t\t\t\t\t\t\t       hide #history-breadcrumbs\n\t\t\t\t\t\t\t\t     end\"> <span class=\"label-text\">Show history breadcrumbs</span></label></div></details></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -58,7 +58,7 @@ func AppSettingsPage(currentTheme string, links []hypermedia.LinkRelation) templ
 					var templ_7745c5c3_Var2 templ.SafeURL
 					templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(link.Href))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 52, Col: 40}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 76, Col: 40}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 					if templ_7745c5c3_Err != nil {
@@ -76,7 +76,7 @@ func AppSettingsPage(currentTheme string, links []hypermedia.LinkRelation) templ
 						var templ_7745c5c3_Var3 string
 						templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(link.Title)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 54, Col: 28}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 78, Col: 28}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 						if templ_7745c5c3_Err != nil {
@@ -86,7 +86,7 @@ func AppSettingsPage(currentTheme string, links []hypermedia.LinkRelation) templ
 						var templ_7745c5c3_Var4 string
 						templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(link.Title)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 56, Col: 24}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 80, Col: 24}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 						if templ_7745c5c3_Err != nil {
@@ -141,7 +141,7 @@ func themeDropdown(currentTheme string) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs("{ current: '" + currentTheme + "' }")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 72, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 96, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -154,7 +154,7 @@ func themeDropdown(currentTheme string) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs("document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.dothogChannel) window.dothogChannel.postMessage({type:'theme-change',theme:current})")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 82, Col: 398}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 106, Col: 398}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -172,7 +172,7 @@ func themeDropdown(currentTheme string) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 86, Col: 19}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 110, Col: 19}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -195,7 +195,7 @@ func themeDropdown(currentTheme string) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 89, Col: 13}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 113, Col: 13}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Replace Alpine.js `x-data`/`x-show`/`x-cloak` dismiss logic with `_hyperscript` `init`/`on click` handlers on ContextBar, LocalContextBar, and HistoryBreadcrumbs
- Replace Alpine-based settings toggles with `_hyperscript` for reading/writing localStorage and showing/hiding bars
- Remove `hidden` property and `dismiss()` method from `historyBreadcrumbs()` Alpine component (Alpine retained only for `x-for`/`x-text` rendering)

The root cause: on `hx-boost` navigation HTMX swaps the `<body>`, destroying and recreating Alpine components. Alpine re-initialization has a timing gap where `x-cloak` may not suppress the flash. `_hyperscript` `init` runs immediately on DOM insertion, so the dismiss state from localStorage is applied without flicker.

Closes #236