### PR TITLE
fix: layout toggle not switching between classic and app nav

### DIFF
--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -58,7 +58,11 @@ func (ar *appRoutes) handleTheme(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 	}
 }
 
-// handleLayout updates the shared layout setting and redirects to reload.
+// handleLayout updates the shared layout setting and refreshes the page.
+// Uses HX-Refresh instead of HX-Redirect so the browser reloads the current
+// page with the new layout regardless of which page the toggle lives on.
+// Returns 200 (not 204) because HTMX 2.0 responseHandling sets swap:false for
+// 204, which can prevent response headers from being processed reliably.
 func (ar *appRoutes) handleLayout() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		layout := c.FormValue("layout")
@@ -72,12 +76,8 @@ func (ar *appRoutes) handleLayout() echo.HandlerFunc {
 				logger.WithContext(c.Request().Context()).Error("Failed to save layout setting", "error", err)
 			}
 		}
-		redirect := c.Request().Header.Get("HX-Current-URL")
-		if redirect == "" {
-			redirect = "/settings"
-		}
-		c.Response().Header().Set("HX-Redirect", redirect)
-		return c.NoContent(http.StatusNoContent)
+		c.Response().Header().Set("HX-Refresh", "true")
+		return c.String(http.StatusOK, "")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes the layout toggle on `/settings` not switching between classic (top nav) and app nav (mobile-first) layouts
- Changed `handleLayout` from returning 204 No Content with `HX-Redirect` to returning 200 with `HX-Refresh: true`
- HTMX 2.0's `responseHandling` config treats 204 with `swap: false`, which can prevent `HX-Redirect` from being processed reliably

## Details

The root cause is an HTMX 2.0 behavioral change. The default `responseHandling` configuration includes `{code: "204", swap: false}`. When combined with `hx-swap="none"` on the `<select>` element, the `HX-Redirect` response header was not being acted on after the POST to `/settings/layout`.

The fix uses `HX-Refresh: true` (which HTMX always processes before the swap decision) and returns HTTP 200 instead of 204. This also simplifies the handler by removing the `HX-Current-URL` header parsing since `HX-Refresh` reloads the current page automatically.

Closes #285

## Test plan

- [ ] Go to `/settings`, select "App Nav (mobile-first)" from the Layout dropdown
- [ ] Verify the page reloads with the bottom navigation bar layout
- [ ] Select "Classic (top nav)" and verify the page reloads with top navigation
- [ ] Verify the selected option persists after navigating away and returning to `/settings`