### PR TITLE
test: verify mage setup strips all dothog references

### DIFF
--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -595,4 +596,106 @@ func TestSetup_FeaturesDemo(t *testing.T) {
 	assertNoSetupMarkers(t, dest)
 	assertBuildSucceeds(t, dest)
 	assertDirExists(t, filepath.Join(dest, "internal", "demo"))
+}
+
+// TestSetup_NoDothogReferences runs setup with all features enabled and verifies
+// that no dothog/Dothog/DOTHOG references remain in the derived app. This catches
+// template substitution gaps where the original project name leaks through.
+func TestSetup_NoDothogReferences(t *testing.T) {
+	t.Parallel()
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+
+	dest := setupTempDir(t)
+	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	require.NoError(t, err)
+
+	// Remove setup-only files (mimics the copy flow in mage_setup.go).
+	_ = os.RemoveAll(filepath.Join(dest, "_template_setup"))
+	_ = os.RemoveAll(filepath.Join(dest, "internal", "setup"))
+	_ = os.Remove(filepath.Join(dest, "mage_setup.go"))
+	_ = os.RemoveAll(filepath.Join(dest, "tests"))
+
+	appName := "Test Clean App"
+	modulePath := "github.com/example/testcleanapp"
+
+	err = setup.Run(context.Background(), dest, setup.Options{
+		AppName:    appName,
+		ModulePath: modulePath,
+		BasePort:   "21000",
+		NoCaddy:    false,
+		Force:      true,
+		Features:   setup.AllFeatures,
+	})
+	require.NoError(t, err)
+
+	// --- Scan all files for residual dothog references ---
+	dothogRE := regexp.MustCompile(`(?i)dothog`)
+
+	// Directories and file extensions to skip.
+	skipDirs := map[string]bool{
+		".git":             true,
+		"node_modules":     true,
+		"_template_setup":  true,
+	}
+
+	var violations []string
+	err = filepath.Walk(dest, func(path string, info os.FileInfo, errWalk error) error {
+		if errWalk != nil {
+			return errWalk
+		}
+		if info.IsDir() {
+			if skipDirs[filepath.Base(path)] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Skip binary / non-text files by extension.
+		ext := strings.ToLower(filepath.Ext(path))
+		binaryExts := map[string]bool{
+			".png": true, ".jpg": true, ".jpeg": true, ".gif": true,
+			".ico": true, ".woff": true, ".woff2": true, ".ttf": true,
+			".eot": true, ".zip": true, ".gz": true, ".tar": true,
+			".exe": true, ".dll": true, ".so": true, ".dylib": true,
+			".db": true, ".sqlite": true, ".wasm": true,
+		}
+		if binaryExts[ext] {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(dest, path)
+		for i, line := range strings.Split(string(data), "\n") {
+			if dothogRE.MatchString(line) {
+				violations = append(violations, fmt.Sprintf("  %s:%d: %s", rel, i+1, strings.TrimSpace(line)))
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	if len(violations) > 0 {
+		t.Errorf("found %d residual dothog reference(s) in derived app:\n%s",
+			len(violations), strings.Join(violations, "\n"))
+	}
+
+	// --- Verify the new app name appears in key files ---
+
+	// go.mod module path
+	modBytes, err := os.ReadFile(filepath.Join(dest, "go.mod"))
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(strings.TrimSpace(string(modBytes)), "module "+modulePath),
+		"go.mod should declare module %s", modulePath)
+
+	// HTML title in the public index.html
+	indexPath := filepath.Join(dest, "web", "assets", "public", "index.html")
+	if indexBytes, readErr := os.ReadFile(indexPath); readErr == nil {
+		require.Contains(t, string(indexBytes), appName,
+			"index.html should contain the app name")
+	}
+
+	// --- Confirm the derived app compiles ---
+	assertBuildSucceeds(t, dest)
 }


### PR DESCRIPTION
## Summary

- Adds `TestSetup_NoDothogReferences` that runs `setup.Run` with all features enabled, then scans every non-binary file for residual `dothog`/`Dothog`/`DOTHOG` references (case-insensitive), skipping `.git/`, `node_modules/`, and `_template_setup/`
- Verifies the new app name appears in `go.mod` module path and `index.html` title
- Confirms the derived app compiles via `assertBuildSucceeds`
- Currently fails (expected) -- will pass once #332 fixes the remaining template substitutions

Closes #333

## Test plan

- [x] `go vet ./tests/` passes
- [x] `go test ./tests/ -run TestSetup_NoDothogReferences -v` runs and correctly detects residual dothog references
- [ ] Will pass clean once #332 is merged