### PR TITLE
feat: add Microsoft Full Internal setup preset

### DIFF
--- a/mage_setup.go
+++ b/mage_setup.go
@@ -226,6 +226,7 @@ func Setup() error {
 var presets = map[string][]string{
 	"internal": {setup.FeatureAuth, setup.FeatureCSRF, setup.FeatureDatabase, setup.FeatureSessionSettings, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards},
 	"public":   {setup.FeatureSessionSettings, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards, setup.FeatureBrowserAPIs},
+	"microsoft-full-internal": {setup.FeatureSessionSettings, setup.FeatureCSRF, setup.FeatureAuth, setup.FeatureGraph, setup.FeatureAvatar, setup.FeatureDatabase, setup.FeatureMSSQL, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards, setup.FeatureBrowserAPIs, setup.FeatureOffline, setup.FeatureSync, setup.FeaturePWA},
 	"demo":     setup.AllFeatures,
 	"minimal":  {},
 }
@@ -308,6 +309,7 @@ func runWizard() (*setup.Options, error) {
 				Title("What are you building?").
 				Options(
 					huh.NewOption("Internal tool — auth, database, sessions, SSE, link relations, web standards", "internal"),
+					huh.NewOption("Microsoft Full Internal — auth, Graph, MSSQL, SSE, offline + sync + PWA", "microsoft-full-internal"),
 					huh.NewOption("Public site — sessions, link relations, web standards, browser APIs", "public"),
 					huh.NewOption("Demo/playground — everything enabled", "demo"),
 					huh.NewOption("Minimal — bare HTMX app", "minimal"),


### PR DESCRIPTION
## Summary

- Adds a `microsoft-full-internal` preset to the setup wizard for internal tools targeting the Microsoft stack
- Includes: sessions, CSRF, auth, Graph API, avatars, database, MSSQL, SSE, Caddy, link relations, web standards, browser APIs, offline mode, sync, and PWA
- Excludes: PostgreSQL, Capacitor (auto-included via PWA/Offline deps), and Demo content

## Test plan
- [ ] Run `mage setup` and select the new preset
- [ ] Verify all expected features are checked and dependencies auto-resolve