### PR TITLE
feat: aria-live, prefers-reduced-motion, spellcheck, scripting detection

### DIFF
--- a/web/components/core/filter.templ
+++ b/web/components/core/filter.templ
@@ -101,6 +101,7 @@ templ searchFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) 
 		<input
 			type="search"
 			autocomplete="off"
+			spellcheck="false"
 			enterkeyhint="search"
 			name={ field.Name }
 			value={ field.Value }

--- a/web/styles/input.css
+++ b/web/styles/input.css
@@ -69,6 +69,23 @@
     accent-color: var(--color-primary);
   }
 
+  /* Accessibility: disable all motion for users who prefer reduced motion */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+
+  /* Progressive enhancement: hide JS-only elements when scripting is unavailable */
+  @media (scripting: none) {
+    .requires-js {
+      display: none !important;
+    }
+  }
+
   /* Entry animations for HTMX-swapped content */
   @media (prefers-reduced-motion: no-preference) {
     /* Cards and content blocks fade in when inserted by HTMX */

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -25,7 +25,7 @@ templ Index(layoutContent templ.Component, menuContent templ.Component, csrfToke
 				setTimeout(() => { t.style.transition = 'opacity 0.3s ease'; t.style.opacity = '0'; setTimeout(() => t.remove(), 300); }, 3000);
 			"
 		>
-			<div id="error-status" class="sticky top-0 z-40"></div>
+			<div id="error-status" class="sticky top-0 z-40" aria-live="assertive"></div>
 			if len(crumbs) > 0 {
 				<meta name="page-title" content={ crumbs[len(crumbs)-1].Label }/>
 			}
@@ -49,6 +49,9 @@ templ Index(layoutContent templ.Component, menuContent templ.Component, csrfToke
 			// setup:feature:demo:start
 			@components.SiteMap(hubs)
 			// setup:feature:demo:end
+			<noscript>
+				<div class="alert alert-warning m-4">JavaScript is required for full functionality.</div>
+			</noscript>
 			<footer class="text-center text-xs text-base-content/60 py-2">
 				{ version }
 			</footer>


### PR DESCRIPTION
## Summary
- Add `aria-live="assertive"` to `#error-status` div for screen reader announcements
- Add `prefers-reduced-motion: reduce` media query to disable all animations/transitions
- Add `scripting: none` media query to hide `.requires-js` elements when JS is unavailable
- Add `spellcheck="false"` to search filter inputs
- Add `<noscript>` warning banner before footer

Closes #255, closes #259

## Test plan
- [ ] Verify screen readers announce error status changes
- [ ] Enable "reduce motion" in OS settings and confirm no animations play
- [ ] Disable JavaScript and confirm `.requires-js` elements are hidden and noscript banner shows
- [ ] Confirm search inputs do not trigger spellcheck underlines