### PR TITLE
fix: move Preferences page behind demo feature marker

### DIFF
--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -40,9 +40,9 @@ func appNavComponent(path string) templ.Component {
 		{Label: "Hypermedia", Href: "/hypermedia"},
 		{Label: "Demo", Href: "/demo"},
 		// setup:feature:demo:end
-		// setup:feature:session_settings:start
+		// setup:feature:demo:start
 		{Label: "Preferences", Href: "/user/settings"},
-		// setup:feature:session_settings:end
+		// setup:feature:demo:end
 		{Label: "Settings", Href: "/settings"},
 		{Label: "Admin", Href: "/admin"},
 	}, path)

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -109,8 +109,10 @@ func (ar *appRoutes) InitRoutes() error {
 	// setup:feature:demo:end
 
 	ar.e.GET("/", handler.HandleComponent(views.ArchitecturePage()))
-	// setup:feature:session_settings:start
+	// setup:feature:demo:start
 	ar.initUserSettingsRoutes()
+	// setup:feature:demo:end
+	// setup:feature:session_settings:start
 	ar.e.GET("/settings", func(c echo.Context) error {
 		s := middleware.GetSessionSettings(c)
 		return handler.RenderBaseLayout(c, views.AppSettingsPage(s.Theme, s.Layout))

--- a/internal/routes/routes_user_settings.go
+++ b/internal/routes/routes_user_settings.go
@@ -1,4 +1,4 @@
-// setup:feature:session_settings
+// setup:feature:demo
 
 package routes
 

--- a/web/views/user_settings.templ
+++ b/web/views/user_settings.templ
@@ -1,4 +1,4 @@
-// setup:feature:session_settings
+// setup:feature:demo
 
 package views
 


### PR DESCRIPTION
## Summary

- The Preferences page (`/user/settings`) is a cosmetic placeholder with in-memory storage that resets on restart
- Moved it behind `setup:feature:demo` markers so it's stripped from derived apps
- Changed file markers on `routes_user_settings.go` and `user_settings.templ` from `session_settings` to `demo`
- Moved `initUserSettingsRoutes()` call and nav item to demo markers
- The `/settings` page (theme/layout) remains under `session_settings`

## Test plan
- [ ] Scaffold without demo — verify no Preferences nav item and `/user/settings` returns 404
- [ ] Scaffold with demo — verify Preferences still works