### PR TITLE
fix: auto-cleanup in non-interactive setup mode

### DIFF
--- a/mage_setup.go
+++ b/mage_setup.go
@@ -107,16 +107,9 @@ func Setup() error {
 		if err := setup.Run(context.Background(), ".", *parsed); err != nil {
 			return err
 		}
-		if goModulePath() == templateModulePath {
-			return nil
-		}
-		cleanup, err := huhConfirm("Cleanup template files and setup helpers from this repo?")
-		if err != nil {
-			return err
-		}
-		if cleanup {
+		if goModulePath() != templateModulePath {
 			if err := cleanupTemplateFiles(); err != nil {
-				return err
+				fmt.Println("Warning: cleanup failed:", err)
 			}
 			fmt.Println("Template setup files removed.")
 		}


### PR DESCRIPTION
## Summary

- Skip the `huhConfirm()` cleanup prompt when running `mage setup` with CLI flags (non-interactive mode)
- Auto-cleanup template files after successful setup instead of prompting, preventing TTY failures in non-interactive contexts
- Print a warning instead of returning an error if cleanup fails

Fixes #339