### PR TITLE
fix: move theme routes outside demo block and gate demo-only UI

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -147,18 +147,19 @@ func (ar *appRoutes) InitRoutes() error {
 	ar.initComponents3Routes()
 	// setup:feature:demo:end
 
-	// setup:feature:demo:start
 	// setup:feature:sse:start
 	broker := ssebroker.NewSSEBroker()
 	// setup:feature:sse:end
+	// setup:feature:session_settings:start
+	ar.initThemeRoutes(broker)
+	// setup:feature:session_settings:end
+
+	// setup:feature:demo:start
 	ar.initHypermediaRoutes()
 	ar.initHALRoutes()
 	ar.initErrorsRoutes()
 	// setup:feature:sse:start
 	ar.initRealtimeRoutes(broker)
-	// setup:feature:session_settings:start
-	ar.initThemeRoutes(broker)
-	// setup:feature:session_settings:end
 	// setup:feature:sse:end
 
 	db, err := demo.Open("db/demo.db")

--- a/web/views/admin_index.templ
+++ b/web/views/admin_index.templ
@@ -16,7 +16,9 @@ templ AdminIndexPage() {
 			@adminResourceCard("/admin/config", "Config", "Application configuration values. Secrets are redacted.", "M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z")
 			// setup:feature:demo:end
 			@adminResourceCard("/admin/error-traces", "Error Traces", "Captured error traces with request context for debugging.", "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z")
+			// setup:feature:demo:start
 			@adminResourceCard("/admin/error-reports", "Error Reports", "User-submitted error reports with captured context and status tracking.", "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z")
+			// setup:feature:demo:end
 			// setup:feature:session_settings:start
 			@adminResourceCard("/admin/sessions", "Sessions", "Active session settings. Theme preferences per session.", "M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z")
 			// setup:feature:session_settings:end

--- a/web/views/settings_app.templ
+++ b/web/views/settings_app.templ
@@ -1,6 +1,8 @@
 package views
 
+// setup:feature:demo:start
 import "catgoose/dothog/internal/version"
+// setup:feature:demo:end
 
 // AppSettingsPage renders the /settings page organized into collapsible sections.
 templ AppSettingsPage(currentTheme string, currentLayout string) {
@@ -98,6 +100,7 @@ templ AppSettingsPage(currentTheme string, currentLayout string) {
 				</details>
 			</div>
 		</div>
+		// setup:feature:demo:start
 		<div class="card bg-base-100 shadow-sm border border-base-300">
 			<div class="card-body">
 				<details>
@@ -114,6 +117,7 @@ templ AppSettingsPage(currentTheme string, currentLayout string) {
 				</details>
 			</div>
 		</div>
+		// setup:feature:demo:end
 	</div>
 }
 


### PR DESCRIPTION
## Summary

Fixes multiple issues in apps scaffolded without the `demo` feature:

- **`/settings/layout` returns 404** (closes #316): `initThemeRoutes(broker)` was nested inside the `setup:feature:demo` block in `routes.go`. Moved broker creation and theme route initialization outside the demo block — they only need `sse` and `session_settings` features respectively.

- **Admin Error Reports white screen**: The Error Reports card in `admin_index.templ` linked to `/admin/error-reports` which only exists when demo is selected. Wrapped the card in `setup:feature:demo` markers.

- **Settings About section**: The About card (version, architecture link, web standards link) references demo-only pages. Wrapped in `setup:feature:demo` markers along with the `version` import.

## Test plan
- [ ] Scaffold a new app with Microsoft Full Internal preset (no demo)
- [ ] Verify `/settings/layout` works (change to mobile-first layout)
- [ ] Verify `/admin` page only shows cards for routes that exist
- [ ] Verify Settings page does not show the About section
- [ ] Scaffold with demo preset and verify everything still works