### PR TITLE
feat: web standards batch — output, anchor positioning, @scope, Trusted Types, scroll animations

### DIFF
--- a/internal/routes/routes_hypermedia_components3.go
+++ b/internal/routes/routes_hypermedia_components3.go
@@ -4,6 +4,7 @@ package routes
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"sync"
 	"time"
@@ -90,6 +91,9 @@ func (ar *appRoutes) initComponents3Routes() {
 
 	// Optimistic UI
 	ar.e.POST(components3Base+"/favorite/:id", s.handleFavoriteToggle)
+
+	// Calculate (output element demo)
+	ar.e.GET(components3Base+"/calculate", handleCalculate)
 
 	// Undo / soft delete
 	ar.e.DELETE(components3Base+"/undo/:id", s.handleUndoDelete)
@@ -237,6 +241,14 @@ func (s *components3State) handleUndoList(c echo.Context) error {
 	s.mu.RUnlock()
 
 	return handler.RenderComponent(c, views.UndoListFragment(items))
+}
+
+// ─── Calculate handler (output element demo) ────────────────────────────────────
+
+func handleCalculate(c echo.Context) error {
+	a := rand.Intn(100) + 1
+	b := rand.Intn(100) + 1
+	return c.HTML(200, fmt.Sprintf("%d + %d = <strong>%d</strong>", a, b, a+b))
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────────────

--- a/web/styles/input.css
+++ b/web/styles/input.css
@@ -121,6 +121,44 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Anchor positioning for tooltips (progressive enhancement) */
+@supports (anchor-name: --x) {
+    [data-tooltip-anchor] {
+        anchor-name: --tooltip-trigger;
+    }
+    [data-tooltip-content] {
+        position: fixed;
+        position-anchor: --tooltip-trigger;
+        top: anchor(bottom);
+        left: anchor(center);
+        translate: -50% 4px;
+    }
+}
+
+/* Scoped styles example — component isolation without Shadow DOM */
+@supports (selector(&)) {
+    @scope (.scoped-card) to (.scoped-card-body) {
+        h3 { font-weight: 700; }
+        p { margin-block: 0.25em; color: color-mix(in oklch, currentColor 70%, transparent); }
+    }
+}
+
+/* Scroll-driven animations (progressive enhancement) */
+@supports (animation-timeline: view()) {
+    @media (prefers-reduced-motion: no-preference) {
+        .scroll-reveal {
+            animation: scrollReveal linear both;
+            animation-timeline: view();
+            animation-range: entry 0% entry 100%;
+        }
+
+        @keyframes scrollReveal {
+            from { opacity: 0; transform: translateY(12px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+    }
+}
+
 /* View Transitions: animated page navigation for hx-boost */
 @view-transition {
     navigation: auto;

--- a/web/views/hypermedia_components3.templ
+++ b/web/views/hypermedia_components3.templ
@@ -162,6 +162,13 @@ templ Components3Page(data Components3PageData) {
 					The <mark>hypermedia</mark> approach uses <mark>server-driven</mark> UI instead of client-side routing.
 					Each response contains the full <mark>HTML</mark> needed to render the next state.
 				</p>
+				<!-- output element -->
+				<h3 class="font-semibold text-sm mt-4 mb-1">Accessible Results — <code class="text-xs bg-base-200 px-1 rounded">&lt;output&gt;</code></h3>
+				<p class="text-xs text-base-content/60 mb-2">Implicit aria-live region. Screen readers announce changes automatically.</p>
+				<div class="flex items-center gap-3">
+					<button class="btn btn-sm btn-primary" hx-get="/hypermedia/components3/calculate" hx-target="#calc-result" hx-swap="innerHTML">Calculate</button>
+					<output id="calc-result" class="font-mono text-sm">—</output>
+				</div>
 			</div>
 		</div>
 		<!-- 5. Locale Formatting -->

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -75,6 +75,13 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 		<link rel="preload" href="/public/css/tailwind.css" as="style"/>
 		<link rel="preload" href="/public/js/_hyperscript.min.js" as="script"/>
 		<link rel="preload" href="/public/js/htmx.min.js" as="script"/>
+		<script>
+			if (window.trustedTypes) {
+				trustedTypes.createPolicy('default', {
+					createHTML: function(value) { return value; }
+				});
+			}
+		</script>
 		<script defer src="/public/js/htmx.min.js"></script>
 		<script defer src="/public/js/_hyperscript.min.js"></script>
 		<script defer src="/public/js/htmx.alpine-morph.js"></script>


### PR DESCRIPTION
## Summary
- **#249**: Add `<output>` element demo with HTMX calculate handler to the Native HTML Elements showcase on components3 page — implicit `aria-live` for screen reader announcements
- **#256**: CSS anchor positioning for tooltips/popovers via `@supports (anchor-name: --x)` progressive enhancement
- **#257**: `@scope` CSS rules for component-scoped styles without Shadow DOM, wrapped in `@supports`
- **#260**: Trusted Types default policy in `<head>` to prepare for DOM XSS prevention with HTMX innerHTML swaps
- **#261**: `.scroll-reveal` utility class using `animation-timeline: view()` for scroll-driven fade-in, respects `prefers-reduced-motion`

All CSS additions are progressive enhancements wrapped in `@supports` — no-op in unsupported browsers.

Closes #249, closes #256, closes #257, closes #260, closes #261

## Test plan
- [ ] Verify `templ generate && go build ./...` passes
- [ ] Visit `/hypermedia/components3` and click Calculate button — output element shows random sum
- [ ] Inspect CSS for anchor positioning, @scope, and scroll-reveal rules in supported browsers
- [ ] Verify Trusted Types policy loads without errors in DevTools console