### PR TITLE
fix: return full page for hx-boost breadcrumb navigation (closes #241)

### DIFF
--- a/internal/routes/htmx/headers.go
+++ b/internal/routes/htmx/headers.go
@@ -42,6 +42,13 @@ func IsHTMX(c echo.Context) bool {
 	return c.Request().Header.Get("HX-Request") == "true"
 }
 
+// IsBoosted reports whether the request was made via hx-boost.
+// Boosted requests carry both HX-Request and HX-Boosted headers and expect a
+// full-page response (HTMX extracts the <body> content for the swap).
+func IsBoosted(c echo.Context) bool {
+	return c.Request().Header.Get("HX-Boosted") == "true"
+}
+
 // Trigger sets the HX-Trigger response header to the given raw JSON string.
 func Trigger(c echo.Context, jsonStr string) {
 	c.Response().Header().Set(HeaderTrigger, jsonStr)

--- a/internal/routes/htmx/headers_test.go
+++ b/internal/routes/htmx/headers_test.go
@@ -45,6 +45,34 @@ func TestIsHTMX_OtherValue(t *testing.T) {
 	require.False(t, IsHTMX(c))
 }
 
+// ---------- IsBoosted ----------
+
+func TestIsBoosted_True(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Boosted", "true")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.True(t, IsBoosted(c))
+}
+
+func TestIsBoosted_Missing(t *testing.T) {
+	c, _ := newContext()
+	require.False(t, IsBoosted(c))
+}
+
+func TestIsBoosted_OtherValue(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("HX-Boosted", "yes")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.False(t, IsBoosted(c))
+}
+
 // ---------- Trigger ----------
 
 func TestTrigger(t *testing.T) {

--- a/internal/routes/routes_catalog.go
+++ b/internal/routes/routes_catalog.go
@@ -5,6 +5,7 @@ package routes
 import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
+	hx "catgoose/dothog/internal/routes/htmx"
 	"catgoose/dothog/internal/routes/hypermedia"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/web/views"
@@ -34,9 +35,12 @@ func (cat *catalogRoutes) handleCatalogPage(c echo.Context) error {
 }
 
 func (cat *catalogRoutes) handleCatalogItems(c echo.Context) error {
-	_, container, err := cat.buildCatalogContent(c)
+	bar, container, err := cat.buildCatalogContent(c)
 	if err != nil {
 		return handler.HandleHypermediaError(c, 500, "Failed to load items", err)
+	}
+	if hx.IsBoosted(c) {
+		return handler.RenderBaseLayout(c, views.CatalogPage(bar, container))
 	}
 	setTableReplaceURL(c, catalogBase)
 	return handler.RenderComponent(c, container)

--- a/internal/routes/routes_inventory.go
+++ b/internal/routes/routes_inventory.go
@@ -8,6 +8,7 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
+	hx "catgoose/dothog/internal/routes/htmx"
 	"catgoose/dothog/internal/routes/hypermedia"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/web/views"
@@ -43,9 +44,12 @@ func (d *inventoryRoutes) handleInventoryPage(c echo.Context) error {
 }
 
 func (d *inventoryRoutes) handleInventoryItems(c echo.Context) error {
-	_, container, err := d.buildInventoryContent(c)
+	bar, container, err := d.buildInventoryContent(c)
 	if err != nil {
 		return handler.HandleHypermediaError(c, 500, "Failed to load items", err)
+	}
+	if hx.IsBoosted(c) {
+		return handler.RenderBaseLayout(c, views.InventoryPage(bar, container))
 	}
 	setTableReplaceURL(c, inventoryBase)
 	return handler.RenderComponent(c, container)
@@ -98,7 +102,7 @@ func (d *inventoryRoutes) handleItemRow(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 404, "Item not found", err)
 	}
-	if c.Request().Header.Get("HX-Request") == "" {
+	if !hx.IsHTMX(c) || hx.IsBoosted(c) {
 		handler.SetPageLabel(c, item.Name)
 		return handler.RenderBaseLayout(c, views.InventoryDetailPage(item))
 	}


### PR DESCRIPTION
## Summary

- Added `IsBoosted()` helper to the `htmx` package to detect `HX-Boosted: true` header
- Fixed inventory item detail handler (`/demo/inventory/items/:id`) to return a full page layout for boosted requests instead of a bare table row partial
- Fixed inventory items list handler (`/demo/inventory/items`) to return a full page layout for boosted requests
- Fixed catalog items list handler (`/demo/catalog/items`) with the same pattern

## Root cause

Breadcrumb links are plain `<a>` tags that inherit `hx-boost="true"` from the body. When clicked, HTMX sends the request with both `HX-Request: true` and `HX-Boosted: true`. Handlers that checked only `HX-Request` returned partial fragments, but hx-boost expects a full HTML page (it extracts the `<body>` for the swap). The fix checks `HX-Boosted` and returns a full page layout via `RenderBaseLayout` for boosted requests.

## Test plan

- [ ] Navigate to `/demo/inventory/items/6`, click "Inventory" breadcrumb — app shell remains
- [ ] Navigate to `/demo/inventory/items/6`, click "Items" breadcrumb — app shell remains
- [ ] Navigate to `/demo/catalog/items/5`, click "Items" breadcrumb — app shell remains
- [ ] Verify inline table row edits and HTMX partial swaps still work correctly
- [ ] Run `go test ./internal/routes/...` — all pass