### PR TITLE
fix: resolve CI test hangs from recursion, goroutine leak, and httptest issues

### DIFF
--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -263,7 +263,7 @@ func HandleError(c echo.Context, statusCode int, message string, err error) erro
 	requestID := middleware.GetRequestID(c)
 	logger.WithContext(c.Request().Context()).Error("Request error", "error", err, "status_code", statusCode, "message", message)
 	c.Response().Status = statusCode
-	renderErr := RenderComponent(c, corecomponents.ErrorStatus(statusCode, message, err, c.Request().URL.Path, requestID, true))
+	renderErr := corecomponents.ErrorStatus(statusCode, message, err, c.Request().URL.Path, requestID, true).Render(c.Request().Context(), c.Response())
 	if renderErr != nil {
 		return c.HTML(http.StatusInternalServerError, fmt.Sprintf(
 			`<div class="bg-error text-error-content p-3 shadow-lg text-sm">

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -232,14 +232,18 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 	// before the final 200. Requires HTTP/2+ and a flusher-capable writer.
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			w := c.Response().Writer
-			if flusher, ok := w.(http.Flusher); ok {
-				h := w.Header()
-				h.Add("Link", "</public/css/tailwind.css>; rel=preload; as=style")
-				h.Add("Link", "</public/css/daisyui.css>; rel=preload; as=style")
-				h.Add("Link", "</public/js/htmx.min.js>; rel=preload; as=script")
-				w.WriteHeader(http.StatusEarlyHints) // 103
-				flusher.Flush()
+			// Only send 103 Early Hints on HTTP/2+ connections.
+			// httptest.ResponseRecorder mishandles 1xx status codes.
+			if c.Request().ProtoMajor >= 2 {
+				w := c.Response().Writer
+				if flusher, ok := w.(http.Flusher); ok {
+					h := w.Header()
+					h.Add("Link", "</public/css/tailwind.css>; rel=preload; as=style")
+					h.Add("Link", "</public/css/daisyui.css>; rel=preload; as=style")
+					h.Add("Link", "</public/js/htmx.min.js>; rel=preload; as=script")
+					w.WriteHeader(http.StatusEarlyHints) // 103
+					flusher.Flush()
+				}
 			}
 			return next(c)
 		}

--- a/internal/routes/routes_canvas.go
+++ b/internal/routes/routes_canvas.go
@@ -3,6 +3,7 @@
 package routes
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -26,10 +27,11 @@ const canvasClientCookie = "canvas_client"
 type canvasRoutes struct {
 	canvas *demo.PixelCanvas
 	broker *ssebroker.SSEBroker
+	ctx    context.Context
 }
 
 func (ar *appRoutes) initCanvasRoutes(canvas *demo.PixelCanvas, broker *ssebroker.SSEBroker) {
-	cr := &canvasRoutes{canvas: canvas, broker: broker}
+	cr := &canvasRoutes{canvas: canvas, broker: broker, ctx: ar.ctx}
 	ar.e.GET("/demo/canvas", cr.handleCanvasPage)
 	ar.e.GET("/demo/canvas/state", cr.handleCanvasState)
 	ar.e.POST("/demo/canvas/place", cr.handlePlace)
@@ -132,9 +134,14 @@ func (cr *canvasRoutes) handleCanvasSSE(c echo.Context) error {
 func (cr *canvasRoutes) runTicker() {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
-	for range ticker.C {
-		cr.canvas.PruneStale()
-		cr.broadcastClients()
+	for {
+		select {
+		case <-cr.ctx.Done():
+			return
+		case <-ticker.C:
+			cr.canvas.PruneStale()
+			cr.broadcastClients()
+		}
 	}
 }
 

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -13,8 +13,9 @@ import (
 
 // TestServer represents a test server instance
 type TestServer struct {
-	Echo *echo.Echo
-	URL  string
+	Echo   *echo.Echo
+	Server *httptest.Server
+	URL    string
 }
 
 // SetupTestServer creates a test server for integration tests
@@ -28,15 +29,24 @@ func SetupTestServer(t *testing.T) *TestServer {
 	// Create a test server
 	server := httptest.NewServer(e)
 
-	return &TestServer{
-		Echo: e,
-		URL:  server.URL,
+	ts := &TestServer{
+		Echo:   e,
+		Server: server,
+		URL:    server.URL,
 	}
+	t.Cleanup(func() { ts.Server.Close() })
+	return ts
 }
 
 // CleanupTestServer cleans up test server resources
 func CleanupTestServer(ts *TestServer) {
-	if ts != nil && ts.Echo != nil {
+	if ts == nil {
+		return
+	}
+	if ts.Server != nil {
+		ts.Server.Close()
+	}
+	if ts.Echo != nil {
 		ts.Echo.Close()
 	}
 }


### PR DESCRIPTION
## Summary

Fixes four root causes of CI test hangs identified in #284:

- **HandleError infinite recursion**: `HandleError` called `RenderComponent`, which on failure called `HandleError` again. Fixed by rendering the error template directly via `.Render()`, so failures fall through to the HTML fallback.
- **103 Early Hints breaking httptest**: The Early Hints middleware wrote `WriteHeader(103)` on every request. `httptest.ResponseRecorder` mishandles 1xx status codes. Fixed by guarding behind `ProtoMajor >= 2` (tests use HTTP/1.1).
- **Canvas goroutine leak**: `runTicker` looped forever with no cancellation. Fixed by selecting on the app context so the goroutine exits on shutdown.
- **httptest.Server leak**: `SetupTestServer` created an `httptest.NewServer` but never stored or closed it. Fixed by storing the server reference and closing it via `t.Cleanup`.

Closes #284

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test -race -timeout 2m $(go list ./... | grep -v /tests)` passes (all unit tests, no hangs)
- [x] Integration test failures in `./tests/` are pre-existing on main (unrelated to this change)