### PR TITLE
fix: wrap parseFeatureFlag in demo markers to prevent post-setup compile error

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -675,6 +675,8 @@ func SetupTo(dest, appName string) error {
 
 // setup:feature:demo:end
 
+// setup:feature:demo:start
+
 // parseFeatureFlag parses the --features value.
 // "all" → all features, "none" → empty slice, otherwise comma-separated tags.
 func parseFeatureFlag(val string) []string {
@@ -716,6 +718,8 @@ func parseFeatureFlag(val string) []string {
 	}
 	return features
 }
+
+// setup:feature:demo:end
 
 // Lint runs static analysis and style checks on the codebase.
 func Lint() error {


### PR DESCRIPTION
## Summary

- After `mage setup`, `internal/setup` is deleted and `mage_setup.go` is removed
- `parseFeatureFlag` in `magefile.go` references `setup.*` constants but wasn't wrapped in demo markers
- The orphaned import cleanup couldn't remove the `setup` import because `parseFeatureFlag` still referenced it
- Result: `mage watch` (and any mage command) failed with `undefined: setup`
- Fix: wrap `parseFeatureFlag` in `// setup:feature:demo:start/end` markers so it's stripped along with its only caller (`SetupTo`)

## Test plan
- [ ] Run `mage setup` with a non-demo preset
- [ ] Verify `mage watch` compiles and runs after setup