### PR TITLE
fix: resolve pre-existing setup test failures

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -159,14 +159,13 @@ func (ar *appRoutes) InitRoutes() error {
 	ar.initComponents3Routes()
 	// setup:feature:demo:end
 
+	// setup:feature:demo:start
 	// setup:feature:sse:start
 	broker := ssebroker.NewSSEBroker()
 	// setup:feature:sse:end
 	// setup:feature:session_settings:start
 	ar.initThemeRoutes(broker)
 	// setup:feature:session_settings:end
-
-	// setup:feature:demo:start
 	ar.initHypermediaRoutes()
 	ar.initHALRoutes()
 	ar.initErrorsRoutes()

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -62,6 +62,7 @@ var featureDeps = map[string][]string{
 	FeatureSync:           {FeatureOffline},
 	FeatureOffline:        {FeatureCapacitor},
 	FeaturePWA:            {FeatureOffline, FeatureSync, FeatureCapacitor},
+	FeatureDemo:            {FeatureSessionSettings},
 	FeatureLinkRelations:  {FeatureSessionSettings},
 	FeatureBrowserAPIs:    {FeatureSSE},
 	FeatureWebStandards:   {FeatureSessionSettings},
@@ -170,7 +171,7 @@ func replaceDothogNames(dir, binaryName, appName string) error {
 		}
 		if info.IsDir() {
 			name := info.Name()
-			if name == ".git" || name == TemplateSetupDir || name == "node_modules" || name == "tests" {
+			if name == ".git" || name == ".claude" || name == TemplateSetupDir || name == "log" || name == "node_modules" || name == "tests" {
 				return filepath.SkipDir
 			}
 			// Skip setup package — it contains "dothog" in replacement
@@ -367,6 +368,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	if data, err := os.ReadFile(dockerfilePath); err == nil {
 		content := string(data)
 		content = strings.ReplaceAll(content, "-o /dothog", "-o /"+binaryName)
+		content = strings.ReplaceAll(content, "build /dothog", "build /"+binaryName)
 		content = strings.ReplaceAll(content, "/usr/local/bin/dothog", "/usr/local/bin/"+binaryName)
 		content = strings.ReplaceAll(content, `ENTRYPOINT ["dothog"]`, `ENTRYPOINT ["`+binaryName+`"]`)
 		content = strings.ReplaceAll(content, "SERVER_LISTEN_PORT=3000", "SERVER_LISTEN_PORT="+appTLSPort)
@@ -1095,7 +1097,7 @@ func replaceDefaultFavicons(dir string) {
 // isTextFile returns true for file extensions that may contain setup markers.
 func isTextFile(path string) bool {
 	switch filepath.Ext(path) {
-	case ".go", ".templ", ".mod", ".sum", ".toml", ".yaml", ".yml", ".json", ".js", ".ts", ".css", ".html", ".md", ".txt", ".rb":
+	case ".go", ".templ", ".mod", ".sum", ".toml", ".yaml", ".yml", ".json", ".js", ".ts", ".css", ".html", ".md", ".txt", ".rb", ".webmanifest":
 		return true
 	}
 	// Extensionless files that are known text.

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -23,7 +23,7 @@ func TestSetupReplacesAppNameAndModule(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -122,7 +122,7 @@ func TestSetupUsesRandomPortWhenPOmitted(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -316,7 +316,7 @@ func TestSetup_NoBareBinaryInGitignore(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -355,7 +355,7 @@ func TestSetup_MageSetupAndInternalSetupRemovable(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	// Remove setup-only files before running setup (mimics the copy flow in mage_setup.go)
@@ -390,7 +390,7 @@ func TestSetup_FeaturesAll(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	features := make([]string, len(setup.AllFeatures))
@@ -420,7 +420,7 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -456,7 +456,7 @@ func TestSetup_FeaturesAuthOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -494,7 +494,7 @@ func TestSetup_FeaturesDatabaseOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	// database is implicit — no need to pass it explicitly; MSSQL not selected
@@ -524,7 +524,7 @@ func TestSetup_FeaturesMSSQL(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	// database is implicit; explicitly selecting mssql adds MSSQL support
@@ -550,7 +550,7 @@ func TestSetup_FeaturesSSECaddy(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -580,7 +580,7 @@ func TestSetup_FeaturesDemo(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -607,7 +607,7 @@ func TestSetup_NoDothogReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", "bin", "build", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
 	require.NoError(t, err)
 
 	// Remove setup-only files (mimics the copy flow in mage_setup.go).
@@ -635,6 +635,8 @@ func TestSetup_NoDothogReferences(t *testing.T) {
 	// Directories and file extensions to skip.
 	skipDirs := map[string]bool{
 		".git":             true,
+		".claude":          true,
+		"log":              true,
 		"node_modules":     true,
 		"_template_setup":  true,
 	}
@@ -648,6 +650,10 @@ func TestSetup_NoDothogReferences(t *testing.T) {
 			if skipDirs[filepath.Base(path)] {
 				return filepath.SkipDir
 			}
+			return nil
+		}
+		// In a worktree .git is a file, not a directory; skip it.
+		if filepath.Base(path) == ".git" {
 			return nil
 		}
 		// Skip binary / non-text files by extension.


### PR DESCRIPTION
## Summary

- **TestSetup_FeaturesDemo**: demo feature now declares session_settings as a dependency, and SSE broker creation is nested inside the demo feature block so it gets stripped when demo is not selected
- **TestSetup_NoDothogReferences**: tests exclude gitignored directories (.claude/, log/) from copy and scan; Dockerfile COPY source path and .webmanifest files now get dothog name replacement
- **TestSetup_FeaturesSSECaddy** (bonus): also fixed by the broker nesting change above

## Test plan

- [x] `TestSetup_FeaturesDemo` passes
- [x] `TestSetup_NoDothogReferences` passes
- [x] `TestSetup_FeaturesSSECaddy` passes
- [x] All 12 setup tests pass
- [x] Full `go test ./...` passes with zero failures
- [x] `go build ./...` succeeds