### PR TITLE
fix: feature-stripping build failures and missing templ generate in e2e CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -144,6 +144,9 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
 
+      - name: Generate templ files
+        run: go tool templ generate
+
       - name: Build Go binary
         run: go build -o dothog .
 

--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -2,7 +2,9 @@
 package handler
 
 import (
+	// setup:feature:session_settings:start
 	"catgoose/dothog/internal/domain"
+	// setup:feature:session_settings:end
 	"catgoose/dothog/internal/logger"
 	"catgoose/dothog/internal/routes/hypermedia"
 	"catgoose/dothog/internal/routes/middleware"
@@ -75,10 +77,8 @@ type layoutCtx struct {
 	theme     string
 	path      string
 	crumbs    []hypermedia.Breadcrumb
-	// setup:feature:demo:start
-	links []hypermedia.LinkRelation
-	hubs  []hypermedia.HubEntry
-	// setup:feature:demo:end
+	links     []hypermedia.LinkRelation
+	hubs      []hypermedia.HubEntry
 }
 
 // getLayoutCtx extracts CSRF token, theme, and breadcrumbs from the request.
@@ -108,9 +108,11 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 	}
 
 	// Priority 2: declared document hierarchy via rel="up" chain
+	// setup:feature:demo:start
 	if len(crumbs) == 0 {
 		crumbs = hypermedia.BreadcrumbsFromLinks(path)
 	}
+	// setup:feature:demo:end
 
 	// Priority 3: derive from URL path segments (last resort)
 	if len(crumbs) == 0 {
@@ -129,7 +131,16 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 	hubs := hypermedia.Hubs()
 	// setup:feature:demo:end
 
-	return layoutCtx{csrfToken: csrfToken, theme: theme, path: c.Request().URL.Path, crumbs: crumbs, links: links, hubs: hubs}
+	return layoutCtx{
+		csrfToken: csrfToken,
+		theme:     theme,
+		path:      c.Request().URL.Path,
+		crumbs:    crumbs,
+		// setup:feature:demo:start
+		links: links,
+		hubs:  hubs,
+		// setup:feature:demo:end
+	}
 }
 
 // appNavNavConfig returns a NavConfig with icons for use with the AppNavLayout.
@@ -151,6 +162,7 @@ func appNavNavConfig() hypermedia.NavConfig {
 // renderDefaultLayout is the standard dothog layout with nav, breadcrumbs, and theme.
 func renderDefaultLayout(c echo.Context, cmp templ.Component) error {
 	lc := getLayoutCtx(c)
+	// setup:feature:session_settings:start
 	settings := middleware.GetSessionSettings(c)
 	if settings.Layout == domain.LayoutApp {
 		cfg := appNavNavConfig()
@@ -161,6 +173,7 @@ func renderDefaultLayout(c echo.Context, cmp templ.Component) error {
 			lc.crumbs, lc.links, lc.path, version.Display(), lc.hubs,
 		))
 	}
+	// setup:feature:session_settings:end
 	nav := appNavComponent(c.Request().URL.Path)
 	return RenderComponent(c, views.Index(cmp, nav, lc.csrfToken, dio.Dev(), lc.theme, lc.crumbs, lc.links, lc.path, version.Display(), appName, lc.hubs))
 }

--- a/internal/routes/hypermedia/link_types.go
+++ b/internal/routes/hypermedia/link_types.go
@@ -1,0 +1,64 @@
+package hypermedia
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LinkRelation represents a relationship between two resources.
+type LinkRelation struct {
+	Rel   string // IANA link relation (e.g., "related", "collection", "up")
+	Href  string // Target URL
+	Title string // Human-readable label
+	Group string // Optional group name (e.g., ring name) for UI grouping
+}
+
+// RelEntry is a path+title pair for use with Ring and Hub.
+type RelEntry struct {
+	Path  string
+	Title string
+}
+
+// Rel creates a RelEntry for use with Ring and Hub.
+func Rel(path, title string) RelEntry {
+	return RelEntry{Path: path, Title: title}
+}
+
+// HubEntry represents a hub center with its spoke links for site map rendering.
+type HubEntry struct {
+	Path   string
+	Title  string
+	Spokes []LinkRelation
+}
+
+// TitleFromPath extracts a title from the last segment of a URL path.
+// "/demo/inventory" -> "Inventory", "/admin/error-traces" -> "Error Traces"
+func TitleFromPath(path string) string {
+	path = strings.TrimSuffix(path, "/")
+	idx := strings.LastIndex(path, "/")
+	if idx < 0 {
+		return path
+	}
+	seg := path[idx+1:]
+	seg = strings.ReplaceAll(seg, "-", " ")
+	// Title case
+	words := strings.Fields(seg)
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// LinkHeader formats link relations as an RFC 8288 Link header value.
+func LinkHeader(links []LinkRelation) string {
+	if len(links) == 0 {
+		return ""
+	}
+	parts := make([]string, len(links))
+	for i, l := range links {
+		parts[i] = fmt.Sprintf("<%s>; rel=\"%s\"; title=\"%s\"", l.Href, l.Rel, l.Title)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/routes/hypermedia/links.go
+++ b/internal/routes/hypermedia/links.go
@@ -2,19 +2,9 @@
 package hypermedia
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 	"sync"
 )
-
-// LinkRelation represents a relationship between two resources.
-type LinkRelation struct {
-	Rel   string // IANA link relation (e.g., "related", "collection", "up")
-	Href  string // Target URL
-	Title string // Human-readable label
-	Group string // Optional group name (e.g., ring name) for UI grouping
-}
 
 // linkRegistry stores registered link relations keyed by source path.
 var (
@@ -92,29 +82,6 @@ func RelatedLinksFor(path string) []LinkRelation {
 		unique = append(unique, l)
 	}
 	return unique
-}
-
-// LinkHeader formats link relations as an RFC 8288 Link header value.
-func LinkHeader(links []LinkRelation) string {
-	if len(links) == 0 {
-		return ""
-	}
-	parts := make([]string, len(links))
-	for i, l := range links {
-		parts[i] = fmt.Sprintf("<%s>; rel=\"%s\"; title=\"%s\"", l.Href, l.Rel, l.Title)
-	}
-	return strings.Join(parts, ", ")
-}
-
-// RelEntry is a path+title pair for use with Ring and Hub.
-type RelEntry struct {
-	Path  string
-	Title string
-}
-
-// Rel creates a RelEntry for use with Ring and Hub.
-func Rel(path, title string) RelEntry {
-	return RelEntry{Path: path, Title: title}
 }
 
 // Ring registers symmetric rel="related" links between all members.
@@ -206,13 +173,6 @@ func SortedPaths(links map[string][]LinkRelation) []string {
 	}
 	sort.Strings(paths)
 	return paths
-}
-
-// HubEntry represents a hub center with its spoke links for site map rendering.
-type HubEntry struct {
-	Path   string
-	Title  string
-	Spokes []LinkRelation
 }
 
 // Hubs returns all registered hub centers with their spokes, sorted by path.
@@ -317,24 +277,3 @@ func ResetForTesting() {
 	hubsMap = make(map[string]string)
 	hubsMu.Unlock()
 }
-
-// TitleFromPath extracts a title from the last segment of a URL path.
-// "/demo/inventory" -> "Inventory", "/admin/error-traces" -> "Error Traces"
-func TitleFromPath(path string) string {
-	path = strings.TrimSuffix(path, "/")
-	idx := strings.LastIndex(path, "/")
-	if idx < 0 {
-		return path
-	}
-	seg := path[idx+1:]
-	seg = strings.ReplaceAll(seg, "-", " ")
-	// Title case
-	words := strings.Fields(seg)
-	for i, w := range words {
-		if len(w) > 0 {
-			words[i] = strings.ToUpper(w[:1]) + w[1:]
-		}
-	}
-	return strings.Join(words, " ")
-}
-

--- a/magefile.go
+++ b/magefile.go
@@ -17,9 +17,7 @@ import (
 	"strings"
 	"time"
 
-	// setup:feature:demo:start
 	"catgoose/dothog/internal/setup"
-	// setup:feature:demo:end
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -675,6 +673,8 @@ func SetupTo(dest, appName string) error {
 	return nil
 }
 
+// setup:feature:demo:end
+
 // parseFeatureFlag parses the --features value.
 // "all" → all features, "none" → empty slice, otherwise comma-separated tags.
 func parseFeatureFlag(val string) []string {
@@ -716,8 +716,6 @@ func parseFeatureFlag(val string) []string {
 	}
 	return features
 }
-
-// setup:feature:demo:end
 
 // Lint runs static analysis and style checks on the codebase.
 func Lint() error {


### PR DESCRIPTION
## Summary

- **#300** — Add `go tool templ generate` step to the `e2e-test` job in `pipeline.yml` before the Go build step, matching the existing `go-test` job
- **#301** — Extract `LinkRelation`, `HubEntry`, `RelEntry`, `Rel()`, `TitleFromPath()`, and `LinkHeader()` from the demo-gated `links.go` into a new `link_types.go` (no feature marker), so these types survive demo stripping. Also gate `BreadcrumbsFromLinks` call, `domain` import, and session-settings layout logic in `handler.go`
- **#298** — Move `parseFeatureFlag` outside the `setup:feature:demo` block in `magefile.go` and un-gate the `setup` import, so the function is available after demo stripping when `mage_setup.go` calls it

Closes #298, closes #300, closes #301
Ref #207

## Test plan

- [x] `go tool templ generate` succeeds
- [x] `go build ./...` succeeds
- [x] `go test -race -timeout 2m $(go list ./... | grep -v /tests)` — all unit tests pass
- [x] `go test -timeout 5m ./tests/...` — integration tests pass (scaffolds apps with various feature combos including none, SSE-only, and demo)