### PR TITLE
feat: Speculation Rules prefetch and color-mix utilities

### DIFF
--- a/web/styles/input.css
+++ b/web/styles/input.css
@@ -67,6 +67,9 @@
   /* Theming: brand all native form controls */
   :root {
     accent-color: var(--color-primary);
+    /* Dynamic color utilities using color-mix() */
+    --color-primary-hover: color-mix(in oklch, var(--color-primary) 85%, black);
+    --color-primary-subtle: color-mix(in oklch, var(--color-primary) 15%, transparent);
   }
 
   /* Accessibility: disable all motion for users who prefer reduced motion */

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -103,6 +103,24 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 		// setup:feature:demo:start
 		<link rel="manifest" href="/public/images/site.webmanifest"/>
 		// setup:feature:demo:end
+		// setup:feature:demo:start
+		<script type="speculationrules">
+		{
+			"prefetch": [{
+				"where": {
+					"and": [
+						{"href_matches": "/*"},
+						{"not": {"href_matches": "/log/*"}},
+						{"not": {"href_matches": "/sync"}},
+						{"not": {"href_matches": "/health"}},
+						{"not": {"selector_matches": "[hx-get],[hx-post],[hx-put],[hx-delete],[hx-patch]"}}
+					]
+				},
+				"eagerness": "moderate"
+			}]
+		}
+		</script>
+		// setup:feature:demo:end
 		<title>{ appName }</title>
 		if devMode {
 			<script src="/public/js/dev-logging.js"></script>


### PR DESCRIPTION
## Summary
- **#252 Speculation Rules**: Added `<script type="speculationrules">` in the `<head>` (demo-gated) to prefetch internal pages on hover with moderate eagerness, excluding HTMX elements, API endpoints, and logging routes. Falls back gracefully in non-Chrome browsers.
- **#250 fetchpriority/loading=lazy**: No `<img>` tags exist in templ files (the app uses SVG icons only), so no changes needed.
- **#251 color-mix()**: Added `--color-primary-hover` and `--color-primary-subtle` custom properties using `color-mix(in oklch, ...)` to `:root` in `input.css`.

Closes #252, closes #250, closes #251

## Test plan
- [ ] Verify speculation rules appear in `<head>` when demo feature is enabled
- [ ] Verify prefetch triggers on hover for internal links in Chrome DevTools Network tab
- [ ] Verify HTMX-enhanced elements and excluded paths are not prefetched
- [ ] Verify `--color-primary-hover` and `--color-primary-subtle` resolve correctly in browser DevTools
- [ ] Confirm `templ generate` and `go build ./...` pass cleanly