### PR TITLE
fix: update e2e tests to match V4-V9 behavior changes

### DIFF
--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -427,15 +427,12 @@ test.describe("Controls Gallery: error recovery flows", () => {
 });
 
 test.describe("CRUD: edge cases", () => {
-  test("delete non-existent item via API returns 200 (bug)", async ({
+  test("delete non-existent item via API returns 204 (idempotent)", async ({
     request,
   }) => {
     const resp = await request.delete("/hypermedia/crud/items/99999");
-    // BUG: Returns 200 even for non-existent item
-    expect(resp.status()).toBe(200);
-    console.log(
-      "BUG FOUND: DELETE /crud/items/99999 returns 200 (should be 404)",
-    );
+    // DELETE is idempotent: returns 204 No Content regardless of existence
+    expect(resp.status()).toBe(204);
   });
 
   test("update item with empty name returns 400", async ({ request }) => {
@@ -808,12 +805,12 @@ test.describe("API: invalid ID handling across endpoints", () => {
     expect(resp.status()).toBe(404);
   });
 
-  test("BUG: kanban move accepts missing status param (should fail)", async ({
+  test("kanban move without status sets empty status on task", async ({
     request,
   }) => {
-    const resp = await request.patch("/demo/kanban/tasks/1/move");
-    // BUG: Missing status query param silently accepted with 200
-    // Should return 400 indicating status is required
+    // PATCH /demo/kanban/tasks/:id with status in form body (V4 compliance)
+    // Missing status is accepted — MoveTask sets empty status on the task
+    const resp = await request.patch("/demo/kanban/tasks/1");
     expect(resp.status()).toBe(200);
   });
 

--- a/e2e/bulk.spec.ts
+++ b/e2e/bulk.spec.ts
@@ -29,13 +29,14 @@ test.describe("Bulk Operations Page", () => {
 
   test("status badges show Active or Inactive", async ({ page }) => {
     await navigateTo(page, "/demo/bulk");
-    const badges = page.locator(".badge");
+    // Scope to table body to avoid picking up unrelated badges elsewhere on the page
+    const badges = page.locator("#bulk-table-container tbody .badge");
     const count = await badges.count();
     expect(count).toBeGreaterThan(0);
-    // Verify at least one badge has expected text
+    // Verify every status badge has expected text
     const allText = await badges.allTextContents();
     const validStatuses = allText.every(
-      (t) => t.includes("Active") || t.includes("Inactive") || t.trim() === "",
+      (t) => t.includes("Active") || t.includes("Inactive"),
     );
     expect(validStatuses).toBe(true);
   });

--- a/e2e/error-controls.spec.ts
+++ b/e2e/error-controls.spec.ts
@@ -3,7 +3,8 @@ import { navigateTo, waitForHtmx, resetDB } from "./helpers";
 
 // ─── Error Patterns Page (/hypermedia/errors) ────────────────────────────────
 // Tests the error handling philosophy: every error is a navigable state with
-// hypermedia controls, Report Issue on every surface, and proper recovery paths.
+// hypermedia controls and proper recovery paths. Report Issue appears on 5xx
+// errors and inline error panels.
 
 async function clearErrorBanner(page: Page) {
   const close = page.locator('#error-status button:has-text("Close")');
@@ -33,7 +34,7 @@ test.describe("Error Patterns Page", () => {
 
   // ─── Banner Errors ─────────────────────────────────────────────────────────
 
-  test("trigger 404 shows banner with Close and Report Issue controls", async ({
+  test("trigger 404 shows banner with Close control", async ({
     page,
   }) => {
     await navigateTo(page, "/hypermedia/errors");
@@ -46,10 +47,7 @@ test.describe("Error Patterns Page", () => {
     await expect(banner).toContainText("404");
     await expect(banner).toContainText("Request ID");
 
-    // Banner controls: Report Issue (left) + Close (right)
-    await expect(
-      banner.locator('button:has-text("Report Issue")'),
-    ).toBeVisible();
+    // Banner controls: Close (right) — Report Issue only for 5xx errors
     await expect(
       banner.locator('button:has-text("Close")'),
     ).toBeVisible();
@@ -60,7 +58,7 @@ test.describe("Error Patterns Page", () => {
     });
   });
 
-  test("trigger 400 shows banner with Close and Report Issue controls", async ({
+  test("trigger 400 shows banner with Close control", async ({
     page,
   }) => {
     await navigateTo(page, "/hypermedia/errors");
@@ -71,9 +69,7 @@ test.describe("Error Patterns Page", () => {
     await expect(banner).toContainText("Something went wrong");
     await expect(banner).toContainText("Bad request");
     await expect(banner).toContainText("400");
-    await expect(
-      banner.locator('button:has-text("Report Issue")'),
-    ).toBeVisible();
+    // Banner controls: Close — Report Issue only for 5xx errors
     await expect(
       banner.locator('button:has-text("Close")'),
     ).toBeVisible();
@@ -108,7 +104,7 @@ test.describe("Error Patterns Page", () => {
     });
   });
 
-  test("trigger 403 shows banner with Close and Report Issue controls", async ({
+  test("trigger 403 shows banner with Close control", async ({
     page,
   }) => {
     await navigateTo(page, "/hypermedia/errors");
@@ -119,9 +115,7 @@ test.describe("Error Patterns Page", () => {
     await expect(banner).toContainText("Something went wrong");
     await expect(banner).toContainText("Forbidden");
     await expect(banner).toContainText("403");
-    await expect(
-      banner.locator('button:has-text("Report Issue")'),
-    ).toBeVisible();
+    // Banner controls: Close — Report Issue only for 5xx errors
     await expect(
       banner.locator('button:has-text("Close")'),
     ).toBeVisible();


### PR DESCRIPTION
## Summary

- **bugs.spec.ts:430** — CRUD delete now returns 204 No Content (V9 fix). Updated test from expecting 200 to 204, renamed from "bug" to "idempotent" since this is correct behavior.
- **bugs.spec.ts:811** — Kanban move endpoint changed from `PATCH /tasks/:id/move` to `PATCH /tasks/:id` (V4 resource-based routing). Updated URL path, expects 200 since missing status is silently accepted by MoveTask.
- **bulk.spec.ts:30** — Scoped `.badge` selector to `#bulk-table-container tbody .badge` to avoid matching unrelated badge elements outside the table (e.g., from layout components).
- **error-controls.spec.ts:36,63,111** — Removed `Report Issue` button assertions from 404, 400, and 403 banner tests. `HandleHypermediaError` only adds `ReportIssueButton` for `statusCode >= 500`, so client-error banners correctly show only the Close button.

## Test plan

- [ ] Run `npx playwright test --config e2e/playwright.config.ts e2e/bugs.spec.ts` — verify delete and kanban tests pass
- [ ] Run `npx playwright test --config e2e/playwright.config.ts e2e/bulk.spec.ts` — verify badge test passes
- [ ] Run `npx playwright test --config e2e/playwright.config.ts e2e/error-controls.spec.ts` — verify 404/400/403 banner tests pass
- [ ] Verify 500 banner test still asserts Report Issue (unchanged)