### PR TITLE
fix: auto-run npm ci when node_modules missing

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -521,7 +521,10 @@ func openBrowserURL(url string) {
 
 func nodeModulesCheck() error {
 	if _, err := os.Stat("node_modules"); os.IsNotExist(err) {
-		return errors.New("node_modules not found. Run: npm ci")
+		fmt.Println("node_modules not found, running npm ci...")
+		if err := sh.Run("npm", "ci"); err != nil {
+			return fmt.Errorf("npm ci failed: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- `nodeModulesCheck()` now automatically runs `npm ci` when `node_modules` is missing instead of returning an error with a manual instruction
- Fixes `mage watch` failing when DaisyUI can't resolve without `node_modules`

Closes #328