### PR TITLE
fix: template app-specific names during setup

### DIFF
--- a/internal/routes/middleware/session_settings.go
+++ b/internal/routes/middleware/session_settings.go
@@ -30,7 +30,7 @@ type SessionIDFunc func(c echo.Context) string
 
 const (
 	settingsContextKey = "sessionSettings"
-	sessionCookieName  = "dothog_session_id"
+	sessionCookieName  = "{{BINARY_NAME}}_session_id"
 	// setup:feature:demo:start
 	// sharedSessionUUID is used for all visitors so the demo behaves as a
 	// single-user application — every browser reads/writes the same row.

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -344,6 +344,26 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		}
 	}
 
+	// Replace {{BINARY_NAME}} placeholder in JS and Go source files so that
+	// derived apps get unique cache names, IndexedDB databases, cookie names,
+	// and BroadcastChannel identifiers.
+	for _, f := range []string{
+		filepath.Join("web", "assets", "public", "js", "sw.js"),
+		filepath.Join("web", "assets", "public", "js", "sync.js"),
+		filepath.Join("web", "assets", "public", "js", "broadcast.js"),
+		filepath.Join("internal", "routes", "middleware", "session_settings.go"),
+	} {
+		p := filepath.Join(dir, f)
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		content := strings.ReplaceAll(string(data), "{{BINARY_NAME}}", binaryName)
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+
 	_ = os.Remove(filepath.Join(dir, ".golangci.yml"))
 
 	if err := removeOptionalContent(dir, opts); err != nil {

--- a/web/assets/public/js/broadcast.js
+++ b/web/assets/public/js/broadcast.js
@@ -6,7 +6,7 @@
 (function() {
   if (!('BroadcastChannel' in window)) return;
 
-  var channel = new BroadcastChannel('dothog');
+  var channel = new BroadcastChannel('{{BINARY_NAME}}');
 
   channel.onmessage = function(event) {
     var msg = event.data;
@@ -15,5 +15,5 @@
     }
   };
 
-  window.dothogChannel = channel;
+  window.appChannel = channel;
 })();

--- a/web/assets/public/js/sw.js
+++ b/web/assets/public/js/sw.js
@@ -10,7 +10,7 @@
 
 importScripts('/public/js/sync.js');
 
-const CACHE_NAME = 'dothog-v1';
+const CACHE_NAME = '{{BINARY_NAME}}-v1';
 
 // Connectivity state — updated by the main thread via postMessage
 self._isOnline = true;

--- a/web/assets/public/js/sync.js
+++ b/web/assets/public/js/sync.js
@@ -5,7 +5,7 @@
  * and regular browsers without Capacitor.
  */
 
-const DB_NAME = 'dothog_sync';
+const DB_NAME = '{{BINARY_NAME}}_sync';
 const QUEUE_STORE = 'sync_queue';
 
 /** @type {IDBDatabase|null} */

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -176,7 +176,7 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 				var es = new EventSource("/sse/theme");
 				es.addEventListener("theme-change", function(/** @type {MessageEvent} */ e) {
 					document.documentElement.dataset.theme = e.data;
-					if (window.dothogChannel) window.dothogChannel.postMessage({type:'theme-change',theme:e.data});
+					if (window.appChannel) window.appChannel.postMessage({type:'theme-change',theme:e.data});
 				});
 			})();
 		</script>

--- a/web/views/settings_app.templ
+++ b/web/views/settings_app.templ
@@ -121,7 +121,7 @@ templ themeDropdown(currentTheme string) {
 			<select
 				class="select select-bordered select-sm w-full max-w-xs capitalize"
 				x-model="current"
-				x-on:change={ "document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.dothogChannel) window.dothogChannel.postMessage({type:'theme-change',theme:current})" }
+				x-on:change={ "document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.appChannel) window.appChannel.postMessage({type:'theme-change',theme:current})" }
 			>
 				for _, cat := range ThemeCategories {
 					<optgroup label={ cat.Label }>
@@ -143,7 +143,7 @@ templ themeDropdown(currentTheme string) {
 								type="button"
 								:class={ "current === '" + theme + "' ? 'ring-2 ring-primary ring-offset-1' : ''" }
 								class="rounded-md overflow-hidden cursor-pointer"
-								x-on:click={ "current = '" + theme + "'; document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.dothogChannel) window.dothogChannel.postMessage({type:'theme-change',theme:current})" }
+								x-on:click={ "current = '" + theme + "'; document.documentElement.dataset.theme = current; var t = document.querySelector('meta[name=\"csrf-token\"]'); fetch('/settings/theme', { method: 'POST', headers: {'Content-Type': 'application/x-www-form-urlencoded', 'X-CSRF-Token': t ? t.content : ''}, body: 'theme=' + current }); if (window.appChannel) window.appChannel.postMessage({type:'theme-change',theme:current})" }
 								title={ theme }
 							>
 								<div data-theme={ theme } class="flex gap-0.5 p-1 bg-base-100">


### PR DESCRIPTION
## Summary
- Add `{{BINARY_NAME}}` placeholder to `sw.js` (cache name), `sync.js` (IndexedDB name), `session_settings.go` (cookie name), and `broadcast.js` (BroadcastChannel name)
- Setup process replaces `{{BINARY_NAME}}` with the derived binary name so derived apps get unique browser-side identifiers
- Rename `window.dothogChannel` to `window.appChannel` in templ files since the BroadcastChannel constructor already carries the app-specific name

Refs #322

## Test plan
- [ ] Run setup with a custom app name and verify `sw.js` cache name, `sync.js` DB name, `session_settings.go` cookie name, and `broadcast.js` channel name all use the derived binary name
- [ ] Verify theme changes still broadcast across tabs via BroadcastChannel
- [ ] Verify session cookie uses the templated name in a derived app