### PR TITLE
feat: theme picker color previews and light/dark sorting

### DIFF
--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -208,12 +208,31 @@ templ ThemeChanged(theme string) {
 	<span class="hidden">{ theme }</span>
 }
 
-// DaisyThemes is the list of available DaisyUI themes for the picker.
-var DaisyThemes = []string{
-	"light", "dark", "cupcake", "emerald", "corporate", "synthwave",
-	"retro", "cyberpunk", "valentine", "garden", "forest", "lofi",
-	"pastel", "fantasy", "wireframe", "luxury", "dracula", "cmyk",
-	"autumn", "business", "acid", "lemonade", "night", "coffee",
-	"winter", "dim", "nord", "sunset", "caramellatte", "abyss", "silk",
+// ThemeCategory groups themes under a label (e.g. "Light", "Dark").
+type ThemeCategory struct {
+	Label  string
+	Themes []string
+}
+
+// ThemeCategories lists DaisyUI themes grouped by light/dark, alphabetically sorted
+// within each category (with "light"/"dark" pinned first in their respective groups).
+var ThemeCategories = []ThemeCategory{
+	{
+		Label:  "Light",
+		Themes: []string{"light", "acid", "autumn", "caramellatte", "cmyk", "corporate", "cupcake", "emerald", "fantasy", "garden", "lemonade", "lofi", "pastel", "retro", "silk", "valentine", "winter", "wireframe"},
+	},
+	{
+		Label:  "Dark",
+		Themes: []string{"dark", "abyss", "business", "coffee", "cyberpunk", "dim", "dracula", "forest", "luxury", "night", "nord", "sunset", "synthwave"},
+	},
+}
+
+// DaisyThemes is the flat list of available DaisyUI themes (used for validation).
+var DaisyThemes []string
+
+func init() {
+	for _, cat := range ThemeCategories {
+		DaisyThemes = append(DaisyThemes, cat.Themes...)
+	}
 }
 

--- a/web/views/index_templ.go
+++ b/web/views/index_templ.go
@@ -342,13 +342,32 @@ func ThemeChanged(theme string) templ.Component {
 	})
 }
 
-// DaisyThemes is the list of available DaisyUI themes for the picker.
-var DaisyThemes = []string{
-	"light", "dark", "cupcake", "emerald", "corporate", "synthwave",
-	"retro", "cyberpunk", "valentine", "garden", "forest", "lofi",
-	"pastel", "fantasy", "wireframe", "luxury", "dracula", "cmyk",
-	"autumn", "business", "acid", "lemonade", "night", "coffee",
-	"winter", "dim", "nord", "sunset", "caramellatte", "abyss", "silk",
+// ThemeCategory groups themes under a label (e.g. "Light", "Dark").
+type ThemeCategory struct {
+	Label  string
+	Themes []string
+}
+
+// ThemeCategories lists DaisyUI themes grouped by light/dark, alphabetically sorted
+// within each category (with "light"/"dark" pinned first in their respective groups).
+var ThemeCategories = []ThemeCategory{
+	{
+		Label:  "Light",
+		Themes: []string{"light", "acid", "autumn", "caramellatte", "cmyk", "corporate", "cupcake", "emerald", "fantasy", "garden", "lemonade", "lofi", "pastel", "retro", "silk", "valentine", "winter", "wireframe"},
+	},
+	{
+		Label:  "Dark",
+		Themes: []string{"dark", "abyss", "business", "coffee", "cyberpunk", "dim", "dracula", "forest", "luxury", "night", "nord", "sunset", "synthwave"},
+	},
+}
+
+// DaisyThemes is the flat list of available DaisyUI themes (used for validation).
+var DaisyThemes []string
+
+func init() {
+	for _, cat := range ThemeCategories {
+		DaisyThemes = append(DaisyThemes, cat.Themes...)
+	}
 }
 
 var _ = templruntime.GeneratedTemplate

--- a/web/views/settings_app.templ
+++ b/web/views/settings_app.templ
@@ -117,7 +117,8 @@ templ AppSettingsPage(currentTheme string, currentLayout string) {
 	</div>
 }
 
-// themeDropdown renders a dropdown select for choosing a DaisyUI theme.
+// themeDropdown renders a dropdown select for choosing a DaisyUI theme,
+// grouped by light/dark category, with a visual color-swatch grid below.
 templ themeDropdown(currentTheme string) {
 	<div x-data={ "{ current: '" + currentTheme + "' }" }>
 		<div class="flex items-center gap-3">
@@ -131,15 +132,40 @@ templ themeDropdown(currentTheme string) {
 				x-model="current"
 				x-on:change={ "document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.dothogChannel) window.dothogChannel.postMessage({type:'theme-change',theme:current})" }
 			>
-				for _, theme := range DaisyThemes {
-					<option
-						value={ theme }
-						selected?={ theme == currentTheme }
-					>
-						{ theme }
-					</option>
+				for _, cat := range ThemeCategories {
+					<optgroup label={ cat.Label }>
+						for _, theme := range cat.Themes {
+							<option value={ theme } selected?={ theme == currentTheme }>{ theme }</option>
+						}
+					</optgroup>
 				}
 			</select>
+		</div>
+		<div class="mt-3">
+			<p class="text-xs text-base-content/60 mb-2">Or pick visually:</p>
+			for _, cat := range ThemeCategories {
+				<div class="mb-2">
+					<p class="text-xs font-medium text-base-content/50 mb-1">{ cat.Label }</p>
+					<div class="flex flex-wrap gap-1.5">
+						for _, theme := range cat.Themes {
+							<button
+								type="button"
+								:class={ "current === '" + theme + "' ? 'ring-2 ring-primary ring-offset-1' : ''" }
+								class="rounded-md overflow-hidden cursor-pointer"
+								x-on:click={ "current = '" + theme + "'; document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.dothogChannel) window.dothogChannel.postMessage({type:'theme-change',theme:current})" }
+								title={ theme }
+							>
+								<div data-theme={ theme } class="flex gap-0.5 p-1 bg-base-100">
+									<span class="w-2 h-4 rounded-sm bg-primary"></span>
+									<span class="w-2 h-4 rounded-sm bg-secondary"></span>
+									<span class="w-2 h-4 rounded-sm bg-accent"></span>
+									<span class="w-2 h-4 rounded-sm bg-neutral"></span>
+								</div>
+							</button>
+						}
+					</div>
+				</div>
+			}
 		</div>
 	</div>
 }

--- a/web/views/settings_app_templ.go
+++ b/web/views/settings_app_templ.go
@@ -81,7 +81,8 @@ func AppSettingsPage(currentTheme string, currentLayout string) templ.Component 
 	})
 }
 
-// themeDropdown renders a dropdown select for choosing a DaisyUI theme.
+// themeDropdown renders a dropdown select for choosing a DaisyUI theme,
+// grouped by light/dark category, with a visual color-swatch grid below.
 func themeDropdown(currentTheme string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -110,7 +111,7 @@ func themeDropdown(currentTheme string) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("{ current: '" + currentTheme + "' }")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 122, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 123, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -123,7 +124,7 @@ func themeDropdown(currentTheme string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs("document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.dothogChannel) window.dothogChannel.postMessage({type:'theme-change',theme:current})")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 132, Col: 398}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 133, Col: 398}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -133,49 +134,157 @@ func themeDropdown(currentTheme string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, theme := range DaisyThemes {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<option value=\"")
+		for _, cat := range ThemeCategories {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<optgroup label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(cat.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 136, Col: 19}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 136, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if theme == currentTheme {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " selected")
+			for _, theme := range cat.Themes {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<option value=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 138, Col: 28}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if theme == currentTheme {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " selected")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, ">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var8 string
+				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 138, Col: 74}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</option>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, ">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 139, Col: 13}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</option>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</optgroup>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</select></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</select></div><div class=\"mt-3\"><p class=\"text-xs text-base-content/60 mb-2\">Or pick visually:</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, cat := range ThemeCategories {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div class=\"mb-2\"><p class=\"text-xs font-medium text-base-content/50 mb-1\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(cat.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 148, Col: 73}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</p><div class=\"flex flex-wrap gap-1.5\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, theme := range cat.Themes {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<button type=\"button\" :class=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var10 string
+				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs("current === '" + theme + "' ? 'ring-2 ring-primary ring-offset-1' : ''")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 153, Col: 89}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" class=\"rounded-md overflow-hidden cursor-pointer\" x-on:click=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var11 string
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs("current = '" + theme + "'; document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.dothogChannel) window.dothogChannel.postMessage({type:'theme-change',theme:current})")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 155, Col: 428}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 string
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 156, Col: 21}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\"><div data-theme=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(theme)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings_app.templ`, Line: 158, Col: 31}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" class=\"flex gap-0.5 p-1 bg-base-100\"><span class=\"w-2 h-4 rounded-sm bg-primary\"></span> <span class=\"w-2 h-4 rounded-sm bg-secondary\"></span> <span class=\"w-2 h-4 rounded-sm bg-accent\"></span> <span class=\"w-2 h-4 rounded-sm bg-neutral\"></span></div></button>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- Replace flat `DaisyThemes` slice with `ThemeCategories` (Light/Dark groups, alphabetically sorted within each category) and derive `DaisyThemes` from it via `init()` so route validation is unchanged
- Add `<optgroup>` labels to the theme dropdown for Light/Dark sections
- Add a visual color-swatch grid below the dropdown showing primary/secondary/accent/neutral colors per theme via `data-theme`, with ring highlight on the active selection

Closes #290, closes #291

## Test plan
- [ ] Open `/settings` and verify the dropdown shows Light and Dark optgroup headers
- [ ] Verify clicking a color swatch in the grid selects that theme and applies it immediately
- [ ] Verify the active theme shows a ring highlight in the grid
- [ ] Verify theme changes persist across page reloads
- [ ] Verify `go build ./...` passes