### PR TITLE
feat: add inline relationship editor on links demo page

### DIFF
--- a/internal/demo/db.go
+++ b/internal/demo/db.go
@@ -190,6 +190,9 @@ func (d *DB) initSchema() error {
 	if err := d.initErrorReports(); err != nil {
 		return fmt.Errorf("init error_reports: %w", err)
 	}
+	if err := d.initLinkRelations(); err != nil {
+		return fmt.Errorf("init link_relations: %w", err)
+	}
 	return nil
 }
 

--- a/internal/demo/link_relations.go
+++ b/internal/demo/link_relations.go
@@ -1,0 +1,98 @@
+// setup:feature:demo
+package demo
+
+import "fmt"
+
+// StoredLinkRelation represents an admin-created link relation persisted in SQLite.
+type StoredLinkRelation struct {
+	ID        int
+	Source    string
+	Rel       string
+	Target    string
+	Title     string
+	GroupName string
+	CreatedAt string
+}
+
+func (d *DB) initLinkRelations() error {
+	_, err := d.db.Exec(`
+		CREATE TABLE IF NOT EXISTS link_relations (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			source     TEXT NOT NULL,
+			rel        TEXT NOT NULL DEFAULT 'related',
+			target     TEXT NOT NULL,
+			title      TEXT NOT NULL,
+			group_name TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			UNIQUE(source, rel, target)
+		)
+	`)
+	return err
+}
+
+// ListStoredLinks returns all admin-created link relations.
+func (d *DB) ListStoredLinks() ([]StoredLinkRelation, error) {
+	rows, err := d.db.Query(
+		"SELECT id, source, rel, target, title, group_name, created_at FROM link_relations ORDER BY source, rel, target")
+	if err != nil {
+		return nil, fmt.Errorf("list stored links: %w", err)
+	}
+	defer rows.Close()
+
+	var links []StoredLinkRelation
+	for rows.Next() {
+		var l StoredLinkRelation
+		if err := rows.Scan(&l.ID, &l.Source, &l.Rel, &l.Target, &l.Title, &l.GroupName, &l.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan stored link: %w", err)
+		}
+		links = append(links, l)
+	}
+	return links, rows.Err()
+}
+
+// InsertLink creates a new admin link relation.
+func (d *DB) InsertLink(source, rel, target, title, groupName string) error {
+	_, err := d.db.Exec(
+		"INSERT INTO link_relations (source, rel, target, title, group_name) VALUES (?, ?, ?, ?, ?)",
+		source, rel, target, title, groupName)
+	if err != nil {
+		return fmt.Errorf("insert link: %w", err)
+	}
+	return nil
+}
+
+// DeleteLink removes an admin-created link relation by ID.
+func (d *DB) DeleteLink(id int) error {
+	res, err := d.db.Exec("DELETE FROM link_relations WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("delete link %d: %w", id, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("delete link %d: no rows affected", id)
+	}
+	return nil
+}
+
+// StoredLinkIDs returns the set of (source, rel, target) tuples that are admin-created,
+// keyed for quick lookup.
+func (d *DB) StoredLinkIDs() (map[int]bool, error) {
+	rows, err := d.db.Query("SELECT id FROM link_relations")
+	if err != nil {
+		return nil, fmt.Errorf("stored link ids: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make(map[int]bool)
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids[id] = true
+	}
+	return ids, rows.Err()
+}

--- a/internal/routes/hypermedia/links.go
+++ b/internal/routes/hypermedia/links.go
@@ -280,6 +280,34 @@ func BreadcrumbsFromLinks(path string) []Breadcrumb {
 	return crumbs
 }
 
+// LoadStoredLink adds a single link relation from an external source (e.g., database)
+// into the in-memory registry. Skips duplicates.
+func LoadStoredLink(source string, r LinkRelation) {
+	linksMu.Lock()
+	defer linksMu.Unlock()
+	if !hasLink(linksMap[source], r.Href, r.Rel) {
+		linksMap[source] = append(linksMap[source], r)
+	}
+}
+
+// RemoveLink removes a link relation matching source, href, and rel from the
+// in-memory registry. Returns true if a link was removed.
+func RemoveLink(source, href, rel string) bool {
+	linksMu.Lock()
+	defer linksMu.Unlock()
+	links := linksMap[source]
+	for i, l := range links {
+		if l.Href == href && l.Rel == rel {
+			linksMap[source] = append(links[:i], links[i+1:]...)
+			if len(linksMap[source]) == 0 {
+				delete(linksMap, source)
+			}
+			return true
+		}
+	}
+	return false
+}
+
 // TitleFromPath extracts a title from the last segment of a URL path.
 // "/demo/inventory" -> "Inventory", "/admin/error-traces" -> "Error Traces"
 func TitleFromPath(path string) string {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -169,6 +169,16 @@ func (ar *appRoutes) InitRoutes() error {
 	ar.versionChecker = NewSQLVersionChecker(db.RawDB())
 	// setup:feature:sync:end
 	ar.demoDB = db
+	if stored, err := db.ListStoredLinks(); err == nil {
+		for _, s := range stored {
+			hypermedia.LoadStoredLink(s.Source, hypermedia.LinkRelation{
+				Rel:   s.Rel,
+				Href:  s.Target,
+				Title: s.Title,
+				Group: s.GroupName,
+			})
+		}
+	}
 	ar.initInventoryRoutes(db)
 	ar.initCatalogRoutes(db)
 	ar.initBulkRoutes(db)

--- a/internal/routes/routes_hypermedia.go
+++ b/internal/routes/routes_hypermedia.go
@@ -4,10 +4,14 @@ package routes
 
 import (
 	"fmt"
+	"net/http"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 
+	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/routes/hypermedia"
 	"catgoose/dothog/web/views"
@@ -48,10 +52,9 @@ func newHypermediaState() *hypermediaState {
 
 func (ar *appRoutes) initHypermediaRoutes() {
 	// Links demo page
-	ar.e.GET(hypermediaBase+"/links", func(c echo.Context) error {
-		links := hypermedia.AllLinks()
-		return handler.RenderBaseLayout(c, views.HypermediaLinksPage(links))
-	})
+	ar.e.GET(hypermediaBase+"/links", ar.handleLinksPage)
+	ar.e.POST(hypermediaBase+"/links", ar.handleLinksCreate)
+	ar.e.DELETE(hypermediaBase+"/links/:id", ar.handleLinksDelete)
 
 	s := newHypermediaState()
 
@@ -371,4 +374,98 @@ func crudItemsToView(items []crudItem) []views.CRUDViewItem {
 
 func (ar *appRoutes) incrementPollCount() int64 {
 	return atomic.AddInt64(&ar.pollCount, 1)
+}
+
+// ─── Links editor handlers ───────────────────────────────────────────────────
+
+func (ar *appRoutes) buildLinksPageData(c echo.Context) views.LinksPageData {
+	data := views.LinksPageData{
+		Links:  hypermedia.AllLinks(),
+		Routes: getRoutesList(c),
+	}
+	if ar.demoDB != nil {
+		stored, _ := ar.demoDB.ListStoredLinks()
+		data.StoredLinks = stored
+	}
+	return data
+}
+
+func (ar *appRoutes) handleLinksPage(c echo.Context) error {
+	return handler.RenderBaseLayout(c, views.HypermediaLinksPage(ar.buildLinksPageData(c)))
+}
+
+func (ar *appRoutes) handleLinksCreate(c echo.Context) error {
+	if ar.demoDB == nil {
+		return handler.HandleHypermediaError(c, http.StatusServiceUnavailable, "Demo DB not available", nil)
+	}
+	source := strings.TrimSpace(c.FormValue("source"))
+	rel := strings.TrimSpace(c.FormValue("rel"))
+	target := strings.TrimSpace(c.FormValue("target"))
+	title := strings.TrimSpace(c.FormValue("title"))
+	groupName := strings.TrimSpace(c.FormValue("group"))
+
+	if source == "" || target == "" || title == "" {
+		return handler.HandleHypermediaError(c, http.StatusBadRequest, "Source, target, and title are required", nil)
+	}
+	if rel == "" {
+		rel = "related"
+	}
+
+	if err := ar.demoDB.InsertLink(source, rel, target, title, groupName); err != nil {
+		return handler.HandleHypermediaError(c, http.StatusConflict, "Link already exists or insert failed", err)
+	}
+
+	hypermedia.LoadStoredLink(source, hypermedia.LinkRelation{
+		Rel:   rel,
+		Href:  target,
+		Title: title,
+		Group: groupName,
+	})
+
+	return handler.RenderComponent(c, views.LinksRegistryTable(ar.buildLinksPageData(c)))
+}
+
+func (ar *appRoutes) handleLinksDelete(c echo.Context) error {
+	if ar.demoDB == nil {
+		return handler.HandleHypermediaError(c, http.StatusServiceUnavailable, "Demo DB not available", nil)
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil || id < 1 {
+		return handler.HandleHypermediaError(c, http.StatusBadRequest, "Invalid link ID", fmt.Errorf("id=%q", c.Param("id")))
+	}
+
+	// Look up the link before deleting so we can remove it from the in-memory registry.
+	stored, err := ar.demoDB.ListStoredLinks()
+	if err != nil {
+		return handler.HandleHypermediaError(c, http.StatusInternalServerError, "Failed to list links", err)
+	}
+	var found *demo.StoredLinkRelation
+	for _, s := range stored {
+		if s.ID == id {
+			found = &s
+			break
+		}
+	}
+
+	if err := ar.demoDB.DeleteLink(id); err != nil {
+		return handler.HandleHypermediaError(c, http.StatusNotFound, "Link not found", err)
+	}
+
+	if found != nil {
+		hypermedia.RemoveLink(found.Source, found.Target, found.Rel)
+	}
+
+	return handler.RenderComponent(c, views.LinksRegistryTable(ar.buildLinksPageData(c)))
+}
+
+// getRoutesList returns sorted GET routes suitable for the datalist autocomplete.
+func getRoutesList(c echo.Context) []string {
+	var routes []string
+	for _, r := range c.Echo().Routes() {
+		if r.Method == http.MethodGet && r.Path != "" && r.Path != "/*" && !strings.Contains(r.Path, ":") {
+			routes = append(routes, r.Path)
+		}
+	}
+	sort.Strings(routes)
+	return routes
 }

--- a/web/views/hypermedia_links.go
+++ b/web/views/hypermedia_links.go
@@ -4,6 +4,7 @@ package views
 import (
 	"fmt"
 
+	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/hypermedia"
 )
 
@@ -21,6 +22,22 @@ func linksCount(links map[string][]hypermedia.LinkRelation) string {
 
 func pathsCount(links map[string][]hypermedia.LinkRelation) string {
 	return fmt.Sprintf("%d", len(links))
+}
+
+// storedLinkID returns the DB ID of a stored link matching source/rel/target,
+// or 0 if the link is code-declared (not in the DB).
+func storedLinkID(stored []demo.StoredLinkRelation, source, rel, target string) int {
+	for _, s := range stored {
+		if s.Source == source && s.Rel == rel && s.Target == target {
+			return s.ID
+		}
+	}
+	return 0
+}
+
+// linkDeleteURL returns the HTMX delete endpoint for a stored link.
+func linkDeleteURL(id int) string {
+	return fmt.Sprintf("/hypermedia/links/%d", id)
 }
 
 func codeLinkExample() string {

--- a/web/views/hypermedia_links.templ
+++ b/web/views/hypermedia_links.templ
@@ -1,9 +1,19 @@
 // setup:feature:demo
 package views
 
-import "catgoose/dothog/internal/routes/hypermedia"
+import (
+	"catgoose/dothog/internal/demo"
+	"catgoose/dothog/internal/routes/hypermedia"
+)
 
-templ HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) {
+// LinksPageData holds all data needed to render the links page.
+type LinksPageData struct {
+	Links       map[string][]hypermedia.LinkRelation
+	StoredLinks []demo.StoredLinkRelation
+	Routes      []string
+}
+
+templ HypermediaLinksPage(data LinksPageData) {
 	<div class="p-4 space-y-6 max-w-5xl mx-auto">
 		<div class="flex items-center justify-between mb-4">
 			<h1 class="text-2xl font-bold">Link Relations</h1>
@@ -58,45 +68,114 @@ templ HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) {
 			</p>
 			<pre class="bg-base-200 rounded-lg p-3 text-xs overflow-x-auto"><code>{ codeDedupExample() }</code></pre>
 		}
-		@linksSection("6. Live Registry") {
+		@linksSection("6. Relationship Editor") {
+			<p class="text-sm text-base-content/70 mb-3">
+				Add custom link relations between routes. Admin-created links are persisted in SQLite and loaded into the in-memory registry on startup.
+			</p>
+			@linksEditorForm(data.Routes)
+		}
+		@linksSection("7. Live Registry") {
 			<p class="text-sm text-base-content/70 mb-3">
 				All link relations currently registered in this running application, via
 				<code class="text-xs bg-base-200 px-1 rounded">hypermedia.AllLinks()</code>.
 			</p>
-			<div class="overflow-x-auto">
-				<table class="table table-xs">
-					<thead>
-						<tr>
-							<th>Source</th>
-							<th>Rel</th>
-							<th>Target</th>
-							<th>Title</th>
-						</tr>
-					</thead>
-					<tbody>
-						for _, src := range hypermedia.SortedPaths(links) {
-							for i, link := range links[src] {
-								<tr class={ templ.KV("border-t border-base-300", i == 0) }>
-									if i == 0 {
-										<td class="font-mono text-xs align-top" rowspan={ linksRowspan(links[src]) }>{ src }</td>
-									}
-									<td class="text-xs">
-										<span class="badge badge-sm badge-outline">{ link.Rel }</span>
-									</td>
-									<td class="font-mono text-xs">
-										<a href={ templ.URL(link.Href) } class="link link-hover link-primary">{ link.Href }</a>
-									</td>
-									<td class="text-xs">{ link.Title }</td>
-								</tr>
-							}
-						}
-					</tbody>
-				</table>
-			</div>
-			<div class="mt-2 text-xs text-base-content/50">
-				{ linksCount(links) } total directed links across { pathsCount(links) } source paths.
-			</div>
+			@LinksRegistryTable(data)
 		}
+	</div>
+}
+
+templ linksEditorForm(routes []string) {
+	<form
+		hx-post="/hypermedia/links"
+		hx-target="#links-table"
+		hx-swap="outerHTML"
+		class="flex flex-wrap items-end gap-2"
+	>
+		<div class="form-control">
+			<label class="label py-0"><span class="label-text text-xs">Source</span></label>
+			<input name="source" list="link-routes" placeholder="/demo/inventory" required class="input input-bordered input-sm w-44"/>
+		</div>
+		<div class="form-control">
+			<label class="label py-0"><span class="label-text text-xs">Rel</span></label>
+			<select name="rel" class="select select-bordered select-sm w-32">
+				<option value="related">related</option>
+				<option value="up">up</option>
+				<option value="create-form">create-form</option>
+			</select>
+		</div>
+		<div class="form-control">
+			<label class="label py-0"><span class="label-text text-xs">Target</span></label>
+			<input name="target" list="link-routes" placeholder="/demo/catalog" required class="input input-bordered input-sm w-44"/>
+		</div>
+		<div class="form-control">
+			<label class="label py-0"><span class="label-text text-xs">Title</span></label>
+			<input name="title" placeholder="Catalog" required class="input input-bordered input-sm w-32"/>
+		</div>
+		<div class="form-control">
+			<label class="label py-0"><span class="label-text text-xs">Group</span></label>
+			<input name="group" placeholder="(optional)" class="input input-bordered input-sm w-28"/>
+		</div>
+		<button type="submit" class="btn btn-primary btn-sm">Add</button>
+		<datalist id="link-routes">
+			for _, route := range routes {
+				<option value={ route }></option>
+			}
+		</datalist>
+	</form>
+}
+
+templ LinksRegistryTable(data LinksPageData) {
+	<div id="links-table">
+		<div class="overflow-x-auto">
+			<table class="table table-xs">
+				<thead>
+					<tr>
+						<th>Source</th>
+						<th>Rel</th>
+						<th>Target</th>
+						<th>Title</th>
+						<th class="w-8"></th>
+					</tr>
+				</thead>
+				<tbody>
+					for _, src := range hypermedia.SortedPaths(data.Links) {
+						for i, link := range data.Links[src] {
+							<tr class={ templ.KV("border-t border-base-300", i == 0) }>
+								if i == 0 {
+									<td class="font-mono text-xs align-top" rowspan={ linksRowspan(data.Links[src]) }>{ src }</td>
+								}
+								<td class="text-xs">
+									<span class="badge badge-sm badge-outline">{ link.Rel }</span>
+								</td>
+								<td class="font-mono text-xs">
+									<a href={ templ.URL(link.Href) } class="link link-hover link-primary">{ link.Href }</a>
+								</td>
+								<td class="text-xs">{ link.Title }</td>
+								<td class="text-xs">
+									if id := storedLinkID(data.StoredLinks, src, link.Rel, link.Href); id > 0 {
+										<button
+											hx-delete={ linkDeleteURL(id) }
+											hx-target="#links-table"
+											hx-swap="outerHTML"
+											hx-confirm="Remove this admin link?"
+											class="btn btn-ghost btn-xs text-error"
+											title="Delete admin link"
+										>
+											&#x2715;
+										</button>
+									} else {
+										<span class="text-base-content/30" title="Code-declared (read-only)">&#x1F512;</span>
+									}
+								</td>
+							</tr>
+						}
+					}
+				</tbody>
+			</table>
+		</div>
+		<div class="mt-2 text-xs text-base-content/50">
+			{ linksCount(data.Links) } total directed links across { pathsCount(data.Links) } source paths.
+		</div>
 	</div>
 }
 

--- a/web/views/hypermedia_links_templ.go
+++ b/web/views/hypermedia_links_templ.go
@@ -10,9 +10,19 @@ package views
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "catgoose/dothog/internal/routes/hypermedia"
+import (
+	"catgoose/dothog/internal/demo"
+	"catgoose/dothog/internal/routes/hypermedia"
+)
 
-func HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) templ.Component {
+// LinksPageData holds all data needed to render the links page.
+type LinksPageData struct {
+	Links       map[string][]hypermedia.LinkRelation
+	StoredLinks []demo.StoredLinkRelation
+	Routes      []string
+}
+
+func HypermediaLinksPage(data LinksPageData) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -56,7 +66,7 @@ func HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) templ.Compo
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(codeLinkExample())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 25, Col: 92}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 35, Col: 92}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -91,7 +101,7 @@ func HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) templ.Compo
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(codeRingExample())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 33, Col: 92}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 43, Col: 92}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -126,7 +136,7 @@ func HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) templ.Compo
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(codeHubExample())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 42, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 52, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -161,7 +171,7 @@ func HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) templ.Compo
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(codeRelExample())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 51, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 61, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -196,7 +206,7 @@ func HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) templ.Compo
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(codeDedupExample())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 59, Col: 93}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 69, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -224,161 +234,300 @@ func HypermediaLinksPage(links map[string][]hypermedia.LinkRelation) templ.Compo
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<p class=\"text-sm text-base-content/70 mb-3\">All link relations currently registered in this running application, via <code class=\"text-xs bg-base-200 px-1 rounded\">hypermedia.AllLinks()</code>.</p><div class=\"overflow-x-auto\"><table class=\"table table-xs\"><thead><tr><th>Source</th><th>Rel</th><th>Target</th><th>Title</th></tr></thead> <tbody>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<p class=\"text-sm text-base-content/70 mb-3\">Add custom link relations between routes. Admin-created links are persisted in SQLite and loaded into the in-memory registry on startup.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, src := range hypermedia.SortedPaths(links) {
-				for i, link := range links[src] {
-					var templ_7745c5c3_Var13 = []any{templ.KV("border-t border-base-300", i == 0)}
-					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var13...)
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<tr class=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var14 string
-					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var13).String())
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 1, Col: 0}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					if i == 0 {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<td class=\"font-mono text-xs align-top\" rowspan=\"")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var15 string
-						templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(linksRowspan(links[src]))
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 81, Col: 84}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\">")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var16 string
-						templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(src)
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 81, Col: 92}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</td>")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<td class=\"text-xs\"><span class=\"badge badge-sm badge-outline\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var17 string
-					templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(link.Rel)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 84, Col: 63}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span></td><td class=\"font-mono text-xs\"><a href=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var18 templ.SafeURL
-					templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(link.Href))
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 87, Col: 40}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" class=\"link link-hover link-primary\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var19 string
-					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(link.Href)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 87, Col: 91}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</a></td><td class=\"text-xs\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var20 string
-					templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(link.Title)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 89, Col: 41}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</td></tr>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</tbody></table></div><div class=\"mt-2 text-xs text-base-content/50\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var21 string
-			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(linksCount(links))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 97, Col: 23}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " total directed links across ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var22 string
-			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(pathsCount(links))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 97, Col: 73}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " source paths.</div>")
+			templ_7745c5c3_Err = linksEditorForm(data.Routes).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = linksSection("6. Live Registry").Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = linksSection("6. Relationship Editor").Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div>")
+		templ_7745c5c3_Var13 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<p class=\"text-sm text-base-content/70 mb-3\">All link relations currently registered in this running application, via <code class=\"text-xs bg-base-200 px-1 rounded\">hypermedia.AllLinks()</code>.</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = LinksRegistryTable(data).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = linksSection("7. Live Registry").Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func linksEditorForm(routes []string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<form hx-post=\"/hypermedia/links\" hx-target=\"#links-table\" hx-swap=\"outerHTML\" class=\"flex flex-wrap items-end gap-2\"><div class=\"form-control\"><label class=\"label py-0\"><span class=\"label-text text-xs\">Source</span></label> <input name=\"source\" list=\"link-routes\" placeholder=\"/demo/inventory\" required class=\"input input-bordered input-sm w-44\"></div><div class=\"form-control\"><label class=\"label py-0\"><span class=\"label-text text-xs\">Rel</span></label> <select name=\"rel\" class=\"select select-bordered select-sm w-32\"><option value=\"related\">related</option> <option value=\"up\">up</option> <option value=\"create-form\">create-form</option></select></div><div class=\"form-control\"><label class=\"label py-0\"><span class=\"label-text text-xs\">Target</span></label> <input name=\"target\" list=\"link-routes\" placeholder=\"/demo/catalog\" required class=\"input input-bordered input-sm w-44\"></div><div class=\"form-control\"><label class=\"label py-0\"><span class=\"label-text text-xs\">Title</span></label> <input name=\"title\" placeholder=\"Catalog\" required class=\"input input-bordered input-sm w-32\"></div><div class=\"form-control\"><label class=\"label py-0\"><span class=\"label-text text-xs\">Group</span></label> <input name=\"group\" placeholder=\"(optional)\" class=\"input input-bordered input-sm w-28\"></div><button type=\"submit\" class=\"btn btn-primary btn-sm\">Add</button> <datalist id=\"link-routes\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, route := range routes {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<option value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(route)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 121, Col: 25}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"></option>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</datalist></form>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func LinksRegistryTable(data LinksPageData) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"links-table\"><div class=\"overflow-x-auto\"><table class=\"table table-xs\"><thead><tr><th>Source</th><th>Rel</th><th>Target</th><th>Title</th><th class=\"w-8\"></th></tr></thead> <tbody>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, src := range hypermedia.SortedPaths(data.Links) {
+			for i, link := range data.Links[src] {
+				var templ_7745c5c3_Var17 = []any{templ.KV("border-t border-base-300", i == 0)}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var17...)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<tr class=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var18 string
+				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var17).String())
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 1, Col: 0}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if i == 0 {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<td class=\"font-mono text-xs align-top\" rowspan=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var19 string
+					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(linksRowspan(data.Links[src]))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 145, Col: 88}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var20 string
+					templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(src)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 145, Col: 96}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<td class=\"text-xs\"><span class=\"badge badge-sm badge-outline\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var21 string
+				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(link.Rel)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 148, Col: 62}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</span></td><td class=\"font-mono text-xs\"><a href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var22 templ.SafeURL
+				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(link.Href))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 151, Col: 39}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" class=\"link link-hover link-primary\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var23 string
+				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(link.Href)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 151, Col: 90}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</a></td><td class=\"text-xs\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var24 string
+				templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(link.Title)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 153, Col: 40}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</td><td class=\"text-xs\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if id := storedLinkID(data.StoredLinks, src, link.Rel, link.Href); id > 0 {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<button hx-delete=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var25 string
+					templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(linkDeleteURL(id))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 157, Col: 40}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" hx-target=\"#links-table\" hx-swap=\"outerHTML\" hx-confirm=\"Remove this admin link?\" class=\"btn btn-ghost btn-xs text-error\" title=\"Delete admin link\">&#x2715;</button>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				} else {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<span class=\"text-base-content/30\" title=\"Code-declared (read-only)\">&#x1F512;</span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</td></tr>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</tbody></table></div><div class=\"mt-2 text-xs text-base-content/50\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var26 string
+		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(linksCount(data.Links))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 177, Col: 27}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " total directed links across ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var27 string
+		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(pathsCount(data.Links))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 177, Col: 82}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " source paths.</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -402,33 +551,33 @@ func linksSection(title string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var23 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var23 == nil {
-			templ_7745c5c3_Var23 = templ.NopComponent
+		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var28 == nil {
+			templ_7745c5c3_Var28 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title text-base\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body\"><h2 class=\"card-title text-base\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var24 string
-		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(title)
+		var templ_7745c5c3_Var29 string
+		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 106, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/hypermedia_links.templ`, Line: 185, Col: 43}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</h2>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var23.Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</h2>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</div></div>")
+		templ_7745c5c3_Err = templ_7745c5c3_Var28.Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- Add SQLite-backed `link_relations` table for admin-created link relations (`internal/demo/link_relations.go`)
- Add `LoadStoredLink` and `RemoveLink` to the in-memory link registry for runtime mutation
- Add HTMX-powered create/delete forms on the `/hypermedia/links` page with route datalist autocomplete
- Stored links load into the registry on startup; admin links show a delete button, code-declared links show a lock icon

## Test plan
- [ ] Navigate to `/hypermedia/links` and verify existing content (pattern docs, code examples) is preserved
- [ ] Use the relationship editor form to add a new link relation between two routes
- [ ] Verify the new link appears in the live registry table with a delete button
- [ ] Delete an admin-created link and verify it is removed from the table
- [ ] Restart the app and verify previously stored links are loaded from SQLite
- [ ] Verify code-declared links show a lock icon and cannot be deleted

Closes #230