### PR TITLE
fix: hide site map footer with single hub

### DIFF
--- a/web/components/core/sitemap.templ
+++ b/web/components/core/sitemap.templ
@@ -5,7 +5,7 @@ import "catgoose/dothog/internal/routes/hypermedia"
 
 // SiteMap renders a footer site map grid from the hub/spoke topology.
 templ SiteMap(hubs []hypermedia.HubEntry) {
-	if len(hubs) > 0 {
+	if len(hubs) > 1 {
 		<div class="border-t border-base-300 bg-base-200/30 px-4 py-6">
 			<div class="max-w-6xl mx-auto">
 				<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 text-sm">

--- a/web/components/core/sitemap_templ.go
+++ b/web/components/core/sitemap_templ.go
@@ -34,7 +34,7 @@ func SiteMap(hubs []hypermedia.HubEntry) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		if len(hubs) > 0 {
+		if len(hubs) > 1 {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"border-t border-base-300 bg-base-200/30 px-4 py-6\"><div class=\"max-w-6xl mx-auto\"><div class=\"grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 text-sm\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err


### PR DESCRIPTION
A site map with one hub is redundant — the context bar already covers navigation. Changed guard from `len(hubs) > 0` to `len(hubs) > 1`.