### PR TITLE
fix: wrap Navigation settings card in demo markers

### DIFF
--- a/web/views/settings_app.templ
+++ b/web/views/settings_app.templ
@@ -39,6 +39,7 @@ templ AppSettingsPage(currentTheme string, currentLayout string) {
 				</details>
 			</div>
 		</div>
+		// setup:feature:demo:start
 		<div class="card bg-base-100 shadow-sm border border-base-300">
 			<div class="card-body">
 				<details>
@@ -100,6 +101,7 @@ templ AppSettingsPage(currentTheme string, currentLayout string) {
 				</details>
 			</div>
 		</div>
+		// setup:feature:demo:end
 		// setup:feature:demo:start
 		<div class="card bg-base-100 shadow-sm border border-base-300">
 			<div class="card-body">


### PR DESCRIPTION
## Summary

- The Navigation settings card toggles `#context-bar`, `#local-context-bar`, and `#history-breadcrumbs` elements
- These elements live in `context_bar.templ` which is marked `setup:feature:demo`
- Without demo, the elements don't exist and hyperscript throws `'#context-bar' is null` errors
- Wrapped the Navigation card in `setup:feature:demo` markers so it's stripped along with the context bars

## Test plan
- [ ] Scaffold without demo — verify Settings page has no Navigation card
- [ ] Scaffold with demo — verify Navigation toggles still work
- [ ] No more `'#context-bar' is null` hyperscript errors in console