### PR TITLE
feat: add @starting-style CSS entry animations for HTMX swaps

### DIFF
--- a/web/styles/input.css
+++ b/web/styles/input.css
@@ -68,6 +68,35 @@
   :root {
     accent-color: var(--color-primary);
   }
+
+  /* Entry animations for HTMX-swapped content */
+  @media (prefers-reduced-motion: no-preference) {
+    /* Cards and content blocks fade in when inserted by HTMX */
+    .card, [id*="base-content"] > * {
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    @starting-style {
+      .card, [id*="base-content"] > * {
+        opacity: 0;
+        transform: translateY(4px);
+      }
+    }
+
+    /* Popover open/close animations */
+    [popover]:popover-open {
+      opacity: 1;
+      transform: scale(1);
+      transition: opacity 0.2s ease, transform 0.2s ease, display 0.2s allow-discrete;
+    }
+
+    @starting-style {
+      [popover]:popover-open {
+        opacity: 0;
+        transform: scale(0.97);
+      }
+    }
+  }
 }
 
 @custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
## Summary
- Adds `@starting-style` CSS entry animations for HTMX-swapped content (cards, base-content children)
- Adds popover open/close animations using `@starting-style` and `allow-discrete`
- All animations are subtle (0.2s, 4px translateY, 0.97 scale) and gated behind `prefers-reduced-motion: no-preference`

Closes #247

## Test plan
- [ ] Verify cards and base-content children fade/slide in on HTMX swap
- [ ] Verify popover elements animate on open/close
- [ ] Verify no animations when `prefers-reduced-motion: reduce` is set
- [ ] Verify no visual regressions on initial page load