### PR TITLE
fix: remove import aliases and pin porter after library extraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/catgoose/flighty v0.1.1
 	github.com/catgoose/fraggle v0.1.12
 	github.com/catgoose/linkwell v0.1.0
-	github.com/catgoose/porter v0.0.0-20260331020153-fe7a239323da
+	github.com/catgoose/porter v0.2.1
 	github.com/catgoose/tavern v0.2.0
 	github.com/charmbracelet/huh v1.0.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/catgoose/fraggle v0.1.12 h1:0yL8VmOWBcQKJL5RFt19Natgb9RUMIF4AC9WGS9Nx
 github.com/catgoose/fraggle v0.1.12/go.mod h1:cH5k1/se9azQqMj6aBgjR0iu5knl52ZxVu6wlPer+6s=
 github.com/catgoose/linkwell v0.1.0 h1:aCZogCAQD8fZ5pzx+LMRbyRHY0g3iu24PVmPTL18pOs=
 github.com/catgoose/linkwell v0.1.0/go.mod h1:7JkMf8ic5aCwQ0jeSiQl8Wa2fQGhxbQXCVLDH4aDvbM=
-github.com/catgoose/porter v0.0.0-20260331020153-fe7a239323da h1:qBA4nBrqjdbVCbrqoL4f8JmE2pZxFrkG5Pf3iWUWTLA=
-github.com/catgoose/porter v0.0.0-20260331020153-fe7a239323da/go.mod h1:2E7Kl6X8ayPkN78AddS00NfNShF68yaEnYMb0IZIEBk=
+github.com/catgoose/porter v0.2.1 h1:yl68arIdYhvnhyBLEpEt+DfDGIaa81yoY75dytNRXH4=
+github.com/catgoose/porter v0.2.1/go.mod h1:2E7Kl6X8ayPkN78AddS00NfNShF68yaEnYMb0IZIEBk=
 github.com/catgoose/promolog v0.2.5 h1:AIf1tG9rPMfyTgGepplcSS9ih6EsCCh5y6EWe9J7wx0=
 github.com/catgoose/promolog v0.2.5/go.mod h1:GbcuVryWlVefxM2jbOSyBd4R7mxoMky0i5eV+cAAfJk=
 github.com/catgoose/tavern v0.2.0 h1:vllwfeTksuhwaYK+KqTct6txnFSdqAeEOWeni0W9Ax8=

--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -3,7 +3,7 @@ package handler
 
 import (
 	"catgoose/dothog/internal/logger"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/middleware"
 	"catgoose/dothog/internal/version"
 	"catgoose/dothog/web/views"
@@ -33,7 +33,7 @@ func SetPageLabel(c echo.Context, label string) {
 
 // appNavComponent builds the NavBar with the active item set for the given path
 func appNavComponent(path string) templ.Component {
-	items := hypermedia.SetActiveNavItemPrefix([]hypermedia.NavItem{
+	items := linkwell.SetActiveNavItemPrefix([]linkwell.NavItem{
 		// setup:feature:demo:start
 		{Label: "Home", Href: "/"},
 		{Label: "Dashboard", Href: "/dashboard"},
@@ -76,9 +76,9 @@ type layoutCtx struct {
 	csrfToken string
 	theme     string
 	path      string
-	crumbs    []hypermedia.Breadcrumb
-	links     []hypermedia.LinkRelation
-	hubs      []hypermedia.HubEntry
+	crumbs    []linkwell.Breadcrumb
+	links     []linkwell.LinkRelation
+	hubs      []linkwell.HubEntry
 }
 
 // getLayoutCtx extracts CSRF token, theme, and breadcrumbs from the request.
@@ -97,20 +97,20 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 	theme = porter.GetSessionSettings(c).Theme
 	// setup:feature:session_settings:end
 
-	var crumbs []hypermedia.Breadcrumb
+	var crumbs []linkwell.Breadcrumb
 	path := c.Request().URL.Path
 	from := c.QueryParam("from")
 
 	// Priority 1: explicit navigation context via ?from= bitmask
-	if mask := hypermedia.ParseFromParam(from); mask != 0 {
+	if mask := linkwell.ParseFromParam(from); mask != 0 {
 		pathCrumbs := buildPathCrumbs(path, from, getRoutes)
-		crumbs = append(hypermedia.ResolveFromMask(mask), pathCrumbs...)
+		crumbs = append(linkwell.ResolveFromMask(mask), pathCrumbs...)
 	}
 
 	// Priority 2: declared document hierarchy via rel="up" chain
 	// setup:feature:demo:start
 	if len(crumbs) == 0 {
-		crumbs = hypermedia.BreadcrumbsFromLinks(path)
+		crumbs = linkwell.BreadcrumbsFromLinks(path)
 	}
 	// setup:feature:demo:end
 
@@ -118,7 +118,7 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 	if len(crumbs) == 0 {
 		pathCrumbs := buildPathCrumbs(path, from, getRoutes)
 		if len(pathCrumbs) > 1 {
-			crumbs = append([]hypermedia.Breadcrumb{{Label: hypermedia.BreadcrumbLabelHome, Href: "/"}}, pathCrumbs...)
+			crumbs = append([]linkwell.Breadcrumb{{Label: linkwell.BreadcrumbLabelHome, Href: "/"}}, pathCrumbs...)
 		}
 	}
 
@@ -128,7 +128,7 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 
 	// setup:feature:demo:start
 	links := middleware.GetLinkRelations(c)
-	hubs := hypermedia.Hubs()
+	hubs := linkwell.Hubs()
 	// setup:feature:demo:end
 
 	return layoutCtx{
@@ -144,10 +144,10 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 }
 
 // appNavNavConfig returns a NavConfig with icons for use with the AppNavLayout.
-func appNavNavConfig() hypermedia.NavConfig {
-	return hypermedia.NavConfig{
+func appNavNavConfig() linkwell.NavConfig {
+	return linkwell.NavConfig{
 		AppName: appName,
-		Items: []hypermedia.NavItem{
+		Items: []linkwell.NavItem{
 			// setup:feature:demo:start
 			{Label: "Home", Href: "/", Icon: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"},
 			{Label: "Dashboard", Href: "/dashboard", Icon: "M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"},
@@ -165,7 +165,7 @@ func appNavNavConfig() hypermedia.NavConfig {
 func renderDefaultLayout(c echo.Context, cmp templ.Component) error {
 	lc := getLayoutCtx(c)
 	cfg := appNavNavConfig()
-	cfg.Items = hypermedia.SetActiveNavItemPrefix(cfg.Items, lc.path)
+	cfg.Items = linkwell.SetActiveNavItemPrefix(cfg.Items, lc.path)
 	return RenderComponent(c, views.AppNavLayout(
 		cmp, cfg,
 		lc.csrfToken, dio.Dev(), lc.theme,
@@ -175,11 +175,11 @@ func renderDefaultLayout(c echo.Context, cmp templ.Component) error {
 
 // AppNavLayoutFunc returns a LayoutFunc that uses the responsive app-nav layout.
 // The NavConfig defines navigation structure and optional custom slots.
-func AppNavLayoutFunc(cfg hypermedia.NavConfig) LayoutFunc {
+func AppNavLayoutFunc(cfg linkwell.NavConfig) LayoutFunc {
 	return func(c echo.Context, cmp templ.Component) error {
 		path := c.Request().URL.Path
 		navCfg := cfg
-		navCfg.Items = hypermedia.SetActiveNavItemPrefix(cfg.Items, path)
+		navCfg.Items = linkwell.SetActiveNavItemPrefix(cfg.Items, path)
 		if navCfg.MaxVisible <= 0 {
 			navCfg.MaxVisible = len(navCfg.Items)
 		}
@@ -218,7 +218,7 @@ func InitRouteSet(e *echo.Echo, name string) {
 // linked breadcrumb; segments with no route are silently skipped. The terminal
 // segment always appears (unlinked). The from param is forwarded on
 // intermediate links.
-func buildPathCrumbs(path, from string, routes map[string]bool) []hypermedia.Breadcrumb {
+func buildPathCrumbs(path, from string, routes map[string]bool) []linkwell.Breadcrumb {
 	trimmed := strings.Trim(path, "/")
 	if trimmed == "" {
 		return nil
@@ -228,7 +228,7 @@ func buildPathCrumbs(path, from string, routes map[string]bool) []hypermedia.Bre
 		return nil
 	}
 
-	var crumbs []hypermedia.Breadcrumb
+	var crumbs []linkwell.Breadcrumb
 	// Intermediate segments: only include if the path is a real route.
 	for i := 0; i < len(segments)-1; i++ {
 		fullPath := "/" + strings.Join(segments[:i+1], "/")
@@ -239,9 +239,9 @@ func buildPathCrumbs(path, from string, routes map[string]bool) []hypermedia.Bre
 		if len(label) > 0 {
 			label = strings.ToUpper(label[:1]) + label[1:]
 		}
-		crumbs = append(crumbs, hypermedia.Breadcrumb{
+		crumbs = append(crumbs, linkwell.Breadcrumb{
 			Label: label,
-			Href:  hypermedia.FromNav(fullPath, from),
+			Href:  linkwell.FromNav(fullPath, from),
 		})
 	}
 
@@ -250,7 +250,7 @@ func buildPathCrumbs(path, from string, routes map[string]bool) []hypermedia.Bre
 	if len(terminal) > 0 {
 		terminal = strings.ToUpper(terminal[:1]) + terminal[1:]
 	}
-	crumbs = append(crumbs, hypermedia.Breadcrumb{Label: terminal})
+	crumbs = append(crumbs, linkwell.Breadcrumb{Label: terminal})
 	return crumbs
 }
 
@@ -287,17 +287,17 @@ func HandleError(c echo.Context, statusCode int, message string, err error) erro
 // from handler arguments and returns it for the middleware to render.
 // When no controls are supplied, sensible defaults are provided based on the
 // status code so that every error response is a navigable hypermedia state.
-func HandleHypermediaError(c echo.Context, statusCode int, message string, err error, controls ...hypermedia.Control) error {
+func HandleHypermediaError(c echo.Context, statusCode int, message string, err error, controls ...linkwell.Control) error {
 	if len(controls) == 0 {
-		opts := hypermedia.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
-		controls = hypermedia.ErrorControlsForStatus(statusCode, opts)
+		opts := linkwell.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
+		controls = linkwell.ErrorControlsForStatus(statusCode, opts)
 		if statusCode >= 500 {
 			requestID := middleware.GetRequestID(c)
-			controls = append(controls, hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID))
+			controls = append(controls, linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID))
 		}
 	}
 	ec := middleware.HypermediaError(c, statusCode, message, err, controls...)
-	return hypermedia.NewHTTPError(ec)
+	return linkwell.NewHTTPError(ec)
 }
 
 // HandleNotFound renders a full-page 404 within the base layout for direct

--- a/internal/routes/handler/handler_test.go
+++ b/internal/routes/handler/handler_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"catgoose/dothog/internal/logger"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 
 	"github.com/a-h/templ"
 	"github.com/catgoose/promolog"
@@ -98,11 +98,11 @@ func TestDefaultControls_ExplicitControlsOverride(t *testing.T) {
 	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
 	c = e.NewContext(c.Request(), c.Response().Writer.(*httptest.ResponseRecorder))
 
-	custom := hypermedia.RetryButton("Try Again", hypermedia.HxMethodGet, "/retry", "#target")
+	custom := linkwell.RetryButton("Try Again", linkwell.HxMethodGet, "/retry", "#target")
 	err := HandleHypermediaError(c, 500, "fail", errors.New("test"), custom)
 	require.Error(t, err)
 
-	var hhe *hypermedia.HTTPError
+	var hhe *linkwell.HTTPError
 	require.True(t, errors.As(err, &hhe))
 	require.Len(t, hhe.EC.Controls, 1)
 	assert.Equal(t, "Try Again", hhe.EC.Controls[0].Label)

--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -10,8 +10,8 @@ import (
 	"github.com/catgoose/porter"
 	// setup:feature:session_settings:end
 	"github.com/catgoose/promolog"
-	hypermedia "github.com/catgoose/linkwell"
-	response "github.com/catgoose/flighty"
+	"github.com/catgoose/linkwell"
+	"github.com/catgoose/flighty"
 	corecomponents "catgoose/dothog/web/components/core"
 
 	"github.com/a-h/templ"
@@ -34,14 +34,14 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 	)
 	log.Error("Request error", "error", err)
 
-	opts := hypermedia.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
-	controls := hypermedia.ErrorControlsForStatus(statusCode, opts)
+	opts := linkwell.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
+	controls := linkwell.ErrorControlsForStatus(statusCode, opts)
 	if statusCode >= 500 {
-		controls = append(controls, hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID))
+		controls = append(controls, linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID))
 	}
 
 	if c.Request().Header.Get("HX-Request") == "true" {
-		ec := hypermedia.ErrorContext{
+		ec := linkwell.ErrorContext{
 			StatusCode: statusCode,
 			Message:    message,
 			Err:        err,
@@ -51,12 +51,12 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 			Controls:   controls,
 		}
 		if ec.OOBTarget == "" {
-			ec.OOBTarget = hypermedia.DefaultErrorStatusTarget
+			ec.OOBTarget = linkwell.DefaultErrorStatusTarget
 		}
 		if ec.OOBSwap == "" {
 			ec.OOBSwap = "innerHTML"
 		}
-		return response.New(c).
+		return flighty.New(c).
 			Status(statusCode).
 			Component(templ.NopComponent).
 			OOB(corecomponents.ErrorStatusFromContext(ec)).
@@ -64,7 +64,7 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 	}
 
 	// Non-HTMX: render a full HATEOAS error page with navigation controls
-	ec := hypermedia.ErrorContext{
+	ec := linkwell.ErrorContext{
 		StatusCode: statusCode,
 		Message:    message,
 		Err:        err,
@@ -79,7 +79,7 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 
 // handleErrorWithContext renders a full hypermedia error response from an ErrorContext.
 // For HTMX requests the error banner is always delivered as an OOB swap to #error-status.
-func handleErrorWithContext(c echo.Context, ec hypermedia.ErrorContext) error {
+func handleErrorWithContext(c echo.Context, ec linkwell.ErrorContext) error {
 	if errors.Is(c.Request().Context().Err(), context.Canceled) {
 		return nil
 	}
@@ -102,12 +102,12 @@ func handleErrorWithContext(c echo.Context, ec hypermedia.ErrorContext) error {
 
 	// HTMX: deliver error banner via OOB swap
 	if ec.OOBTarget == "" {
-		ec.OOBTarget = hypermedia.DefaultErrorStatusTarget
+		ec.OOBTarget = linkwell.DefaultErrorStatusTarget
 	}
 	if ec.OOBSwap == "" {
 		ec.OOBSwap = "innerHTML"
 	}
-	return response.New(c).
+	return flighty.New(c).
 		Status(ec.StatusCode).
 		Component(templ.NopComponent).
 		OOB(corecomponents.ErrorStatusFromContext(ec)).
@@ -122,7 +122,7 @@ func NewHTTPErrorHandler(reqLogStore *promolog.Store) func(err error, c echo.Con
 	return func(err error, c echo.Context) {
 		// Determine status code from error type before promoting.
 		statusCode := http.StatusInternalServerError
-		var hhe *hypermedia.HTTPError
+		var hhe *linkwell.HTTPError
 		var he *echo.HTTPError
 		if errors.As(err, &hhe) {
 			statusCode = hhe.EC.StatusCode

--- a/internal/routes/middleware/error_handler_test.go
+++ b/internal/routes/middleware/error_handler_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"catgoose/dothog/internal/logger"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 
 	"github.com/catgoose/promolog"
 	"github.com/labstack/echo/v4"
@@ -94,20 +94,20 @@ func TestHTTPErrorHandler_EchoHTTPError_NonHTMX(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// 4. hypermedia.HTTPError with HTMX — returns HTML with controls rendered
+// 4. linkwell.HTTPError with HTMX — returns HTML with controls rendered
 // ---------------------------------------------------------------------------
 
 func TestHTTPErrorHandler_HypermediaHTTPError(t *testing.T) {
 	e := setupEcho(nil)
 	e.GET("/test", func(c echo.Context) error {
-		he := hypermedia.NewHTTPError(hypermedia.ErrorContext{
+		he := linkwell.NewHTTPError(linkwell.ErrorContext{
 			StatusCode: 404,
 			Message:    "not found",
 			Route:      "/test",
 			Closable:   true,
-			Controls: []hypermedia.Control{
-				hypermedia.BackButton("Go back"),
-				hypermedia.GoHomeButton("Home", "/", "#main"),
+			Controls: []linkwell.Control{
+				linkwell.BackButton("Go back"),
+				linkwell.GoHomeButton("Home", "/", "#main"),
 			},
 		})
 		return he
@@ -127,19 +127,19 @@ func TestHTTPErrorHandler_HypermediaHTTPError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// 5. hypermedia.HTTPError without HTMX — returns full HTML error page
+// 5. linkwell.HTTPError without HTMX — returns full HTML error page
 // ---------------------------------------------------------------------------
 
 func TestHTTPErrorHandler_HypermediaHTTPError_NonHTMX(t *testing.T) {
 	e := setupEcho(nil)
 	e.GET("/test", func(c echo.Context) error {
-		he := hypermedia.NewHTTPError(hypermedia.ErrorContext{
+		he := linkwell.NewHTTPError(linkwell.ErrorContext{
 			StatusCode: 403,
 			Message:    "forbidden",
 			Route:      "/test",
 			Closable:   true,
-			Controls: []hypermedia.Control{
-				hypermedia.BackButton("Go back"),
+			Controls: []linkwell.Control{
+				linkwell.BackButton("Go back"),
 			},
 		})
 		return he

--- a/internal/routes/middleware/errors.go
+++ b/internal/routes/middleware/errors.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 
 	"github.com/labstack/echo/v4"
 )
@@ -12,19 +12,19 @@ import (
 // from echo contexts
 
 // errorOpts returns the default ErrorControlOpts for convenience error helpers.
-func errorOpts() hypermedia.ErrorControlOpts {
-	return hypermedia.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
+func errorOpts() linkwell.ErrorControlOpts {
+	return linkwell.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
 }
 
-// newError builds a hypermedia.HTTPError with controls dispatched from ErrorControlsForStatus.
+// newError builds a linkwell.HTTPError with controls dispatched from ErrorControlsForStatus.
 // For 500+ errors, a ReportIssueButton is appended.
 func newError(c echo.Context, statusCode int, message string) error {
 	requestID := GetRequestID(c)
-	controls := hypermedia.ErrorControlsForStatus(statusCode, errorOpts())
+	controls := linkwell.ErrorControlsForStatus(statusCode, errorOpts())
 	if statusCode >= 500 {
-		controls = append(controls, hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID))
+		controls = append(controls, linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID))
 	}
-	ec := hypermedia.ErrorContext{
+	ec := linkwell.ErrorContext{
 		StatusCode: statusCode,
 		Message:    message,
 		Route:      c.Request().URL.Path,
@@ -32,7 +32,7 @@ func newError(c echo.Context, statusCode int, message string) error {
 		Closable:   true,
 		Controls:   controls,
 	}
-	return hypermedia.NewHTTPError(ec)
+	return linkwell.NewHTTPError(ec)
 }
 
 // BadRequest returns a 400 Bad Request error
@@ -71,12 +71,12 @@ func ServiceUnavailable(c echo.Context, message string) error {
 	return newError(c, http.StatusServiceUnavailable, message)
 }
 
-// HypermediaError builds a hypermedia.ErrorContext populated with request metadata
-// (route, requestID) from the echo context. Pass the result to hypermedia.NewHTTPError
-// to return it from a handler, or to response.Builder.OOBErrorStatus to compose it
+// HypermediaError builds a linkwell.ErrorContext populated with request metadata
+// (route, requestID) from the echo context. Pass the result to linkwell.NewHTTPError
+// to return it from a handler, or to flighty.Builder.OOBErrorStatus to compose it
 // alongside a primary component.
-func HypermediaError(c echo.Context, statusCode int, message string, err error, controls ...hypermedia.Control) hypermedia.ErrorContext {
-	return hypermedia.ErrorContext{
+func HypermediaError(c echo.Context, statusCode int, message string, err error, controls ...linkwell.Control) linkwell.ErrorContext {
+	return linkwell.ErrorContext{
 		StatusCode: statusCode,
 		Message:    message,
 		Err:        err,

--- a/internal/routes/middleware/helpers_test.go
+++ b/internal/routes/middleware/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 
 	"github.com/a-h/templ"
 	"github.com/labstack/echo/v4"
@@ -35,7 +35,7 @@ func TestBadRequest(t *testing.T) {
 
 	err := BadRequest(c, "invalid input")
 
-	var he *hypermedia.HTTPError
+	var he *linkwell.HTTPError
 	require.ErrorAs(t, err, &he)
 	require.Equal(t, http.StatusBadRequest, he.EC.StatusCode)
 	require.Equal(t, "invalid input", he.EC.Message)
@@ -46,7 +46,7 @@ func TestUnauthorized(t *testing.T) {
 
 	err := Unauthorized(c, "login required")
 
-	var he *hypermedia.HTTPError
+	var he *linkwell.HTTPError
 	require.ErrorAs(t, err, &he)
 	require.Equal(t, http.StatusUnauthorized, he.EC.StatusCode)
 	require.Equal(t, "login required", he.EC.Message)
@@ -57,7 +57,7 @@ func TestForbidden(t *testing.T) {
 
 	err := Forbidden(c, "access denied")
 
-	var he *hypermedia.HTTPError
+	var he *linkwell.HTTPError
 	require.ErrorAs(t, err, &he)
 	require.Equal(t, http.StatusForbidden, he.EC.StatusCode)
 	require.Equal(t, "access denied", he.EC.Message)
@@ -68,7 +68,7 @@ func TestNotFound(t *testing.T) {
 
 	err := NotFound(c, "resource missing")
 
-	var he *hypermedia.HTTPError
+	var he *linkwell.HTTPError
 	require.ErrorAs(t, err, &he)
 	require.Equal(t, http.StatusNotFound, he.EC.StatusCode)
 	require.Equal(t, "resource missing", he.EC.Message)
@@ -79,7 +79,7 @@ func TestInternalServerError(t *testing.T) {
 
 	err := InternalServerError(c, "something broke")
 
-	var he *hypermedia.HTTPError
+	var he *linkwell.HTTPError
 	require.ErrorAs(t, err, &he)
 	require.Equal(t, http.StatusInternalServerError, he.EC.StatusCode)
 	require.Equal(t, "something broke", he.EC.Message)
@@ -90,7 +90,7 @@ func TestServiceUnavailable(t *testing.T) {
 
 	err := ServiceUnavailable(c, "try again later")
 
-	var he *hypermedia.HTTPError
+	var he *linkwell.HTTPError
 	require.ErrorAs(t, err, &he)
 	require.Equal(t, http.StatusServiceUnavailable, he.EC.StatusCode)
 	require.Equal(t, "try again later", he.EC.Message)
@@ -99,7 +99,7 @@ func TestServiceUnavailable(t *testing.T) {
 func TestHypermediaError(t *testing.T) {
 	c, _ := newTestContext(http.MethodGet, "/items/42")
 
-	ctrl := hypermedia.BackButton("Go back")
+	ctrl := linkwell.BackButton("Go back")
 	ec := HypermediaError(c, http.StatusNotFound, "item not found", nil, ctrl)
 
 	require.Equal(t, http.StatusNotFound, ec.StatusCode)
@@ -107,7 +107,7 @@ func TestHypermediaError(t *testing.T) {
 	require.Equal(t, "/items/42", ec.Route)
 	require.True(t, ec.Closable)
 	require.Len(t, ec.Controls, 1)
-	require.Equal(t, hypermedia.ControlKindBack, ec.Controls[0].Kind)
+	require.Equal(t, linkwell.ControlKindBack, ec.Controls[0].Kind)
 	require.Equal(t, "Go back", ec.Controls[0].Label)
 	require.Nil(t, ec.Err)
 	// RequestID is empty because RequestIDMiddleware was not applied
@@ -131,15 +131,15 @@ func TestHypermediaError_WithWrappedError(t *testing.T) {
 func TestHypermediaError_MultipleControls(t *testing.T) {
 	c, _ := newTestContext(http.MethodGet, "/admin")
 
-	ctrls := []hypermedia.Control{
-		hypermedia.BackButton("Back"),
-		hypermedia.GoHomeButton("Home", "/", "#main"),
+	ctrls := []linkwell.Control{
+		linkwell.BackButton("Back"),
+		linkwell.GoHomeButton("Home", "/", "#main"),
 	}
 	ec := HypermediaError(c, http.StatusForbidden, "denied", nil, ctrls...)
 
 	require.Len(t, ec.Controls, 2)
-	require.Equal(t, hypermedia.ControlKindBack, ec.Controls[0].Kind)
-	require.Equal(t, hypermedia.ControlKindHome, ec.Controls[1].Kind)
+	require.Equal(t, linkwell.ControlKindBack, ec.Controls[0].Kind)
+	require.Equal(t, linkwell.ControlKindHome, ec.Controls[1].Kind)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/routes/middleware/links.go
+++ b/internal/routes/middleware/links.go
@@ -2,7 +2,7 @@
 package middleware
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 
 	"github.com/labstack/echo/v4"
 )
@@ -14,9 +14,9 @@ func LinkRelationsMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			path := c.Request().URL.Path
-			links := hypermedia.LinksFor(path)
+			links := linkwell.LinksFor(path)
 			if len(links) > 0 {
-				c.Response().Header().Set("Link", hypermedia.LinkHeader(links))
+				c.Response().Header().Set("Link", linkwell.LinkHeader(links))
 				c.Set("link_relations", links)
 			}
 			return next(c)
@@ -25,9 +25,9 @@ func LinkRelationsMiddleware() echo.MiddlewareFunc {
 }
 
 // GetLinkRelations retrieves link relations from the echo context.
-func GetLinkRelations(c echo.Context) []hypermedia.LinkRelation {
+func GetLinkRelations(c echo.Context) []linkwell.LinkRelation {
 	if v := c.Get("link_relations"); v != nil {
-		if links, ok := v.([]hypermedia.LinkRelation); ok {
+		if links, ok := v.([]linkwell.LinkRelation); ok {
 			return links
 		}
 	}

--- a/internal/routes/middleware/links_test.go
+++ b/internal/routes/middleware/links_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -14,14 +14,14 @@ import (
 
 func resetLinks(t *testing.T) {
 	t.Helper()
-	t.Cleanup(hypermedia.ResetForTesting)
-	hypermedia.ResetForTesting()
+	t.Cleanup(linkwell.ResetForTesting)
+	linkwell.ResetForTesting()
 }
 
 func TestLinkRelationsMiddleware_LinkHeaderPresent(t *testing.T) {
 	resetLinks(t)
 
-	hypermedia.Link("/items", "related", "/items/new", "New Item")
+	linkwell.Link("/items", "related", "/items/new", "New Item")
 
 	c, rec := newTestContext(http.MethodGet, "/items")
 
@@ -40,11 +40,11 @@ func TestLinkRelationsMiddleware_LinkHeaderPresent(t *testing.T) {
 func TestLinkRelationsMiddleware_ContextHasLinks(t *testing.T) {
 	resetLinks(t)
 
-	hypermedia.Link("/items", "related", "/items/new", "New Item")
+	linkwell.Link("/items", "related", "/items/new", "New Item")
 
 	c, _ := newTestContext(http.MethodGet, "/items")
 
-	var captured []hypermedia.LinkRelation
+	var captured []linkwell.LinkRelation
 	mw := LinkRelationsMiddleware()
 	handler := mw(func(c echo.Context) error {
 		captured = GetLinkRelations(c)
@@ -63,7 +63,7 @@ func TestLinkRelationsMiddleware_NoLinksForPath(t *testing.T) {
 
 	c, rec := newTestContext(http.MethodGet, "/unknown")
 
-	var captured []hypermedia.LinkRelation
+	var captured []linkwell.LinkRelation
 	mw := LinkRelationsMiddleware()
 	handler := mw(func(c echo.Context) error {
 		captured = GetLinkRelations(c)
@@ -84,7 +84,7 @@ func TestGetLinkRelations_ReturnsNilWhenNotSet(t *testing.T) {
 
 func TestGetLinkRelations_ReturnsLinksFromContext(t *testing.T) {
 	c, _ := newTestContext(http.MethodGet, "/")
-	expected := []hypermedia.LinkRelation{
+	expected := []linkwell.LinkRelation{
 		{Rel: "related", Href: "/b", Title: "B"},
 	}
 	c.Set("link_relations", expected)

--- a/internal/routes/middleware/status.go
+++ b/internal/routes/middleware/status.go
@@ -3,9 +3,9 @@ package middleware
 import (
 	"net/http"
 
-	htmxpkg "github.com/catgoose/cheddar"
-	hypermedia "github.com/catgoose/linkwell"
-	response "github.com/catgoose/flighty"
+	"github.com/catgoose/cheddar"
+	"github.com/catgoose/linkwell"
+	"github.com/catgoose/flighty"
 	corecomponents "catgoose/dothog/web/components/core"
 
 	"github.com/a-h/templ"
@@ -13,34 +13,34 @@ import (
 )
 
 // Created returns a 201 builder. Chain PushURL, TriggerEvent, etc. as needed.
-func Created(c echo.Context, cmp templ.Component) *response.Builder {
-	return response.New(c).Status(http.StatusCreated).Component(cmp)
+func Created(c echo.Context, cmp templ.Component) *flighty.Builder {
+	return flighty.New(c).Status(http.StatusCreated).Component(cmp)
 }
 
 // Accepted returns a 202 builder.
-func Accepted(c echo.Context, cmp templ.Component) *response.Builder {
-	return response.New(c).Status(http.StatusAccepted).Component(cmp)
+func Accepted(c echo.Context, cmp templ.Component) *flighty.Builder {
+	return flighty.New(c).Status(http.StatusAccepted).Component(cmp)
 }
 
 // NoContent sends a 204 response with HX-Reswap: none so HTMX performs no swap.
 func NoContent(c echo.Context) error {
-	c.Response().Header().Set(htmxpkg.HeaderReswap, string(htmxpkg.SwapNone))
+	c.Response().Header().Set(cheddar.HeaderReswap, string(cheddar.SwapNone))
 	c.Response().WriteHeader(http.StatusNoContent)
 	return nil
 }
 
 // SeeOther sends a 303 redirect via HX-Redirect for HTMX requests.
 func SeeOther(c echo.Context, url string) error {
-	c.Response().Header().Set(htmxpkg.HeaderRedirect, url)
+	c.Response().Header().Set(cheddar.HeaderRedirect, url)
 	c.Response().WriteHeader(http.StatusSeeOther)
 	return nil
 }
 
 // UnprocessableEntity returns a 422 builder pre-loaded with an error panel component.
 // Append additional OOB swaps or triggers via the returned builder before calling Send().
-func UnprocessableEntity(c echo.Context, msg string, controls ...hypermedia.Control) *response.Builder {
+func UnprocessableEntity(c echo.Context, msg string, controls ...linkwell.Control) *flighty.Builder {
 	ec := HypermediaError(c, http.StatusUnprocessableEntity, msg, nil, controls...)
-	return response.New(c).
+	return flighty.New(c).
 		Status(http.StatusUnprocessableEntity).
 		Component(corecomponents.ErrorStatusFromContext(ec))
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -8,13 +8,15 @@ import (
 	"catgoose/dothog/internal/demo"
 	// setup:feature:demo:end
 	// setup:feature:sse:start
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	// setup:feature:sse:end
 	"catgoose/dothog/internal/health"
 	"catgoose/dothog/internal/version"
 	"github.com/catgoose/promolog"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	// setup:feature:demo:start
+	"github.com/catgoose/linkwell"
+	// setup:feature:demo:end
 	"catgoose/dothog/web/views"
 	"catgoose/dothog/internal/routes/middleware"
 	// setup:feature:session_settings:start
@@ -72,7 +74,7 @@ type appRoutes struct {
 	demoDB *demo.DB
 	// setup:feature:demo:end
 	// setup:feature:sse:start
-	broker *ssebroker.SSEBroker
+	broker *tavern.SSEBroker
 	// setup:feature:sse:end
 }
 
@@ -108,7 +110,7 @@ func (ar *appRoutes) InitRoutes() error {
 	// Register known origins for ?from= breadcrumb resolution.
 	// Home (bit 0) is pre-registered. Additional pages register here.
 	// setup:feature:demo:start
-	hypermedia.RegisterFrom(hypermedia.FromDashboard, hypermedia.Breadcrumb{Label: "Dashboard", Href: "/dashboard"})
+	linkwell.RegisterFrom(linkwell.FromDashboard, linkwell.Breadcrumb{Label: "Dashboard", Href: "/dashboard"})
 	// setup:feature:demo:end
 
 	cfg, err := config.GetConfig()
@@ -164,7 +166,7 @@ func (ar *appRoutes) InitRoutes() error {
 
 	// setup:feature:demo:start
 	// setup:feature:sse:start
-	ar.broker = ssebroker.NewSSEBroker()
+	ar.broker = tavern.NewSSEBroker()
 	// setup:feature:sse:end
 	// setup:feature:session_settings:start
 	ar.initThemeRoutes(ar.broker)
@@ -187,7 +189,7 @@ func (ar *appRoutes) InitRoutes() error {
 	ar.demoDB = db
 	if stored, err := db.ListStoredLinks(); err == nil {
 		for _, s := range stored {
-			hypermedia.LoadStoredLink(s.Source, hypermedia.LinkRelation{
+			linkwell.LoadStoredLink(s.Source, linkwell.LinkRelation{
 				Rel:   s.Rel,
 				Href:  s.Target,
 				Title: s.Title,

--- a/internal/routes/routes_admin.go
+++ b/internal/routes/routes_admin.go
@@ -7,7 +7,7 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -16,10 +16,10 @@ import (
 type adminRoutes struct {
 	db     *demo.DB
 	actLog *demo.ActivityLog
-	broker *ssebroker.SSEBroker
+	broker *tavern.SSEBroker
 }
 
-func (ar *appRoutes) initAdminRoutes(db *demo.DB, actLog *demo.ActivityLog, broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initAdminRoutes(db *demo.DB, actLog *demo.ActivityLog, broker *tavern.SSEBroker) {
 	a := &adminRoutes{db: db, actLog: actLog, broker: broker}
 	ar.e.GET("/admin/sqlite", a.handleAdminPage)
 	ar.e.POST("/admin/db/reinit", a.handleReinit)

--- a/internal/routes/routes_admin_error_reports.go
+++ b/internal/routes/routes_admin_error_reports.go
@@ -7,7 +7,7 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/web/views"
 
@@ -78,31 +78,31 @@ func (d *errorReportRoutes) handleDismissReport(c echo.Context) error {
 	return handler.RenderComponent(c, container)
 }
 
-func (d *errorReportRoutes) buildErrorReportsContent(c echo.Context) (hypermedia.FilterBar, templ.Component, error) {
+func (d *errorReportRoutes) buildErrorReportsContent(c echo.Context) (linkwell.FilterBar, templ.Component, error) {
 	const perPage = 20
 	p := parseErrorReportParams(c, perPage)
 
 	reports, total, err := d.db.ListErrorReports(c.Request().Context(), p.Q, p.Status, p.Sort, p.Dir, p.Page, p.PerPage)
 	if err != nil {
-		return hypermedia.FilterBar{}, nil, err
+		return linkwell.FilterBar{}, nil, err
 	}
 
 	target := "#error-reports-table-container"
-	bar := hypermedia.NewFilterBar(errorReportsBase+"/table", target,
-		hypermedia.SearchField("q", "Search reports\u2026", p.Q),
-		hypermedia.SelectField("status", "Status", p.Status,
-			hypermedia.SelectOptions(p.Status, errorReportStatusPairs()...)),
+	bar := linkwell.NewFilterBar(errorReportsBase+"/table", target,
+		linkwell.SearchField("q", "Search reports\u2026", p.Q),
+		linkwell.SelectField("status", "Status", p.Status,
+			linkwell.SelectOptions(p.Status, errorReportStatusPairs()...)),
 	)
 
 	sortBase := buildSortBase(c)
-	cols := []hypermedia.TableCol{
-		hypermedia.SortableCol("created_at", "Timestamp", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+	cols := []linkwell.TableCol{
+		linkwell.SortableCol("created_at", "Timestamp", p.Sort, p.Dir, sortBase, target, "#filter-form"),
 		{Label: "Request ID"},
 		{Label: "Description"},
-		hypermedia.SortableCol("route", "Route", p.Sort, p.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("status_code", "Code", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("route", "Route", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("status_code", "Code", p.Sort, p.Dir, sortBase, target, "#filter-form"),
 		{Label: "User Agent"},
-		hypermedia.SortableCol("status", "Status", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("status", "Status", p.Sort, p.Dir, sortBase, target, "#filter-form"),
 		{Label: "Actions"},
 	}
 

--- a/internal/routes/routes_admin_settings.go
+++ b/internal/routes/routes_admin_settings.go
@@ -7,20 +7,20 @@ import (
 	"time"
 
 	"catgoose/dothog/internal/routes/handler"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/internal/version"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
 )
 
-func (ar *appRoutes) initAdminSettingsRoutes(broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initAdminSettingsRoutes(broker *tavern.SSEBroker) {
 	ar.e.GET("/admin/settings", ar.handleAdminSettings(broker))
 	ar.e.GET("/admin/settings/system", ar.handleAdminSettingsSystem)
 	ar.e.GET("/admin/settings/sse", ar.handleAdminSettingsSSE(broker))
 }
 
-func (ar *appRoutes) handleAdminSettings(broker *ssebroker.SSEBroker) echo.HandlerFunc {
+func (ar *appRoutes) handleAdminSettings(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		data := ar.buildAdminPanelData(broker, c)
 		return handler.RenderBaseLayout(c, views.AdminSettingsPage(data))
@@ -28,19 +28,19 @@ func (ar *appRoutes) handleAdminSettings(broker *ssebroker.SSEBroker) echo.Handl
 }
 
 func (ar *appRoutes) handleAdminSettingsSystem(c echo.Context) error {
-	stats := ssebroker.CollectRuntimeStats(ar.startTime)
+	stats := tavern.CollectRuntimeStats(ar.startTime)
 	return handler.RenderComponent(c, views.AdminSettingsSystemFragment(stats, formatUptime(time.Since(ar.startTime))))
 }
 
-func (ar *appRoutes) handleAdminSettingsSSE(broker *ssebroker.SSEBroker) echo.HandlerFunc {
+func (ar *appRoutes) handleAdminSettingsSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		counts := broker.TopicCounts()
 		return handler.RenderComponent(c, views.AdminSettingsSSEFragment(counts))
 	}
 }
 
-func (ar *appRoutes) buildAdminPanelData(broker *ssebroker.SSEBroker, c echo.Context) views.AdminPanelData {
-	stats := ssebroker.CollectRuntimeStats(ar.startTime)
+func (ar *appRoutes) buildAdminPanelData(broker *tavern.SSEBroker, c echo.Context) views.AdminPanelData {
+	stats := tavern.CollectRuntimeStats(ar.startTime)
 	counts := broker.TopicCounts()
 
 	// Collect registered routes

--- a/internal/routes/routes_approvals.go
+++ b/internal/routes/routes_approvals.go
@@ -8,7 +8,7 @@ import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/routes/params"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -17,10 +17,10 @@ import (
 type approvalRoutes struct {
 	queue  *demo.ApprovalQueue
 	actLog *demo.ActivityLog
-	broker *ssebroker.SSEBroker
+	broker *tavern.SSEBroker
 }
 
-func (ar *appRoutes) initApprovalRoutes(queue *demo.ApprovalQueue, actLog *demo.ActivityLog, broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initApprovalRoutes(queue *demo.ApprovalQueue, actLog *demo.ActivityLog, broker *tavern.SSEBroker) {
 	a := &approvalRoutes{queue: queue, actLog: actLog, broker: broker}
 	ar.e.GET("/demo/approvals", a.handleApprovalsPage)
 	ar.e.PATCH("/demo/approvals/:id", a.handleApprovalAction)

--- a/internal/routes/routes_bulk.go
+++ b/internal/routes/routes_bulk.go
@@ -10,7 +10,7 @@ import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/logger"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/web/views"
 
 	"github.com/a-h/templ"
@@ -120,13 +120,13 @@ func (b *bulkRoutes) doBulkAction(c echo.Context, actionFn func(ctx context.Cont
 	return failedIDs
 }
 
-func (b *bulkRoutes) buildBulkContent(c echo.Context) (hypermedia.FilterBar, templ.Component, error) {
+func (b *bulkRoutes) buildBulkContent(c echo.Context) (linkwell.FilterBar, templ.Component, error) {
 	const perPage = 20
 	tc, err := buildTableContent(c, b.db, parseTableParams(c, perPage),
 		bulkBase+"/items", "#bulk-table-container",
 	)
 	if err != nil {
-		return hypermedia.FilterBar{}, nil, err
+		return linkwell.FilterBar{}, nil, err
 	}
 	body := views.BulkItemsBody(tc.Items)
 	container := views.BulkTableContainer(tc.Cols, body, tc.Info)

--- a/internal/routes/routes_canvas.go
+++ b/internal/routes/routes_canvas.go
@@ -16,7 +16,7 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -26,11 +26,11 @@ const canvasClientCookie = "canvas_client"
 
 type canvasRoutes struct {
 	canvas *demo.PixelCanvas
-	broker *ssebroker.SSEBroker
+	broker *tavern.SSEBroker
 	ctx    context.Context
 }
 
-func (ar *appRoutes) initCanvasRoutes(canvas *demo.PixelCanvas, broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initCanvasRoutes(canvas *demo.PixelCanvas, broker *tavern.SSEBroker) {
 	cr := &canvasRoutes{canvas: canvas, broker: broker, ctx: ar.ctx}
 	ar.e.GET("/demo/canvas", cr.handleCanvasPage)
 	ar.e.GET("/demo/canvas/state", cr.handleCanvasState)
@@ -82,9 +82,9 @@ func (cr *canvasRoutes) handlePlace(c echo.Context) error {
 
 func (cr *canvasRoutes) handleReset(c echo.Context) error {
 	cr.canvas.Reset()
-	if cr.broker.HasSubscribers(ssebroker.TopicCanvasUpdate) {
-		msg := ssebroker.NewSSEMessage("canvas-reset", "").String()
-		cr.broker.Publish(ssebroker.TopicCanvasUpdate, msg)
+	if cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
+		msg := tavern.NewSSEMessage("canvas-reset", "").String()
+		cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -107,7 +107,7 @@ func (cr *canvasRoutes) handleCanvasSSE(c echo.Context) error {
 		return fmt.Errorf("streaming unsupported")
 	}
 
-	ch, unsub := cr.broker.Subscribe(ssebroker.TopicCanvasUpdate)
+	ch, unsub := cr.broker.Subscribe(tavern.TopicCanvasUpdate)
 	defer unsub()
 
 	heartbeat := time.NewTicker(10 * time.Second)
@@ -146,7 +146,7 @@ func (cr *canvasRoutes) runTicker() {
 }
 
 func (cr *canvasRoutes) broadcastPixel(x, y int, color string) {
-	if !cr.broker.HasSubscribers(ssebroker.TopicCanvasUpdate) {
+	if !cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
 		return
 	}
 	data, err := json.Marshal(map[string]any{"x": x, "y": y, "color": color})
@@ -154,12 +154,12 @@ func (cr *canvasRoutes) broadcastPixel(x, y int, color string) {
 		slog.Error("marshal pixel update", "error", err)
 		return
 	}
-	msg := ssebroker.NewSSEMessage("pixel-update", string(data)).String()
-	cr.broker.Publish(ssebroker.TopicCanvasUpdate, msg)
+	msg := tavern.NewSSEMessage("pixel-update", string(data)).String()
+	cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
 }
 
 func (cr *canvasRoutes) broadcastClients() {
-	if !cr.broker.HasSubscribers(ssebroker.TopicCanvasUpdate) {
+	if !cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
 		return
 	}
 	clients := cr.canvas.ActiveClients()
@@ -168,8 +168,8 @@ func (cr *canvasRoutes) broadcastClients() {
 		slog.Error("marshal clients update", "error", err)
 		return
 	}
-	msg := ssebroker.NewSSEMessage("clients-update", string(data)).String()
-	cr.broker.Publish(ssebroker.TopicCanvasUpdate, msg)
+	msg := tavern.NewSSEMessage("clients-update", string(data)).String()
+	cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
 }
 
 func getOrCreateClientID(c echo.Context) string {

--- a/internal/routes/routes_catalog.go
+++ b/internal/routes/routes_catalog.go
@@ -5,8 +5,8 @@ package routes
 import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	hx "github.com/catgoose/cheddar"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/cheddar"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/web/views"
 
@@ -39,7 +39,7 @@ func (cat *catalogRoutes) handleCatalogItems(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 500, "Failed to load items", err)
 	}
-	if hx.IsBoosted(c) {
+	if cheddar.IsBoosted(c) {
 		return handler.RenderBaseLayout(c, views.CatalogPage(bar, container))
 	}
 	setTableReplaceURL(c, catalogBase)
@@ -71,14 +71,14 @@ func (cat *catalogRoutes) handleCatalogItemDetails(c echo.Context) error {
 	return handler.RenderComponent(c, views.CatalogDetailContent(item))
 }
 
-func (cat *catalogRoutes) buildCatalogContent(c echo.Context) (hypermedia.FilterBar, templ.Component, error) {
+func (cat *catalogRoutes) buildCatalogContent(c echo.Context) (linkwell.FilterBar, templ.Component, error) {
 	const perPage = 20
 	tc, err := buildTableContent(c, cat.db, parseTableParams(c, perPage),
 		catalogBase+"/items", "#catalog-table-container",
-		hypermedia.TableCol{Label: "Details"},
+		linkwell.TableCol{Label: "Details"},
 	)
 	if err != nil {
-		return hypermedia.FilterBar{}, nil, err
+		return linkwell.FilterBar{}, nil, err
 	}
 	body := views.CatalogItemsBody(tc.Items)
 	container := views.CatalogTableContainer(tc.Cols, body, tc.Info)

--- a/internal/routes/routes_error_traces.go
+++ b/internal/routes/routes_error_traces.go
@@ -11,11 +11,11 @@ import (
 	"catgoose/dothog/internal/logger"
 	"github.com/catgoose/promolog"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
-	response "github.com/catgoose/flighty"
+	"github.com/catgoose/linkwell"
+	"github.com/catgoose/flighty"
 	"catgoose/dothog/web/views"
 
-	hx "github.com/catgoose/cheddar"
+	"github.com/catgoose/cheddar"
 	corecomponents "catgoose/dothog/web/components/core"
 
 	"github.com/a-h/templ"
@@ -47,15 +47,15 @@ func (ar *appRoutes) handleErrorTracesList(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 500, "Failed to load error traces", err)
 	}
-	b := response.New(c).
+	b := flighty.New(c).
 		Component(container).
 		OOB(corecomponents.FilterGroupOOB(group))
-	if hx.IsHTMX(c) {
+	if cheddar.IsHTMX(c) {
 		pushURL := errorTracesBase
 		if q := c.Request().URL.RawQuery; q != "" {
 			pushURL += "?" + q
 		}
-		hx.ReplaceURL(c, pushURL)
+		cheddar.ReplaceURL(c, pushURL)
 	}
 	return b.Send()
 }
@@ -88,13 +88,13 @@ func (ar *appRoutes) handleErrorTraceDelete(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 500, "Failed to reload traces", err)
 	}
-	return response.New(c).
+	return flighty.New(c).
 		Component(container).
 		OOB(corecomponents.FilterGroupOOB(group)).
 		Send()
 }
 
-func (ar *appRoutes) buildErrorTracesContent(c echo.Context) (hypermedia.FilterGroup, templ.Component, error) {
+func (ar *appRoutes) buildErrorTracesContent(c echo.Context) (linkwell.FilterGroup, templ.Component, error) {
 	const perPage = 20
 	page, _ := strconv.Atoi(c.QueryParam("page"))
 	if page < 1 {
@@ -112,12 +112,12 @@ func (ar *appRoutes) buildErrorTracesContent(c echo.Context) (hypermedia.FilterG
 
 	traces, total, err := ar.reqLogStore.ListTraces(c.Request().Context(), f)
 	if err != nil {
-		return hypermedia.FilterGroup{}, nil, err
+		return linkwell.FilterGroup{}, nil, err
 	}
 
 	avail, err := ar.reqLogStore.AvailableFilters(c.Request().Context(), f)
 	if err != nil {
-		return hypermedia.FilterGroup{}, nil, err
+		return linkwell.FilterGroup{}, nil, err
 	}
 
 	target := "#error-traces-table-container"
@@ -151,31 +151,31 @@ func (ar *appRoutes) buildErrorTracesContent(c echo.Context) (hypermedia.FilterG
 		methodPairs = append(methodPairs, m, m)
 	}
 
-	group := hypermedia.NewFilterGroup(listURL, target,
-		hypermedia.SearchField("q", "Search routes, errors, IDs, users, IPs\u2026", f.Q),
-		hypermedia.SelectField("status", "Status", f.Status,
-			hypermedia.SelectOptions(f.Status, statusPairs...)),
-		hypermedia.SelectField("method", "Method", f.Method,
-			hypermedia.SelectOptions(f.Method, methodPairs...)),
+	group := linkwell.NewFilterGroup(listURL, target,
+		linkwell.SearchField("q", "Search routes, errors, IDs, users, IPs\u2026", f.Q),
+		linkwell.SelectField("status", "Status", f.Status,
+			linkwell.SelectOptions(f.Status, statusPairs...)),
+		linkwell.SelectField("method", "Method", f.Method,
+			linkwell.SelectOptions(f.Method, methodPairs...)),
 	)
 
 	sortBase := traceStripParams(c.Request().URL, "sort", "dir")
-	cols := []hypermedia.TableCol{
+	cols := []linkwell.TableCol{
 		{Label: "", Width: "2rem"},
-		hypermedia.SortableCol("CreatedAt", "Time", f.Sort, f.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("StatusCode", "Status", f.Sort, f.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("Method", "Method", f.Sort, f.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("Route", "Route", f.Sort, f.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("CreatedAt", "Time", f.Sort, f.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("StatusCode", "Status", f.Sort, f.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("Method", "Method", f.Sort, f.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("Route", "Route", f.Sort, f.Dir, sortBase, target, "#filter-form"),
 		{Label: "Error"},
 		{Label: "IP"},
 	}
 
 	pageBase := traceStripParams(c.Request().URL, "page")
-	info := hypermedia.PageInfo{
+	info := linkwell.PageInfo{
 		Page:       page,
 		PerPage:    perPage,
 		TotalItems: total,
-		TotalPages: hypermedia.ComputeTotalPages(total, perPage),
+		TotalPages: linkwell.ComputeTotalPages(total, perPage),
 		BaseURL:    pageBase,
 		Target:     target,
 		Include:    "#filter-form",

--- a/internal/routes/routes_feed.go
+++ b/internal/routes/routes_feed.go
@@ -14,7 +14,7 @@ import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/shared"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -22,10 +22,10 @@ import (
 
 type feedRoutes struct {
 	actLog *demo.ActivityLog
-	broker *ssebroker.SSEBroker
+	broker *tavern.SSEBroker
 }
 
-func (ar *appRoutes) initFeedRoutes(actLog *demo.ActivityLog, broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initFeedRoutes(actLog *demo.ActivityLog, broker *tavern.SSEBroker) {
 	f := &feedRoutes{actLog: actLog, broker: broker}
 	ar.e.GET("/demo/feed", f.handleFeedPage)
 	ar.e.GET("/demo/feed/more", f.handleFeedMore)
@@ -79,7 +79,7 @@ func (f *feedRoutes) handleActivitySSE(c echo.Context) error {
 		return fmt.Errorf("streaming unsupported")
 	}
 
-	ch, unsub := f.broker.Subscribe(ssebroker.TopicActivityFeed)
+	ch, unsub := f.broker.Subscribe(tavern.TopicActivityFeed)
 	defer unsub()
 
 	ctx := c.Request().Context()
@@ -98,8 +98,8 @@ func (f *feedRoutes) handleActivitySSE(c echo.Context) error {
 }
 
 // BroadcastActivity publishes an activity event to the SSE feed.
-func BroadcastActivity(broker *ssebroker.SSEBroker, e demo.ActivityEvent) {
-	if !broker.HasSubscribers(ssebroker.TopicActivityFeed) {
+func BroadcastActivity(broker *tavern.SSEBroker, e demo.ActivityEvent) {
+	if !broker.HasSubscribers(tavern.TopicActivityFeed) {
 		return
 	}
 	buf := statsBufPool.Get().(*bytes.Buffer)
@@ -108,9 +108,9 @@ func BroadcastActivity(broker *ssebroker.SSEBroker, e demo.ActivityEvent) {
 		statsBufPool.Put(buf)
 		return
 	}
-	msg := ssebroker.NewSSEMessage("activity-event", buf.String()).String()
+	msg := tavern.NewSSEMessage("activity-event", buf.String()).String()
 	statsBufPool.Put(buf)
-	broker.Publish(ssebroker.TopicActivityFeed, msg)
+	broker.Publish(tavern.TopicActivityFeed, msg)
 }
 
 // --- Simulated activity ---
@@ -141,14 +141,14 @@ func seedFeedEvents(actLog *demo.ActivityLog) {
 	}
 }
 
-func (ar *appRoutes) publishActivityEvents(actLog *demo.ActivityLog, broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) publishActivityEvents(actLog *demo.ActivityLog, broker *tavern.SSEBroker) {
 	for {
 		delay := time.Duration(2000+rand.IntN(4000)) * time.Millisecond
 		select {
 		case <-ar.ctx.Done():
 			return
 		case <-time.After(delay):
-			if !broker.HasSubscribers(ssebroker.TopicActivityFeed) {
+			if !broker.HasSubscribers(tavern.TopicActivityFeed) {
 				continue
 			}
 			tmpl := activityTemplates[rand.IntN(len(activityTemplates))]

--- a/internal/routes/routes_hypermedia.go
+++ b/internal/routes/routes_hypermedia.go
@@ -13,7 +13,7 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -231,12 +231,12 @@ func handleListsItems(c echo.Context) error {
 	return handler.RenderComponent(c, views.ListsDemoTable(items, info))
 }
 
-func listsPageInfo(page int) hypermedia.PageInfo {
-	return hypermedia.PageInfo{
+func listsPageInfo(page int) linkwell.PageInfo {
+	return linkwell.PageInfo{
 		Page:       page,
 		PerPage:    listsDemoPerPage,
 		TotalItems: listsDemoTotal,
-		TotalPages: hypermedia.ComputeTotalPages(listsDemoTotal, listsDemoPerPage),
+		TotalPages: linkwell.ComputeTotalPages(listsDemoTotal, listsDemoPerPage),
 		BaseURL:    hypermediaBase + "/lists/items",
 		Target:     "#lists-table-container",
 	}
@@ -391,7 +391,7 @@ func (ar *appRoutes) incrementPollCount() int64 {
 
 func (ar *appRoutes) buildLinksPageData(c echo.Context) views.LinksPageData {
 	data := views.LinksPageData{
-		Links:  hypermedia.AllLinks(),
+		Links:  linkwell.AllLinks(),
 		Routes: getRoutesList(c),
 	}
 	if ar.demoDB != nil {
@@ -426,7 +426,7 @@ func (ar *appRoutes) handleLinksCreate(c echo.Context) error {
 		return handler.HandleHypermediaError(c, http.StatusConflict, "Link already exists or insert failed", err)
 	}
 
-	hypermedia.LoadStoredLink(source, hypermedia.LinkRelation{
+	linkwell.LoadStoredLink(source, linkwell.LinkRelation{
 		Rel:   rel,
 		Href:  target,
 		Title: title,
@@ -463,7 +463,7 @@ func (ar *appRoutes) handleLinksDelete(c echo.Context) error {
 	}
 
 	if found != nil {
-		hypermedia.RemoveLink(found.Source, found.Target, found.Rel)
+		linkwell.RemoveLink(found.Source, found.Target, found.Rel)
 	}
 
 	return handler.RenderComponent(c, views.LinksRegistryTable(ar.buildLinksPageData(c)))

--- a/internal/routes/routes_hypermedia_controls.go
+++ b/internal/routes/routes_hypermedia_controls.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/middleware"
 	"catgoose/dothog/web/views"
 
@@ -393,18 +393,18 @@ func (gs *controlsGalleryState) handleErrTransient(c echo.Context) error {
 
 	if attempt%2 == 1 {
 		requestID := middleware.GetRequestID(c)
-		ec := hypermedia.ErrorContext{
+		ec := linkwell.ErrorContext{
 			StatusCode: 500,
 			Message:    fmt.Sprintf("Save failed — transient network error (attempt %d)", attempt),
 			Route:      c.Request().URL.Path,
 			RequestID:  requestID,
 			Closable:   true,
-			Controls: []hypermedia.Control{
-				hypermedia.RetryButton("Retry Save", hypermedia.HxMethodPost,
+			Controls: []linkwell.Control{
+				linkwell.RetryButton("Retry Save", linkwell.HxMethodPost,
 					"/hypermedia/controls/errors/transient", "#"+resultIDTransient).
 					WithErrorTarget("#" + resultIDTransient),
-				hypermedia.DismissButton(hypermedia.LabelDismiss),
-				hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
+				linkwell.DismissButton(linkwell.LabelDismiss),
+				linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID),
 			},
 		}
 		c.Response().WriteHeader(http.StatusInternalServerError)
@@ -431,23 +431,23 @@ func (gs *controlsGalleryState) handleErrValidate(c echo.Context) error {
 		requestID := middleware.GetRequestID(c)
 		fixURL := fmt.Sprintf("/hypermedia/controls/errors/validate/fix?name=%s&price=%s",
 			url.QueryEscape(name), url.QueryEscape(price))
-		ec := hypermedia.ErrorContext{
+		ec := linkwell.ErrorContext{
 			StatusCode: 422,
 			Message:    "Validation failed",
 			Err:        errors.New(strings.Join(errs, "; ")),
 			Route:      c.Request().URL.Path,
 			RequestID:  requestID,
 			Closable:   true,
-			Controls: []hypermedia.Control{
+			Controls: []linkwell.Control{
 				{
-					Kind:        hypermedia.ControlKindHTMX,
+					Kind:        linkwell.ControlKindHTMX,
 					Label:       "Fix & Resubmit",
-					Variant:     hypermedia.VariantPrimary,
+					Variant:     linkwell.VariantPrimary,
 					ErrorTarget: "#" + resultIDValidate,
-					HxRequest:   hypermedia.HxGet(fixURL, "#"+resultIDValidate),
+					HxRequest:   linkwell.HxGet(fixURL, "#"+resultIDValidate),
 				},
-				hypermedia.DismissButton(hypermedia.LabelDismiss),
-				hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
+				linkwell.DismissButton(linkwell.LabelDismiss),
+				linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID),
 			},
 		}
 		c.Response().WriteHeader(http.StatusUnprocessableEntity)
@@ -467,34 +467,34 @@ func (gs *controlsGalleryState) handleErrValidateFix(c echo.Context) error {
 // Scenario 3: Conflict — record already exists, offer update or copy.
 func (gs *controlsGalleryState) handleErrConflict(c echo.Context) error {
 	requestID := middleware.GetRequestID(c)
-	ec := hypermedia.ErrorContext{
+	ec := linkwell.ErrorContext{
 		StatusCode: 409,
 		Message:    "'Widget Alpha' already exists (ID: 42)",
 		Err:        errors.New("unique constraint violated on column 'name'"),
 		Route:      c.Request().URL.Path,
 		RequestID:  requestID,
 		Closable:   true,
-		Controls: []hypermedia.Control{
+		Controls: []linkwell.Control{
 			{
-				Kind:        hypermedia.ControlKindHTMX,
+				Kind:        linkwell.ControlKindHTMX,
 				Label:       "Update Existing",
-				Variant:     hypermedia.VariantPrimary,
+				Variant:     linkwell.VariantPrimary,
 				ErrorTarget: "#" + resultIDConflict,
-				HxRequest: hypermedia.HxRequestConfig{
-					Method: hypermedia.HxMethodPut,
+				HxRequest: linkwell.HxRequestConfig{
+					Method: linkwell.HxMethodPut,
 					URL:    "/hypermedia/controls/errors/conflict/update",
 					Target: "#" + resultIDConflict,
 				},
 			},
 			{
-				Kind:        hypermedia.ControlKindHTMX,
+				Kind:        linkwell.ControlKindHTMX,
 				Label:       "Create as Copy",
-				Variant:     hypermedia.VariantSecondary,
+				Variant:     linkwell.VariantSecondary,
 				ErrorTarget: "#" + resultIDConflict,
-				HxRequest:   hypermedia.HxPost("/hypermedia/controls/errors/conflict/copy", "#"+resultIDConflict),
+				HxRequest:   linkwell.HxPost("/hypermedia/controls/errors/conflict/copy", "#"+resultIDConflict),
 			},
-			hypermedia.DismissButton(hypermedia.LabelDismiss),
-			hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
+			linkwell.DismissButton(linkwell.LabelDismiss),
+			linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID),
 		},
 	}
 	c.Response().WriteHeader(http.StatusConflict)
@@ -528,35 +528,35 @@ func (gs *controlsGalleryState) handleErrStale(c echo.Context) error {
 		requestID := middleware.GetRequestID(c)
 		forceURL := fmt.Sprintf("/hypermedia/controls/errors/stale/force?name=%s",
 			url.QueryEscape(name))
-		ec := hypermedia.ErrorContext{
+		ec := linkwell.ErrorContext{
 			StatusCode: 412,
 			Message:    fmt.Sprintf("Record modified by another user (your v%d, server v%d)", sv, currentVersion),
 			Err:        errors.New("optimistic lock failed — row version mismatch"),
 			Route:      c.Request().URL.Path,
 			RequestID:  requestID,
 			Closable:   true,
-			Controls: []hypermedia.Control{
+			Controls: []linkwell.Control{
 				{
-					Kind:        hypermedia.ControlKindHTMX,
+					Kind:        linkwell.ControlKindHTMX,
 					Label:       "Load Fresh Data",
-					Variant:     hypermedia.VariantPrimary,
+					Variant:     linkwell.VariantPrimary,
 					ErrorTarget: "#" + resultIDStale,
-					HxRequest:   hypermedia.HxGet("/hypermedia/controls/errors/stale/refresh", "#"+resultIDStale),
+					HxRequest:   linkwell.HxGet("/hypermedia/controls/errors/stale/refresh", "#"+resultIDStale),
 				},
 				{
-					Kind:        hypermedia.ControlKindHTMX,
+					Kind:        linkwell.ControlKindHTMX,
 					Label:       "Force Save",
-					Variant:     hypermedia.VariantDanger,
+					Variant:     linkwell.VariantDanger,
 					Confirm:     "Override the other user's changes?",
 					ErrorTarget: "#" + resultIDStale,
-					HxRequest: hypermedia.HxRequestConfig{
-						Method: hypermedia.HxMethodPost,
+					HxRequest: linkwell.HxRequestConfig{
+						Method: linkwell.HxMethodPost,
 						URL:    forceURL,
 						Target: "#" + resultIDStale,
 					},
 				},
-				hypermedia.DismissButton(hypermedia.LabelDismiss),
-				hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
+				linkwell.DismissButton(linkwell.LabelDismiss),
+				linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID),
 			},
 		}
 		c.Response().WriteHeader(http.StatusPreconditionFailed)
@@ -608,27 +608,27 @@ func (gs *controlsGalleryState) handleErrCascade(c echo.Context) error {
 	}
 
 	requestID := middleware.GetRequestID(c)
-	ec := hypermedia.ErrorContext{
+	ec := linkwell.ErrorContext{
 		StatusCode: 409,
 		Message:    fmt.Sprintf("Cannot delete 'Electronics' — %d items depend on it", len(cascadeDependents)),
 		Err:        errors.New("foreign key constraint: items.category_id → categories.id"),
 		Route:      c.Request().URL.Path,
 		RequestID:  requestID,
 		Closable:   true,
-		Controls: []hypermedia.Control{
+		Controls: []linkwell.Control{
 			{
-				Kind:        hypermedia.ControlKindHTMX,
+				Kind:        linkwell.ControlKindHTMX,
 				Label:       "Reassign Items",
-				Variant:     hypermedia.VariantPrimary,
+				Variant:     linkwell.VariantPrimary,
 				ErrorTarget: "#" + resultIDCascade,
-				HxRequest:   hypermedia.HxGet("/hypermedia/controls/errors/cascade/reassign", "#"+resultIDCascade),
+				HxRequest:   linkwell.HxGet("/hypermedia/controls/errors/cascade/reassign", "#"+resultIDCascade),
 			},
-			hypermedia.ConfirmAction("Force Delete All", hypermedia.HxMethodDelete,
+			linkwell.ConfirmAction("Force Delete All", linkwell.HxMethodDelete,
 				"/hypermedia/controls/errors/cascade/force", "#"+resultIDCascade,
 				fmt.Sprintf("Delete 'Electronics' AND all %d items?", len(cascadeDependents))).
 				WithErrorTarget("#" + resultIDCascade),
-			hypermedia.DismissButton(hypermedia.LabelDismiss),
-			hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
+			linkwell.DismissButton(linkwell.LabelDismiss),
+			linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID),
 		},
 	}
 	c.Response().WriteHeader(http.StatusConflict)

--- a/internal/routes/routes_hypermedia_errors.go
+++ b/internal/routes/routes_hypermedia_errors.go
@@ -11,12 +11,12 @@ import (
 
 	"catgoose/dothog/internal/logger"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/middleware"
 	corecomponents "catgoose/dothog/web/components/core"
 	"catgoose/dothog/web/views"
 
-	response "github.com/catgoose/flighty"
+	"github.com/catgoose/flighty"
 	"github.com/labstack/echo/v4"
 )
 
@@ -96,21 +96,21 @@ func (ar *appRoutes) initErrorsRoutes() {
 	// OOB warning — returns success content plus an OOB error banner.
 	ar.e.GET(base+"/oob-warning", func(c echo.Context) error {
 		requestID := middleware.GetRequestID(c)
-		ec := hypermedia.ErrorContext{
+		ec := linkwell.ErrorContext{
 			StatusCode: http.StatusOK,
 			Message:    "Data loaded with warnings — some fields may be stale",
 			Err:        errors.New("upstream cache returned partial data"),
 			Route:      c.Request().URL.Path,
 			RequestID:  requestID,
 			Closable:   true,
-			OOBTarget:  hypermedia.DefaultErrorStatusTarget,
+			OOBTarget:  linkwell.DefaultErrorStatusTarget,
 			OOBSwap:    "innerHTML",
-			Controls: []hypermedia.Control{
-				hypermedia.DismissButton(hypermedia.LabelDismiss),
-				hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
+			Controls: []linkwell.Control{
+				linkwell.DismissButton(linkwell.LabelDismiss),
+				linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID),
 			},
 		}
-		return response.New(c).
+		return flighty.New(c).
 			Component(views.ErrorsOOBSuccess()).
 			OOB(corecomponents.ErrorStatusFromContext(ec)).
 			Send()
@@ -122,18 +122,18 @@ func (ar *appRoutes) initErrorsRoutes() {
 		if n%2 == 1 {
 			requestID := middleware.GetRequestID(c)
 			c.Response().Status = http.StatusInternalServerError
-			ec := hypermedia.ErrorContext{
+			ec := linkwell.ErrorContext{
 				StatusCode: http.StatusInternalServerError,
 				Message:    "Service temporarily unavailable",
 				Err:        errors.New("connection to upstream timed out"),
 				Route:      c.Request().URL.Path,
 				RequestID:  requestID,
 				Closable:   true,
-				Controls: []hypermedia.Control{
-					hypermedia.RetryButton("Retry", hypermedia.HxMethodGet,
+				Controls: []linkwell.Control{
+					linkwell.RetryButton("Retry", linkwell.HxMethodGet,
 						base+"/flaky", "#errors-retry-result").
 						WithErrorTarget("#errors-retry-result"),
-					hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, requestID),
+					linkwell.ReportIssueButton(linkwell.LabelReportIssue, requestID),
 				},
 			}
 			return handler.RenderComponent(c, views.GalleryErrorPanel("flaky-error", ec))

--- a/internal/routes/routes_inventory.go
+++ b/internal/routes/routes_inventory.go
@@ -8,8 +8,8 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	hx "github.com/catgoose/cheddar"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/cheddar"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/web/views"
 
@@ -48,7 +48,7 @@ func (d *inventoryRoutes) handleInventoryItems(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 500, "Failed to load items", err)
 	}
-	if hx.IsBoosted(c) {
+	if cheddar.IsBoosted(c) {
 		return handler.RenderBaseLayout(c, views.InventoryPage(bar, container))
 	}
 	setTableReplaceURL(c, inventoryBase)
@@ -102,7 +102,7 @@ func (d *inventoryRoutes) handleItemRow(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 404, "Item not found", err)
 	}
-	if !hx.IsHTMX(c) || hx.IsBoosted(c) {
+	if !cheddar.IsHTMX(c) || cheddar.IsBoosted(c) {
 		handler.SetPageLabel(c, item.Name)
 		return handler.RenderBaseLayout(c, views.InventoryDetailPage(item))
 	}
@@ -162,14 +162,14 @@ func (d *inventoryRoutes) handleDeleteItem(c echo.Context) error {
 	return handler.RenderComponent(c, container)
 }
 
-func (d *inventoryRoutes) buildInventoryContent(c echo.Context) (hypermedia.FilterBar, templ.Component, error) {
+func (d *inventoryRoutes) buildInventoryContent(c echo.Context) (linkwell.FilterBar, templ.Component, error) {
 	const perPage = 20
 	tc, err := buildTableContent(c, d.db, parseTableParams(c, perPage),
 		inventoryBase+"/items", "#inventory-table-container",
-		hypermedia.TableCol{Label: "Actions"},
+		linkwell.TableCol{Label: "Actions"},
 	)
 	if err != nil {
-		return hypermedia.FilterBar{}, nil, err
+		return linkwell.FilterBar{}, nil, err
 	}
 	body := views.InventoryItemsBody(tc.Items)
 	container := views.InventoryTableContainer(tc.Cols, body, tc.Info)

--- a/internal/routes/routes_kanban.go
+++ b/internal/routes/routes_kanban.go
@@ -6,7 +6,7 @@ import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/routes/params"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -15,10 +15,10 @@ import (
 type kanbanRoutes struct {
 	board  *demo.KanbanBoard
 	actLog *demo.ActivityLog
-	broker *ssebroker.SSEBroker
+	broker *tavern.SSEBroker
 }
 
-func (ar *appRoutes) initKanbanRoutes(board *demo.KanbanBoard, actLog *demo.ActivityLog, broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initKanbanRoutes(board *demo.KanbanBoard, actLog *demo.ActivityLog, broker *tavern.SSEBroker) {
 	k := &kanbanRoutes{board: board, actLog: actLog, broker: broker}
 	ar.e.GET("/demo/kanban", k.handleKanbanPage)
 	ar.e.PATCH("/demo/kanban/tasks/:id", k.handleMoveTask)

--- a/internal/routes/routes_links.go
+++ b/internal/routes/routes_links.go
@@ -2,7 +2,7 @@
 
 package routes
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // initLinkRelations registers all link relation declarations for the app.
 // Hubs define parent→child discovery pages. Rings define peer groups.
@@ -10,141 +10,141 @@ import hypermedia "github.com/catgoose/linkwell"
 func (ar *appRoutes) initLinkRelations() {
 	// ── Hubs (discovery / index pages) ──────────────────────────────
 
-	hypermedia.Hub("/demo", "Demo",
-		hypermedia.Rel("/demo/inventory", "Inventory"),
-		hypermedia.Rel("/demo/catalog", "Catalog"),
-		hypermedia.Rel("/demo/people", "People"),
-		hypermedia.Rel("/demo/kanban", "Kanban"),
-		hypermedia.Rel("/demo/approvals", "Approvals"),
-		hypermedia.Rel("/demo/vendors", "Vendors"),
-		hypermedia.Rel("/demo/feed", "Feed"),
-		hypermedia.Rel("/demo/canvas", "Canvas"),
-		hypermedia.Rel("/demo/settings", "Settings"),
-		hypermedia.Rel("/demo/bulk", "Bulk"),
-		hypermedia.Rel("/demo/logging", "Logging"),
-		hypermedia.Rel("/demo/repository", "Repository"),
-		hypermedia.Rel("/dashboard", "Dashboard"),
-		hypermedia.Rel("/pwa", "PWA Offline"),
+	linkwell.Hub("/demo", "Demo",
+		linkwell.Rel("/demo/inventory", "Inventory"),
+		linkwell.Rel("/demo/catalog", "Catalog"),
+		linkwell.Rel("/demo/people", "People"),
+		linkwell.Rel("/demo/kanban", "Kanban"),
+		linkwell.Rel("/demo/approvals", "Approvals"),
+		linkwell.Rel("/demo/vendors", "Vendors"),
+		linkwell.Rel("/demo/feed", "Feed"),
+		linkwell.Rel("/demo/canvas", "Canvas"),
+		linkwell.Rel("/demo/settings", "Settings"),
+		linkwell.Rel("/demo/bulk", "Bulk"),
+		linkwell.Rel("/demo/logging", "Logging"),
+		linkwell.Rel("/demo/repository", "Repository"),
+		linkwell.Rel("/dashboard", "Dashboard"),
+		linkwell.Rel("/pwa", "PWA Offline"),
 	)
 
-	hypermedia.Hub("/hypermedia", "Hypermedia",
-		hypermedia.Rel("/hypermedia/controls", "Controls"),
-		hypermedia.Rel("/hypermedia/crud", "CRUD"),
-		hypermedia.Rel("/hypermedia/lists", "Lists"),
-		hypermedia.Rel("/hypermedia/interactions", "Interactions"),
-		hypermedia.Rel("/hypermedia/state", "State"),
-		hypermedia.Rel("/hypermedia/errors", "Errors"),
-		hypermedia.Rel("/hypermedia/components", "Components"),
-		hypermedia.Rel("/hypermedia/components2", "Components 2"),
-		hypermedia.Rel("/hypermedia/components3", "Components 3"),
-		hypermedia.Rel("/hypermedia/realtime", "Realtime"),
-		hypermedia.Rel("/hypermedia/links", "Links"),
-		hypermedia.Rel("/hypermedia/hal", "HAL"),
-		hypermedia.Rel("/hypermedia/standards", "Standards"),
+	linkwell.Hub("/hypermedia", "Hypermedia",
+		linkwell.Rel("/hypermedia/controls", "Controls"),
+		linkwell.Rel("/hypermedia/crud", "CRUD"),
+		linkwell.Rel("/hypermedia/lists", "Lists"),
+		linkwell.Rel("/hypermedia/interactions", "Interactions"),
+		linkwell.Rel("/hypermedia/state", "State"),
+		linkwell.Rel("/hypermedia/errors", "Errors"),
+		linkwell.Rel("/hypermedia/components", "Components"),
+		linkwell.Rel("/hypermedia/components2", "Components 2"),
+		linkwell.Rel("/hypermedia/components3", "Components 3"),
+		linkwell.Rel("/hypermedia/realtime", "Realtime"),
+		linkwell.Rel("/hypermedia/links", "Links"),
+		linkwell.Rel("/hypermedia/hal", "HAL"),
+		linkwell.Rel("/hypermedia/standards", "Standards"),
 	)
 
-	hypermedia.Hub("/admin", "Admin",
-		hypermedia.Rel("/admin/health", "Health"),
-		hypermedia.Rel("/admin/sessions", "Sessions"),
-		hypermedia.Rel("/admin/settings", "Control Panel"),
-		hypermedia.Rel("/admin/error-traces", "Error Traces"),
-		hypermedia.Rel("/admin/error-reports", "Error Reports"),
-		hypermedia.Rel("/admin/system", "System"),
-		hypermedia.Rel("/admin/config", "Config"),
+	linkwell.Hub("/admin", "Admin",
+		linkwell.Rel("/admin/health", "Health"),
+		linkwell.Rel("/admin/sessions", "Sessions"),
+		linkwell.Rel("/admin/settings", "Control Panel"),
+		linkwell.Rel("/admin/error-traces", "Error Traces"),
+		linkwell.Rel("/admin/error-reports", "Error Reports"),
+		linkwell.Rel("/admin/system", "System"),
+		linkwell.Rel("/admin/config", "Config"),
 	)
 
-	hypermedia.Hub("/dashboard", "Dashboard",
-		hypermedia.Rel("/demo/inventory", "Inventory"),
-		hypermedia.Rel("/demo/people", "People"),
-		hypermedia.Rel("/demo/kanban", "Kanban"),
-		hypermedia.Rel("/demo/approvals", "Approvals"),
-		hypermedia.Rel("/demo/vendors", "Vendors"),
-		hypermedia.Rel("/demo/feed", "Feed"),
+	linkwell.Hub("/dashboard", "Dashboard",
+		linkwell.Rel("/demo/inventory", "Inventory"),
+		linkwell.Rel("/demo/people", "People"),
+		linkwell.Rel("/demo/kanban", "Kanban"),
+		linkwell.Rel("/demo/approvals", "Approvals"),
+		linkwell.Rel("/demo/vendors", "Vendors"),
+		linkwell.Rel("/demo/feed", "Feed"),
 	)
 
 	// ── Rings (peer groups) ─────────────────────────────────────────
 
 	// Demo: data management pages
-	hypermedia.Ring("Data",
-		hypermedia.Rel("/demo/inventory", "Inventory"),
-		hypermedia.Rel("/demo/catalog", "Catalog"),
-		hypermedia.Rel("/demo/bulk", "Bulk Ops"),
-		hypermedia.Rel("/demo/people", "People"),
-		hypermedia.Rel("/demo/vendors", "Vendors"),
+	linkwell.Ring("Data",
+		linkwell.Rel("/demo/inventory", "Inventory"),
+		linkwell.Rel("/demo/catalog", "Catalog"),
+		linkwell.Rel("/demo/bulk", "Bulk Ops"),
+		linkwell.Rel("/demo/people", "People"),
+		linkwell.Rel("/demo/vendors", "Vendors"),
 	)
 
 	// Demo: workflow and process pages
-	hypermedia.Ring("Workflow",
-		hypermedia.Rel("/demo/kanban", "Kanban"),
-		hypermedia.Rel("/demo/approvals", "Approvals"),
-		hypermedia.Rel("/demo/feed", "Feed"),
+	linkwell.Ring("Workflow",
+		linkwell.Rel("/demo/kanban", "Kanban"),
+		linkwell.Rel("/demo/approvals", "Approvals"),
+		linkwell.Rel("/demo/feed", "Feed"),
 	)
 
 	// Demo: tools and utilities
-	hypermedia.Ring("Utility",
-		hypermedia.Rel("/demo/logging", "Logging"),
-		hypermedia.Rel("/demo/canvas", "Canvas"),
-		hypermedia.Rel("/demo/settings", "Settings"),
-		hypermedia.Rel("/demo/repository", "Repository"),
+	linkwell.Ring("Utility",
+		linkwell.Rel("/demo/logging", "Logging"),
+		linkwell.Rel("/demo/canvas", "Canvas"),
+		linkwell.Rel("/demo/settings", "Settings"),
+		linkwell.Rel("/demo/repository", "Repository"),
 	)
 
 	// Demo: dashboard children are also peers
-	hypermedia.Ring("Dashboard",
-		hypermedia.Rel("/demo/inventory", "Inventory"),
-		hypermedia.Rel("/demo/people", "People"),
-		hypermedia.Rel("/demo/kanban", "Kanban"),
-		hypermedia.Rel("/demo/approvals", "Approvals"),
-		hypermedia.Rel("/demo/vendors", "Vendors"),
-		hypermedia.Rel("/demo/feed", "Feed"),
+	linkwell.Ring("Dashboard",
+		linkwell.Rel("/demo/inventory", "Inventory"),
+		linkwell.Rel("/demo/people", "People"),
+		linkwell.Rel("/demo/kanban", "Kanban"),
+		linkwell.Rel("/demo/approvals", "Approvals"),
+		linkwell.Rel("/demo/vendors", "Vendors"),
+		linkwell.Rel("/demo/feed", "Feed"),
 	)
 
 	// Hypermedia: pattern pages
-	hypermedia.Ring("Patterns",
-		hypermedia.Rel("/hypermedia/controls", "Controls"),
-		hypermedia.Rel("/hypermedia/crud", "CRUD"),
-		hypermedia.Rel("/hypermedia/lists", "Lists"),
-		hypermedia.Rel("/hypermedia/interactions", "Interactions"),
-		hypermedia.Rel("/hypermedia/state", "State"),
-		hypermedia.Rel("/hypermedia/errors", "Errors"),
-		hypermedia.Rel("/hypermedia/realtime", "Realtime"),
-		hypermedia.Rel("/hypermedia/links", "Links"),
-		hypermedia.Rel("/hypermedia/hal", "HAL"),
-		hypermedia.Rel("/hypermedia/standards", "Standards"),
+	linkwell.Ring("Patterns",
+		linkwell.Rel("/hypermedia/controls", "Controls"),
+		linkwell.Rel("/hypermedia/crud", "CRUD"),
+		linkwell.Rel("/hypermedia/lists", "Lists"),
+		linkwell.Rel("/hypermedia/interactions", "Interactions"),
+		linkwell.Rel("/hypermedia/state", "State"),
+		linkwell.Rel("/hypermedia/errors", "Errors"),
+		linkwell.Rel("/hypermedia/realtime", "Realtime"),
+		linkwell.Rel("/hypermedia/links", "Links"),
+		linkwell.Rel("/hypermedia/hal", "HAL"),
+		linkwell.Rel("/hypermedia/standards", "Standards"),
 	)
 
 	// Hypermedia: component gallery pages
-	hypermedia.Ring("Components",
-		hypermedia.Rel("/hypermedia/components", "Components"),
-		hypermedia.Rel("/hypermedia/components2", "Components 2"),
-		hypermedia.Rel("/hypermedia/components3", "Components 3"),
+	linkwell.Ring("Components",
+		linkwell.Rel("/hypermedia/components", "Components"),
+		linkwell.Rel("/hypermedia/components2", "Components 2"),
+		linkwell.Rel("/hypermedia/components3", "Components 3"),
 	)
 
 	// Admin: operational pages
-	hypermedia.Ring("Admin Ops",
-		hypermedia.Rel("/admin/health", "Health"),
-		hypermedia.Rel("/admin/error-traces", "Error Traces"),
-		hypermedia.Rel("/admin/error-reports", "Error Reports"),
-		hypermedia.Rel("/admin/sessions", "Sessions"),
-		hypermedia.Rel("/admin/settings", "Control Panel"),
+	linkwell.Ring("Admin Ops",
+		linkwell.Rel("/admin/health", "Health"),
+		linkwell.Rel("/admin/error-traces", "Error Traces"),
+		linkwell.Rel("/admin/error-reports", "Error Reports"),
+		linkwell.Rel("/admin/sessions", "Sessions"),
+		linkwell.Rel("/admin/settings", "Control Panel"),
 	)
 
 	// Admin: system introspection
-	hypermedia.Ring("System",
-		hypermedia.Rel("/admin/system", "System"),
-		hypermedia.Rel("/admin/config", "Config"),
-		hypermedia.Rel("/admin/health", "Health"),
-		hypermedia.Rel("/admin/error-traces", "Error Traces"),
+	linkwell.Ring("System",
+		linkwell.Rel("/admin/system", "System"),
+		linkwell.Rel("/admin/config", "Config"),
+		linkwell.Rel("/admin/health", "Health"),
+		linkwell.Rel("/admin/error-traces", "Error Traces"),
 	)
 
 	// ── Settings ────────────────────────────────────────────────────
 
-	hypermedia.Link("/settings", "related", "/user/settings", "Preferences")
-	hypermedia.Link("/settings", "related", "/admin/config", "Admin Config")
-	hypermedia.Link("/settings", "related", "/admin/settings", "Control Panel")
+	linkwell.Link("/settings", "related", "/user/settings", "Preferences")
+	linkwell.Link("/settings", "related", "/admin/config", "Admin Config")
+	linkwell.Link("/settings", "related", "/admin/settings", "Control Panel")
 
 	// ── Action relations ────────────────────────────────────────────
 
 	// List pages with create forms
-	hypermedia.Link("/demo/inventory", "create-form", "/demo/inventory/items/new", "New Item")
-	hypermedia.Link("/demo/repository", "create-form", "/demo/repository/tasks", "New Task")
+	linkwell.Link("/demo/inventory", "create-form", "/demo/inventory/items/new", "New Item")
+	linkwell.Link("/demo/repository", "create-form", "/demo/repository/tasks", "New Task")
 }

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -14,7 +14,7 @@ import (
 	"github.com/catgoose/promolog"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/shared"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -46,7 +46,7 @@ func (ar *appRoutes) initLoggingRoutes() {
 	})
 
 	// setup:feature:sse:start
-	broker := ssebroker.NewSSEBroker()
+	broker := tavern.NewSSEBroker()
 
 	// Wire up SSE broadcasting on error trace promotion.
 	if ar.reqLogStore != nil {
@@ -158,7 +158,7 @@ func (ar *appRoutes) initLoggingRoutes() {
 
 // setup:feature:sse:start
 
-func handleErrorTracesSSE(broker *ssebroker.SSEBroker) echo.HandlerFunc {
+func handleErrorTracesSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		c.Response().Header().Set("Content-Type", "text/event-stream")
 		c.Response().Header().Set("Cache-Control", "no-cache")
@@ -166,7 +166,7 @@ func handleErrorTracesSSE(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 		c.Response().WriteHeader(http.StatusOK)
 
 		flusher := c.Response().Writer.(http.Flusher)
-		ch, unsub := broker.Subscribe(ssebroker.TopicErrorTraces)
+		ch, unsub := broker.Subscribe(tavern.TopicErrorTraces)
 		defer unsub()
 
 		ctx := c.Request().Context()
@@ -185,8 +185,8 @@ func handleErrorTracesSSE(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 	}
 }
 
-func broadcastErrorTrace(broker *ssebroker.SSEBroker, summary promolog.TraceSummary) {
-	if !broker.HasSubscribers(ssebroker.TopicErrorTraces) {
+func broadcastErrorTrace(broker *tavern.SSEBroker, summary promolog.TraceSummary) {
+	if !broker.HasSubscribers(tavern.TopicErrorTraces) {
 		return
 	}
 	buf := new(bytes.Buffer)
@@ -194,8 +194,8 @@ func broadcastErrorTrace(broker *ssebroker.SSEBroker, summary promolog.TraceSumm
 	if err := views.LoggingTraceRowOOB(summary).Render(ctx, buf); err != nil {
 		return
 	}
-	msg := ssebroker.NewSSEMessage("error-trace", buf.String()).String()
-	broker.Publish(ssebroker.TopicErrorTraces, msg)
+	msg := tavern.NewSSEMessage("error-trace", buf.String()).String()
+	broker.Publish(tavern.TopicErrorTraces, msg)
 }
 
 // setup:feature:sse:end

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -11,10 +11,10 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/internal/shared"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -24,11 +24,11 @@ const peopleBase = "/demo/people"
 
 type peopleRoutes struct {
 	db     *demo.DB
-	broker *ssebroker.SSEBroker
+	broker *tavern.SSEBroker
 	actLog *demo.ActivityLog
 }
 
-func (ar *appRoutes) initPeopleRoutes(db *demo.DB, broker *ssebroker.SSEBroker, actLog *demo.ActivityLog) {
+func (ar *appRoutes) initPeopleRoutes(db *demo.DB, broker *tavern.SSEBroker, actLog *demo.ActivityLog) {
 	p := &peopleRoutes{db: db, broker: broker, actLog: actLog}
 	ar.e.GET(peopleBase, p.handlePeoplePage)
 	ar.e.GET(peopleBase+"/list", p.handlePeopleList)
@@ -132,7 +132,7 @@ func (p *peopleRoutes) handlePersonUpdate(c echo.Context) error {
 }
 
 func (p *peopleRoutes) broadcastPersonUpdate(person demo.Person) {
-	topic := fmt.Sprintf("%s-%d", ssebroker.TopicPeopleUpdate, person.ID)
+	topic := fmt.Sprintf("%s-%d", tavern.TopicPeopleUpdate, person.ID)
 	if !p.broker.HasSubscribers(topic) {
 		return
 	}
@@ -142,7 +142,7 @@ func (p *peopleRoutes) broadcastPersonUpdate(person demo.Person) {
 		statsBufPool.Put(buf)
 		return
 	}
-	msg := ssebroker.NewSSEMessage("person-update", buf.String()).String()
+	msg := tavern.NewSSEMessage("person-update", buf.String()).String()
 	statsBufPool.Put(buf)
 	p.broker.Publish(topic, msg)
 }
@@ -152,7 +152,7 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 400, "Invalid person ID", err)
 	}
-	topic := fmt.Sprintf("%s-%d", ssebroker.TopicPeopleUpdate, id)
+	topic := fmt.Sprintf("%s-%d", tavern.TopicPeopleUpdate, id)
 
 	c.Response().Header().Set("Content-Type", "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "no-cache")
@@ -182,7 +182,7 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 	}
 }
 
-func (p *peopleRoutes) buildPeopleContent(c echo.Context) ([]demo.Person, int, hypermedia.FilterBar, []hypermedia.TableCol, hypermedia.PageInfo, error) {
+func (p *peopleRoutes) buildPeopleContent(c echo.Context) ([]demo.Person, int, linkwell.FilterBar, []linkwell.TableCol, linkwell.PageInfo, error) {
 	const perPage = 20
 	page, _ := strconv.Atoi(c.QueryParam("page"))
 	if page < 1 {
@@ -195,21 +195,21 @@ func (p *peopleRoutes) buildPeopleContent(c echo.Context) ([]demo.Person, int, h
 
 	people, total, err := p.db.ListPeople(c.Request().Context(), search, department, sort, dir, page, perPage)
 	if err != nil {
-		return nil, 0, hypermedia.FilterBar{}, nil, hypermedia.PageInfo{}, err
+		return nil, 0, linkwell.FilterBar{}, nil, linkwell.PageInfo{}, err
 	}
 
-	bar := hypermedia.NewFilterBar(peopleBase+"/list", "#people-table-container",
-		hypermedia.SearchField("q", "Search people\u2026", search),
-		hypermedia.SelectField("department", "Department", department,
+	bar := linkwell.NewFilterBar(peopleBase+"/list", "#people-table-container",
+		linkwell.SearchField("q", "Search people\u2026", search),
+		linkwell.SelectField("department", "Department", department,
 			deptOptions(department)),
 	)
 
 	sortBase := buildSortBase(c)
-	cols := []hypermedia.TableCol{
-		hypermedia.SortableCol("name", "Name", sort, dir, sortBase, "#people-table-container", "#filter-form"),
-		hypermedia.SortableCol("department", "Department", sort, dir, sortBase, "#people-table-container", "#filter-form"),
+	cols := []linkwell.TableCol{
+		linkwell.SortableCol("name", "Name", sort, dir, sortBase, "#people-table-container", "#filter-form"),
+		linkwell.SortableCol("department", "Department", sort, dir, sortBase, "#people-table-container", "#filter-form"),
 		{Label: "Title"},
-		hypermedia.SortableCol("city", "Location", sort, dir, sortBase, "#people-table-container", "#filter-form"),
+		linkwell.SortableCol("city", "Location", sort, dir, sortBase, "#people-table-container", "#filter-form"),
 		{Label: "Email"},
 	}
 
@@ -218,12 +218,12 @@ func (p *peopleRoutes) buildPeopleContent(c echo.Context) ([]demo.Person, int, h
 	return people, total, bar, cols, info, nil
 }
 
-func deptOptions(current string) []hypermedia.FilterOption {
-	opts := []hypermedia.FilterOption{
+func deptOptions(current string) []linkwell.FilterOption {
+	opts := []linkwell.FilterOption{
 		{Value: "", Label: "All Departments", Selected: current == ""},
 	}
 	for _, d := range demo.Departments {
-		opts = append(opts, hypermedia.FilterOption{Value: d, Label: d, Selected: current == d})
+		opts = append(opts, linkwell.FilterOption{Value: d, Label: d, Selected: current == d})
 	}
 	return opts
 }

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -15,13 +15,13 @@ import (
 
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/shared"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
 )
 
-func (ar *appRoutes) initRealtimeRoutes(broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initRealtimeRoutes(broker *tavern.SSEBroker) {
 	ar.e.GET("/hypermedia/realtime", ar.handleRealtimePage())
 	ar.e.GET("/hypermedia/realtime/poll", ar.handleRealtimePoll)
 	ar.e.GET("/hypermedia/realtime/sse-connect", handleSSEConnect)
@@ -37,7 +37,7 @@ func (ar *appRoutes) initRealtimeRoutes(broker *ssebroker.SSEBroker) {
 
 func (ar *appRoutes) handleRealtimePage() echo.HandlerFunc {
 	return func(c echo.Context) error {
-		stats := ssebroker.CollectRuntimeStats(time.Now())
+		stats := tavern.CollectRuntimeStats(time.Now())
 		snap := initialMetrics()
 		services := initialServices()
 		svcLatencies := initialServiceLatencies()
@@ -60,7 +60,7 @@ func handleSSEConnect(c echo.Context) error {
 	return handler.RenderComponent(c, views.SSEConnectBlock(interval))
 }
 
-func handleSSESystem(broker *ssebroker.SSEBroker) echo.HandlerFunc {
+func handleSSESystem(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		c.Response().Header().Set("Content-Type", "text/event-stream")
 		c.Response().Header().Set("Cache-Control", "no-cache")
@@ -72,7 +72,7 @@ func handleSSESystem(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		ch, unsub := broker.Subscribe(ssebroker.TopicSystemStats)
+		ch, unsub := broker.Subscribe(tavern.TopicSystemStats)
 		defer unsub()
 
 		ctx := c.Request().Context()
@@ -96,7 +96,7 @@ func handleSSESystem(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 // Note: system-stats is NOT subscribed here — the dashboard only renders 6 of 21
 // stat cards, so the full SystemStatsOOB would produce oobErrorNoTarget for the
 // missing 15. Instead, dashboard stats are included in MetricsOOB.
-func handleSSEDashboard(broker *ssebroker.SSEBroker) echo.HandlerFunc {
+func handleSSEDashboard(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		interval := 5 * time.Second
 		if v := c.QueryParam("interval"); v != "" {
@@ -115,11 +115,11 @@ func handleSSEDashboard(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		chMetrics, unsubMetrics := broker.Subscribe(ssebroker.TopicDashMetrics)
+		chMetrics, unsubMetrics := broker.Subscribe(tavern.TopicDashMetrics)
 		defer unsubMetrics()
-		chServices, unsubServices := broker.Subscribe(ssebroker.TopicDashServices)
+		chServices, unsubServices := broker.Subscribe(tavern.TopicDashServices)
 		defer unsubServices()
-		chEvents, unsubEvents := broker.Subscribe(ssebroker.TopicDashEvents)
+		chEvents, unsubEvents := broker.Subscribe(tavern.TopicDashEvents)
 		defer unsubEvents()
 
 		lastSent := make(map[string]time.Time)
@@ -160,7 +160,7 @@ var statsBufPool = sync.Pool{
 	New: func() any { return new(bytes.Buffer) },
 }
 
-func (ar *appRoutes) publishSystemStats(broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) publishSystemStats(broker *tavern.SSEBroker) {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 	start := time.Now()
@@ -169,19 +169,19 @@ func (ar *appRoutes) publishSystemStats(broker *ssebroker.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(ssebroker.TopicSystemStats) {
+			if !broker.HasSubscribers(tavern.TopicSystemStats) {
 				continue
 			}
-			stats := ssebroker.CollectRuntimeStats(start)
+			stats := tavern.CollectRuntimeStats(start)
 			buf := statsBufPool.Get().(*bytes.Buffer)
 			buf.Reset()
 			if err := views.SystemStatsOOB(stats).Render(shared.WithContextIDAndDescription(context.Background(), shared.GenerateContextID(), "publish system stats"), buf); err != nil {
 				statsBufPool.Put(buf)
 				continue
 			}
-			msg := ssebroker.NewSSEMessage("system-stats", buf.String()).String()
+			msg := tavern.NewSSEMessage("system-stats", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(ssebroker.TopicSystemStats, msg)
+			broker.Publish(tavern.TopicSystemStats, msg)
 		}
 	}
 }
@@ -212,7 +212,7 @@ func initialMetrics() views.MetricsSnapshot {
 	}
 }
 
-func (ar *appRoutes) publishMetrics(broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) publishMetrics(broker *tavern.SSEBroker) {
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
@@ -240,7 +240,7 @@ func (ar *appRoutes) publishMetrics(broker *ssebroker.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(ssebroker.TopicDashMetrics) {
+			if !broker.HasSubscribers(tavern.TopicDashMetrics) {
 				continue
 			}
 
@@ -385,7 +385,7 @@ func (ar *appRoutes) publishMetrics(broker *ssebroker.SSEBroker) {
 			snap.ConnWait = connWait
 
 			// Collect runtime stats for dashboard system metrics cards
-			stats := ssebroker.CollectRuntimeStats(ar.startTime)
+			stats := tavern.CollectRuntimeStats(ar.startTime)
 
 			buf := statsBufPool.Get().(*bytes.Buffer)
 			buf.Reset()
@@ -393,9 +393,9 @@ func (ar *appRoutes) publishMetrics(broker *ssebroker.SSEBroker) {
 				statsBufPool.Put(buf)
 				continue
 			}
-			msg := ssebroker.NewSSEMessage("dashboard-metrics", buf.String()).String()
+			msg := tavern.NewSSEMessage("dashboard-metrics", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(ssebroker.TopicDashMetrics, msg)
+			broker.Publish(tavern.TopicDashMetrics, msg)
 		}
 	}
 }
@@ -439,7 +439,7 @@ func initialServiceLatencies() []views.ServiceLatency {
 	return svcLats
 }
 
-func (ar *appRoutes) publishServices(broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) publishServices(broker *tavern.SSEBroker) {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 
@@ -451,7 +451,7 @@ func (ar *appRoutes) publishServices(broker *ssebroker.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(ssebroker.TopicDashServices) {
+			if !broker.HasSubscribers(tavern.TopicDashServices) {
 				continue
 			}
 
@@ -484,9 +484,9 @@ func (ar *appRoutes) publishServices(broker *ssebroker.SSEBroker) {
 				statsBufPool.Put(buf)
 				continue
 			}
-			msg := ssebroker.NewSSEMessage("dashboard-services", buf.String()).String()
+			msg := tavern.NewSSEMessage("dashboard-services", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(ssebroker.TopicDashServices, msg)
+			broker.Publish(tavern.TopicDashServices, msg)
 		}
 	}
 }
@@ -525,7 +525,7 @@ var eventTemplates = []eventTemplate{
 	}},
 }
 
-func (ar *appRoutes) publishEvents(broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) publishEvents(broker *tavern.SSEBroker) {
 	for {
 		// Random interval 800ms–2s
 		delay := time.Duration(800+rand.IntN(1200)) * time.Millisecond
@@ -534,7 +534,7 @@ func (ar *appRoutes) publishEvents(broker *ssebroker.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-time.After(delay):
-			if !broker.HasSubscribers(ssebroker.TopicDashEvents) {
+			if !broker.HasSubscribers(tavern.TopicDashEvents) {
 				continue
 			}
 
@@ -551,9 +551,9 @@ func (ar *appRoutes) publishEvents(broker *ssebroker.SSEBroker) {
 				statsBufPool.Put(buf)
 				continue
 			}
-			msg := ssebroker.NewSSEMessage("dashboard-events", buf.String()).String()
+			msg := tavern.NewSSEMessage("dashboard-events", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(ssebroker.TopicDashEvents, msg)
+			broker.Publish(tavern.TopicDashEvents, msg)
 		}
 	}
 }

--- a/internal/routes/routes_report_issue.go
+++ b/internal/routes/routes_report_issue.go
@@ -8,7 +8,7 @@ import (
 	// setup:feature:demo:end
 	"catgoose/dothog/internal/logger"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"net/http"
 
 	corecomponents "catgoose/dothog/web/components/core"
@@ -78,7 +78,7 @@ func (ar *appRoutes) initReportIssueRoutes() {
 	// The modal auto-opens via HyperScript on load.
 	ar.e.GET("/report-issue/:requestID", func(c echo.Context) error {
 		requestID := c.Param("requestID")
-		cfg := hypermedia.ReportIssueModal(requestID)
+		cfg := linkwell.ReportIssueModal(requestID)
 		return handler.RenderComponent(c, corecomponents.ReportIssueModal(cfg))
 	})
 }

--- a/internal/routes/routes_repository.go
+++ b/internal/routes/routes_repository.go
@@ -10,7 +10,7 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/web/views"
 
 	"github.com/a-h/templ"
@@ -229,7 +229,7 @@ func parseRepoTableParams(c echo.Context, perPage int) repoTableParams {
 	}
 }
 
-func (r *repositoryRoutes) buildContent(c echo.Context) (hypermedia.FilterBar, templ.Component, error) {
+func (r *repositoryRoutes) buildContent(c echo.Context) (linkwell.FilterBar, templ.Component, error) {
 	const perPage = 10
 	p := parseRepoTableParams(c, perPage)
 
@@ -239,43 +239,43 @@ func (r *repositoryRoutes) buildContent(c echo.Context) (hypermedia.FilterBar, t
 		p.Sort, p.Dir, p.Page, p.PerPage,
 	)
 	if err != nil {
-		return hypermedia.FilterBar{}, nil, err
+		return linkwell.FilterBar{}, nil, err
 	}
 
 	itemsURL := repoBase + "/tasks"
 	target := "#repo-table-container"
 
-	bar := hypermedia.NewFilterBar(itemsURL, target,
-		hypermedia.SearchField("q", "Search tasks...", p.Q),
-		hypermedia.SelectField("status", "Status", p.Status,
-			hypermedia.SelectOptions(p.Status,
+	bar := linkwell.NewFilterBar(itemsURL, target,
+		linkwell.SearchField("q", "Search tasks...", p.Q),
+		linkwell.SelectField("status", "Status", p.Status,
+			linkwell.SelectOptions(p.Status,
 				"", "All",
 				"draft", "Draft",
 				"active", "Active",
 				"done", "Done",
 			)),
-		hypermedia.CheckboxField("archived", "Show archived", p.ShowArchived),
-		hypermedia.CheckboxField("deleted", "Show deleted", p.ShowDeleted),
+		linkwell.CheckboxField("archived", "Show archived", p.ShowArchived),
+		linkwell.CheckboxField("deleted", "Show deleted", p.ShowDeleted),
 	)
 
 	sortBase := repoStripParams(c.Request().URL, "sort", "dir")
-	cols := []hypermedia.TableCol{
-		hypermedia.SortableCol("title", "Title", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+	cols := []linkwell.TableCol{
+		linkwell.SortableCol("title", "Title", p.Sort, p.Dir, sortBase, target, "#filter-form"),
 		{Label: "Description"},
-		hypermedia.SortableCol("status", "Status", p.Sort, p.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("sortorder", "Order", p.Sort, p.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("version", "Ver", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("status", "Status", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("sortorder", "Order", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("version", "Ver", p.Sort, p.Dir, sortBase, target, "#filter-form"),
 		{Label: "State"},
-		hypermedia.SortableCol("updated", "Updated", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("updated", "Updated", p.Sort, p.Dir, sortBase, target, "#filter-form"),
 		{Label: "Actions"},
 	}
 
 	pageBase := repoStripParams(c.Request().URL, "page")
-	info := hypermedia.PageInfo{
+	info := linkwell.PageInfo{
 		Page:       p.Page,
 		PerPage:    p.PerPage,
 		TotalItems: total,
-		TotalPages: hypermedia.ComputeTotalPages(total, p.PerPage),
+		TotalPages: linkwell.ComputeTotalPages(total, p.PerPage),
 		BaseURL:    pageBase,
 		Target:     target,
 		Include:    "#filter-form",

--- a/internal/routes/routes_tables.go
+++ b/internal/routes/routes_tables.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 
-	hx "github.com/catgoose/cheddar"
+	"github.com/catgoose/cheddar"
 
 	"github.com/labstack/echo/v4"
 )
@@ -45,32 +45,32 @@ func parseTableParams(c echo.Context, perPage int) tableParams {
 type tableContent struct {
 	Items []demo.Item
 	Total int
-	Bar   hypermedia.FilterBar
-	Cols  []hypermedia.TableCol
-	Info  hypermedia.PageInfo
+	Bar   linkwell.FilterBar
+	Cols  []linkwell.TableCol
+	Info  linkwell.PageInfo
 }
 
 // buildTableContent queries the DB and builds the filter bar, sortable columns, and pagination info.
 // extraCols are appended after the standard sortable columns.
-func buildTableContent(c echo.Context, db *demo.DB, p tableParams, itemsURL, target string, extraCols ...hypermedia.TableCol) (tableContent, error) {
+func buildTableContent(c echo.Context, db *demo.DB, p tableParams, itemsURL, target string, extraCols ...linkwell.TableCol) (tableContent, error) {
 	items, total, err := db.ListItems(c.Request().Context(), p.Q, p.Category, p.Active, p.Sort, p.Dir, p.Page, p.PerPage)
 	if err != nil {
 		return tableContent{}, err
 	}
 
-	bar := hypermedia.NewFilterBar(itemsURL, target,
-		hypermedia.SearchField("q", "Search items\u2026", p.Q),
-		hypermedia.SelectField("category", "Category", p.Category,
-			hypermedia.SelectOptions(p.Category, itemCategoryPairs()...)),
-		hypermedia.CheckboxField("active", "Active only", p.Active),
+	bar := linkwell.NewFilterBar(itemsURL, target,
+		linkwell.SearchField("q", "Search items\u2026", p.Q),
+		linkwell.SelectField("category", "Category", p.Category,
+			linkwell.SelectOptions(p.Category, itemCategoryPairs()...)),
+		linkwell.CheckboxField("active", "Active only", p.Active),
 	)
 
 	sortBase := buildSortBase(c)
-	cols := []hypermedia.TableCol{
-		hypermedia.SortableCol("name", "Name", p.Sort, p.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("category", "Category", p.Sort, p.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("price", "Price", p.Sort, p.Dir, sortBase, target, "#filter-form"),
-		hypermedia.SortableCol("stock", "Stock", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+	cols := []linkwell.TableCol{
+		linkwell.SortableCol("name", "Name", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("category", "Category", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("price", "Price", p.Sort, p.Dir, sortBase, target, "#filter-form"),
+		linkwell.SortableCol("stock", "Stock", p.Sort, p.Dir, sortBase, target, "#filter-form"),
 		{Label: "Status"},
 	}
 	cols = append(cols, extraCols...)
@@ -97,14 +97,14 @@ func filterQueryFromHXCurrentURL(c echo.Context) string {
 // setTableReplaceURL sets HX-Replace-Url to basePath?{currentQueryString} so the browser
 // URL stays in sync with the active filters after any table-replacing response.
 func setTableReplaceURL(c echo.Context, basePath string) {
-	if !hx.IsHTMX(c) {
+	if !cheddar.IsHTMX(c) {
 		return
 	}
 	pushURL := basePath
 	if q := c.Request().URL.RawQuery; q != "" {
 		pushURL += "?" + q
 	}
-	hx.ReplaceURL(c, pushURL)
+	cheddar.ReplaceURL(c, pushURL)
 }
 
 // applyFilterFromCurrentURL reads HX-Current-URL and sets the request URL's query string
@@ -117,13 +117,13 @@ func applyFilterFromCurrentURL(c echo.Context) {
 }
 
 // buildPageInfo constructs a PageInfo from common pagination parameters.
-func buildPageInfo(c echo.Context, page, perPage, total int, target string) hypermedia.PageInfo {
+func buildPageInfo(c echo.Context, page, perPage, total int, target string) linkwell.PageInfo {
 	pageBase := stripParams(c.Request().URL, "page")
-	return hypermedia.PageInfo{
+	return linkwell.PageInfo{
 		Page:       page,
 		PerPage:    perPage,
 		TotalItems: total,
-		TotalPages: hypermedia.ComputeTotalPages(total, perPage),
+		TotalPages: linkwell.ComputeTotalPages(total, perPage),
 		BaseURL:    pageBase,
 		Target:     target,
 		Include:    "#filter-form",

--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -11,7 +11,7 @@ import (
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/web/views"
 	// setup:feature:session_settings:end
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 
 	// setup:feature:session_settings:start
 	"github.com/catgoose/porter"
@@ -21,14 +21,14 @@ import (
 
 // setup:feature:session_settings:start
 
-func (ar *appRoutes) initThemeRoutes(broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initThemeRoutes(broker *tavern.SSEBroker) {
 	ar.e.POST("/settings/theme", ar.handleTheme(broker))
 	ar.e.POST("/settings/layout", ar.handleLayout())
 	ar.e.GET("/sse/theme", handleSSETheme(broker))
 }
 
 // handleTheme updates the shared theme setting and broadcasts to all browsers.
-func (ar *appRoutes) handleTheme(broker *ssebroker.SSEBroker) echo.HandlerFunc {
+func (ar *appRoutes) handleTheme(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		theme := c.FormValue("theme")
 		valid := false
@@ -50,9 +50,9 @@ func (ar *appRoutes) handleTheme(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 		}
 
 		// Broadcast theme change to all connected browsers.
-		if broker.HasSubscribers(ssebroker.TopicThemeChange) {
-			msg := ssebroker.NewSSEMessage("theme-change", theme).String()
-			broker.Publish(ssebroker.TopicThemeChange, msg)
+		if broker.HasSubscribers(tavern.TopicThemeChange) {
+			msg := tavern.NewSSEMessage("theme-change", theme).String()
+			broker.Publish(tavern.TopicThemeChange, msg)
 		}
 
 		return handler.RenderComponent(c, views.ThemeChanged(theme))
@@ -85,7 +85,7 @@ func (ar *appRoutes) handleLayout() echo.HandlerFunc {
 // setup:feature:session_settings:end
 
 // handleSSETheme streams theme-change events to all connected browsers.
-func handleSSETheme(broker *ssebroker.SSEBroker) echo.HandlerFunc {
+func handleSSETheme(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		c.Response().Header().Set("Content-Type", "text/event-stream")
 		c.Response().Header().Set("Cache-Control", "no-cache")
@@ -97,7 +97,7 @@ func handleSSETheme(broker *ssebroker.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		ch, unsub := broker.Subscribe(ssebroker.TopicThemeChange)
+		ch, unsub := broker.Subscribe(tavern.TopicThemeChange)
 		defer unsub()
 
 		ctx := c.Request().Context()

--- a/internal/routes/routes_vendors_contacts.go
+++ b/internal/routes/routes_vendors_contacts.go
@@ -5,9 +5,9 @@ package routes
 import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/params"
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -17,10 +17,10 @@ import (
 type vendorContactRoutes struct {
 	db     *demo.DB
 	actLog *demo.ActivityLog
-	broker *ssebroker.SSEBroker
+	broker *tavern.SSEBroker
 }
 
-func (ar *appRoutes) initVendorContactRoutes(db *demo.DB, actLog *demo.ActivityLog, broker *ssebroker.SSEBroker) {
+func (ar *appRoutes) initVendorContactRoutes(db *demo.DB, actLog *demo.ActivityLog, broker *tavern.SSEBroker) {
 	v := &vendorContactRoutes{db: db, actLog: actLog, broker: broker}
 	ar.e.GET("/demo/vendors", v.handleVendorsPage)
 	ar.e.GET("/demo/vendors/list", v.handleVendorsList)
@@ -112,11 +112,11 @@ func (v *vendorContactRoutes) handleContactUpdate(c echo.Context) error {
 	return handler.RenderComponent(c, views.ContactCard(contact))
 }
 
-func (v *vendorContactRoutes) buildFilterBar(search, category string) hypermedia.FilterBar {
-	return hypermedia.NewFilterBar("/demo/vendors/list", "#vendor-list",
-		hypermedia.SearchField("q", "Search vendors\u2026", search),
-		hypermedia.SelectField("category", "Category", category,
-			hypermedia.SelectOptions(category, vendorCategoryPairs()...)),
+func (v *vendorContactRoutes) buildFilterBar(search, category string) linkwell.FilterBar {
+	return linkwell.NewFilterBar("/demo/vendors/list", "#vendor-list",
+		linkwell.SearchField("q", "Search vendors\u2026", search),
+		linkwell.SelectField("category", "Category", category,
+			linkwell.SelectOptions(category, vendorCategoryPairs()...)),
 	)
 }
 

--- a/web/components/core/attrs.go
+++ b/web/components/core/attrs.go
@@ -1,13 +1,13 @@
 package components
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"github.com/a-h/templ"
 )
 
 // hxAttrsFromControl converts HxRequest fields to templ.Attributes with "hx-" prefix.
 // Also injects hx-confirm, hx-push-url, and hx-swap from their dedicated Control fields.
-func hxAttrsFromControl(ctrl hypermedia.Control) templ.Attributes {
+func hxAttrsFromControl(ctrl linkwell.Control) templ.Attributes {
 	req := ctrl.HxRequest
 	attrs := make(templ.Attributes, 5)
 	if req.URL != "" {

--- a/web/components/core/attrs_test.go
+++ b/web/components/core/attrs_test.go
@@ -3,15 +3,15 @@ package components
 import (
 	"testing"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestHxAttrsFromControl_BasicAttrs(t *testing.T) {
-	ctrl := hypermedia.Control{
-		HxRequest: hypermedia.HxGet("/items", "#list"),
-		Swap:      hypermedia.SwapInnerHTML,
+	ctrl := linkwell.Control{
+		HxRequest: linkwell.HxGet("/items", "#list"),
+		Swap:      linkwell.SwapInnerHTML,
 	}
 	attrs := hxAttrsFromControl(ctrl)
 	require.Equal(t, "/items", attrs["hx-get"])
@@ -20,9 +20,9 @@ func TestHxAttrsFromControl_BasicAttrs(t *testing.T) {
 }
 
 func TestHxAttrsFromControl_Confirm(t *testing.T) {
-	ctrl := hypermedia.Control{
+	ctrl := linkwell.Control{
 		Confirm:   "Are you sure?",
-		HxRequest: hypermedia.HxDelete("/item/1", ""),
+		HxRequest: linkwell.HxDelete("/item/1", ""),
 	}
 	attrs := hxAttrsFromControl(ctrl)
 	require.Equal(t, "Are you sure?", attrs["hx-confirm"])
@@ -30,9 +30,9 @@ func TestHxAttrsFromControl_Confirm(t *testing.T) {
 }
 
 func TestHxAttrsFromControl_PushURL(t *testing.T) {
-	ctrl := hypermedia.Control{
+	ctrl := linkwell.Control{
 		PushURL:   "/dashboard",
-		HxRequest: hypermedia.HxGet("/dashboard", ""),
+		HxRequest: linkwell.HxGet("/dashboard", ""),
 	}
 	attrs := hxAttrsFromControl(ctrl)
 	require.Equal(t, "/dashboard", attrs["hx-push-url"])
@@ -40,9 +40,9 @@ func TestHxAttrsFromControl_PushURL(t *testing.T) {
 }
 
 func TestHxAttrsFromControl_SwapField(t *testing.T) {
-	ctrl := hypermedia.Control{
-		Swap:      hypermedia.SwapOuterHTML,
-		HxRequest: hypermedia.HxPost("/submit", ""),
+	ctrl := linkwell.Control{
+		Swap:      linkwell.SwapOuterHTML,
+		HxRequest: linkwell.HxPost("/submit", ""),
 	}
 	attrs := hxAttrsFromControl(ctrl)
 	require.Equal(t, "outerHTML", attrs["hx-swap"])
@@ -50,11 +50,11 @@ func TestHxAttrsFromControl_SwapField(t *testing.T) {
 }
 
 func TestHxAttrsFromControl_AllFieldsSet(t *testing.T) {
-	ctrl := hypermedia.Control{
-		HxRequest: hypermedia.HxPut("/update", ""),
+	ctrl := linkwell.Control{
+		HxRequest: linkwell.HxPut("/update", ""),
 		Confirm:   "Confirm?",
 		PushURL:   "/updated",
-		Swap:      hypermedia.SwapNone,
+		Swap:      linkwell.SwapNone,
 	}
 	attrs := hxAttrsFromControl(ctrl)
 	require.Equal(t, "/update", attrs["hx-put"])
@@ -64,7 +64,7 @@ func TestHxAttrsFromControl_AllFieldsSet(t *testing.T) {
 }
 
 func TestHxAttrsFromControl_EmptyControl(t *testing.T) {
-	ctrl := hypermedia.Control{}
+	ctrl := linkwell.Control{}
 	attrs := hxAttrsFromControl(ctrl)
 	require.NotNil(t, attrs)
 	_, hasConfirm := attrs["hx-confirm"]
@@ -76,9 +76,9 @@ func TestHxAttrsFromControl_EmptyControl(t *testing.T) {
 }
 
 func TestHxAttrsFromControl_IncludeField(t *testing.T) {
-	ctrl := hypermedia.Control{
-		HxRequest: hypermedia.HxRequestConfig{
-			Method:  hypermedia.HxMethodPut,
+	ctrl := linkwell.Control{
+		HxRequest: linkwell.HxRequestConfig{
+			Method:  linkwell.HxMethodPut,
 			URL:     "/save",
 			Target:  "#tc",
 			Include: "closest tr",
@@ -91,7 +91,7 @@ func TestHxAttrsFromControl_IncludeField(t *testing.T) {
 }
 
 func TestHxAttrsFromControl_ZeroHxRequest(t *testing.T) {
-	ctrl := hypermedia.Control{
+	ctrl := linkwell.Control{
 		Confirm: "Sure?",
 	}
 	attrs := hxAttrsFromControl(ctrl)

--- a/web/components/core/context.templ
+++ b/web/components/core/context.templ
@@ -1,12 +1,12 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // ContextStrip renders a unified bar with breadcrumbs on the left and
 // app-provided context links (children) on the right. On mobile, breadcrumbs
 // are hidden and only context links show. If no breadcrumbs or children are
 // provided, the strip is not rendered.
-templ ContextStrip(crumbs []hypermedia.Breadcrumb) {
+templ ContextStrip(crumbs []linkwell.Breadcrumb) {
 	<div class="px-4 py-1.5 bg-base-100 border-b border-base-300 text-sm">
 		<div class="flex items-center justify-between gap-4">
 			if len(crumbs) > 0 {
@@ -25,7 +25,7 @@ templ ContextStrip(crumbs []hypermedia.Breadcrumb) {
 // The from parameter is forwarded as ?from= for breadcrumb context.
 templ ContextLink(href, label, from string) {
 	<a
-		href={ templ.URL(hypermedia.FromNav(href, from)) }
+		href={ templ.URL(linkwell.FromNav(href, from)) }
 		class="link link-hover text-base-content/60 hover:text-base-content whitespace-nowrap"
 	>
 		{ label }

--- a/web/components/core/context_bar.templ
+++ b/web/components/core/context_bar.templ
@@ -3,7 +3,7 @@
 package components
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"sort"
 )
 
@@ -24,7 +24,7 @@ type contextBarGroup struct {
 // It finds the hub this page belongs to (either as center or spoke) and
 // resolves all spokes into their ring groups. Both hub centers and spoke
 // pages see the same grouped view.
-func contextBarGroups(links []hypermedia.LinkRelation, currentPath string) []contextBarGroup {
+func contextBarGroups(links []linkwell.LinkRelation, currentPath string) []contextBarGroup {
 	// Determine the hub path: either we ARE the hub (have outgoing related links
 	// with a hub group) or we have a rel="up" pointing to our hub.
 	var hubPath string
@@ -65,7 +65,7 @@ func contextBarGroups(links []hypermedia.LinkRelation, currentPath string) []con
 			}
 		}
 	} else {
-		hubLinks := hypermedia.LinksFor(hubPath, "related")
+		hubLinks := linkwell.LinksFor(hubPath, "related")
 		for _, l := range hubLinks {
 			if l.Href != currentPath {
 				spokes = append(spokes, contextBarItem{Href: l.Href, Title: l.Title})
@@ -89,7 +89,7 @@ func contextBarGroups(links []hypermedia.LinkRelation, currentPath string) []con
 }
 
 // simpleGroups is the fallback grouping when no hub relationship exists.
-func simpleGroups(links []hypermedia.LinkRelation, currentPath string) []contextBarGroup {
+func simpleGroups(links []linkwell.LinkRelation, currentPath string) []contextBarGroup {
 	seen := map[string]int{}
 	var groups []contextBarGroup
 	for _, l := range links {
@@ -121,7 +121,7 @@ func resolveIntoRings(spokes []contextBarItem, hubName string, currentPath strin
 	placed := map[string]bool{}
 
 	for _, item := range spokes {
-		spokeLinks := hypermedia.LinksFor(item.Href, "related")
+		spokeLinks := linkwell.LinksFor(item.Href, "related")
 		for _, sl := range spokeLinks {
 			if sl.Group != "" && sl.Group != hubName && !placed[item.Href+"|"+sl.Group] {
 				idx, ok := seen[sl.Group]
@@ -180,7 +180,7 @@ func hasItem(items []contextBarItem, href string) bool {
 
 // ContextBar renders a horizontal strip of related page links grouped by ring name.
 // Server-rendered with a stable ID so it can be updated via hx-swap-oob on navigation.
-templ ContextBar(links []hypermedia.LinkRelation, currentPath string) {
+templ ContextBar(links []linkwell.LinkRelation, currentPath string) {
 	<div id="context-bar"
 		_="init if localStorage.getItem('dothog_show_context_bar') !== 'true' then hide me"
 	>
@@ -201,7 +201,7 @@ templ ContextBar(links []hypermedia.LinkRelation, currentPath string) {
 
 // LocalContextBar renders a compact strip of the current page's immediate
 // ring siblings — the pages in the same ring group(s) as the current page.
-templ LocalContextBar(links []hypermedia.LinkRelation, currentPath string) {
+templ LocalContextBar(links []linkwell.LinkRelation, currentPath string) {
 	<div id="local-context-bar"
 		_="init if localStorage.getItem('dothog_hide_local_context_bar') === 'true' then hide me"
 	>
@@ -231,7 +231,7 @@ templ LocalContextBar(links []hypermedia.LinkRelation, currentPath string) {
 
 // localGroups returns only the rings the current page directly belongs to,
 // prepended with the hub parent link (rel="up") when present.
-func localGroups(links []hypermedia.LinkRelation, currentPath string) []contextBarGroup {
+func localGroups(links []linkwell.LinkRelation, currentPath string) []contextBarGroup {
 	var groups []contextBarGroup
 
 	// Prepend hub parent link if present, matching ContextBar behaviour.

--- a/web/components/core/context_bar_templ.go
+++ b/web/components/core/context_bar_templ.go
@@ -11,7 +11,7 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	"sort"
 )
 
@@ -32,7 +32,7 @@ type contextBarGroup struct {
 // It finds the hub this page belongs to (either as center or spoke) and
 // resolves all spokes into their ring groups. Both hub centers and spoke
 // pages see the same grouped view.
-func contextBarGroups(links []hypermedia.LinkRelation, currentPath string) []contextBarGroup {
+func contextBarGroups(links []linkwell.LinkRelation, currentPath string) []contextBarGroup {
 	// Determine the hub path: either we ARE the hub (have outgoing related links
 	// with a hub group) or we have a rel="up" pointing to our hub.
 	var hubPath string
@@ -73,7 +73,7 @@ func contextBarGroups(links []hypermedia.LinkRelation, currentPath string) []con
 			}
 		}
 	} else {
-		hubLinks := hypermedia.LinksFor(hubPath, "related")
+		hubLinks := linkwell.LinksFor(hubPath, "related")
 		for _, l := range hubLinks {
 			if l.Href != currentPath {
 				spokes = append(spokes, contextBarItem{Href: l.Href, Title: l.Title})
@@ -97,7 +97,7 @@ func contextBarGroups(links []hypermedia.LinkRelation, currentPath string) []con
 }
 
 // simpleGroups is the fallback grouping when no hub relationship exists.
-func simpleGroups(links []hypermedia.LinkRelation, currentPath string) []contextBarGroup {
+func simpleGroups(links []linkwell.LinkRelation, currentPath string) []contextBarGroup {
 	seen := map[string]int{}
 	var groups []contextBarGroup
 	for _, l := range links {
@@ -129,7 +129,7 @@ func resolveIntoRings(spokes []contextBarItem, hubName string, currentPath strin
 	placed := map[string]bool{}
 
 	for _, item := range spokes {
-		spokeLinks := hypermedia.LinksFor(item.Href, "related")
+		spokeLinks := linkwell.LinksFor(item.Href, "related")
 		for _, sl := range spokeLinks {
 			if sl.Group != "" && sl.Group != hubName && !placed[item.Href+"|"+sl.Group] {
 				idx, ok := seen[sl.Group]
@@ -188,7 +188,7 @@ func hasItem(items []contextBarItem, href string) bool {
 
 // ContextBar renders a horizontal strip of related page links grouped by ring name.
 // Server-rendered with a stable ID so it can be updated via hx-swap-oob on navigation.
-func ContextBar(links []hypermedia.LinkRelation, currentPath string) templ.Component {
+func ContextBar(links []linkwell.LinkRelation, currentPath string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -249,7 +249,7 @@ func ContextBar(links []hypermedia.LinkRelation, currentPath string) templ.Compo
 
 // LocalContextBar renders a compact strip of the current page's immediate
 // ring siblings — the pages in the same ring group(s) as the current page.
-func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.Component {
+func LocalContextBar(links []linkwell.LinkRelation, currentPath string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -390,7 +390,7 @@ func LocalContextBar(links []hypermedia.LinkRelation, currentPath string) templ.
 
 // localGroups returns only the rings the current page directly belongs to,
 // prepended with the hub parent link (rel="up") when present.
-func localGroups(links []hypermedia.LinkRelation, currentPath string) []contextBarGroup {
+func localGroups(links []linkwell.LinkRelation, currentPath string) []contextBarGroup {
 	var groups []contextBarGroup
 
 	// Prepend hub parent link if present, matching ContextBar behaviour.

--- a/web/components/core/context_templ.go
+++ b/web/components/core/context_templ.go
@@ -8,13 +8,13 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // ContextStrip renders a unified bar with breadcrumbs on the left and
 // app-provided context links (children) on the right. On mobile, breadcrumbs
 // are hidden and only context links show. If no breadcrumbs or children are
 // provided, the strip is not rendered.
-func ContextStrip(crumbs []hypermedia.Breadcrumb) templ.Component {
+func ContextStrip(crumbs []linkwell.Breadcrumb) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -97,7 +97,7 @@ func ContextLink(href, label, from string) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 templ.SafeURL
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(hypermedia.FromNav(href, from)))
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(linkwell.FromNav(href, from)))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 28, Col: 50}
 		}

--- a/web/components/core/controls.templ
+++ b/web/components/core/controls.templ
@@ -1,17 +1,17 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // variantClass maps a ControlVariant to the corresponding DaisyUI btn modifier class.
-func variantClass(v hypermedia.ControlVariant) string {
+func variantClass(v linkwell.ControlVariant) string {
 	switch v {
-	case hypermedia.VariantPrimary:
+	case linkwell.VariantPrimary:
 		return "btn-primary"
-	case hypermedia.VariantDanger:
+	case linkwell.VariantDanger:
 		return "btn-error"
-	case hypermedia.VariantGhost:
+	case linkwell.VariantGhost:
 		return "btn-ghost"
-	case hypermedia.VariantLink:
+	case linkwell.VariantLink:
 		return "btn-link"
 	default:
 		return "btn-secondary"
@@ -20,7 +20,7 @@ func variantClass(v hypermedia.ControlVariant) string {
 
 // InlineAlertControls renders controls styled for use inside DaisyUI alerts.
 // Buttons use btn-outline to inherit the alert's color context.
-templ InlineAlertControls(controls []hypermedia.Control) {
+templ InlineAlertControls(controls []linkwell.Control) {
 	if len(controls) > 0 {
 		<div class="ml-auto flex flex-wrap gap-2">
 			for _, ctrl := range controls {
@@ -30,16 +30,16 @@ templ InlineAlertControls(controls []hypermedia.Control) {
 	}
 }
 
-templ inlineAlertControl(ctrl hypermedia.Control) {
+templ inlineAlertControl(ctrl linkwell.Control) {
 	switch ctrl.Kind {
-		case hypermedia.ControlKindReport:
+		case linkwell.ControlKindReport:
 			@genericReportButton(ctrl)
 		default:
 			@inlineAlertButton(ctrl)
 	}
 }
 
-templ inlineAlertButton(ctrl hypermedia.Control) {
+templ inlineAlertButton(ctrl linkwell.Control) {
 	<button
 		{ hxAttrsFromControl(ctrl)... }
 		class="btn btn-sm btn-outline"
@@ -52,7 +52,7 @@ templ inlineAlertButton(ctrl hypermedia.Control) {
 
 // Controls renders a flex row of generic DaisyUI-styled controls.
 // Use outside error contexts (CRUD action bars, form footers, empty states).
-templ Controls(controls []hypermedia.Control) {
+templ Controls(controls []linkwell.Control) {
 	if len(controls) > 0 {
 		<div class="flex flex-wrap gap-2">
 			for _, ctrl := range controls {
@@ -62,26 +62,26 @@ templ Controls(controls []hypermedia.Control) {
 	}
 }
 
-templ control(ctrl hypermedia.Control) {
+templ control(ctrl linkwell.Control) {
 	switch ctrl.Kind {
-		case hypermedia.ControlKindRetry:
+		case linkwell.ControlKindRetry:
 			@genericButton(ctrl)
-		case hypermedia.ControlKindHTMX:
+		case linkwell.ControlKindHTMX:
 			@genericButton(ctrl)
-		case hypermedia.ControlKindBack:
+		case linkwell.ControlKindBack:
 			@backButton(ctrl)
-		case hypermedia.ControlKindHome:
+		case linkwell.ControlKindHome:
 			@homeButton(ctrl)
-		case hypermedia.ControlKindLink:
+		case linkwell.ControlKindLink:
 			@genericLink(ctrl)
-		case hypermedia.ControlKindDismiss:
+		case linkwell.ControlKindDismiss:
 			@genericDismiss(ctrl)
-		case hypermedia.ControlKindReport:
+		case linkwell.ControlKindReport:
 			@genericReportButton(ctrl)
 	}
 }
 
-templ genericButton(ctrl hypermedia.Control) {
+templ genericButton(ctrl linkwell.Control) {
 	<button
 		{ hxAttrsFromControl(ctrl)... }
 		class={ "btn btn-sm " + variantClass(ctrl.Variant) }
@@ -92,7 +92,7 @@ templ genericButton(ctrl hypermedia.Control) {
 	</button>
 }
 
-templ backButton(ctrl hypermedia.Control) {
+templ backButton(ctrl linkwell.Control) {
 	<button
 		class={ "btn btn-sm " + variantClass(ctrl.Variant) }
 		disabled?={ ctrl.Disabled }
@@ -103,7 +103,7 @@ templ backButton(ctrl hypermedia.Control) {
 	</button>
 }
 
-templ homeButton(ctrl hypermedia.Control) {
+templ homeButton(ctrl linkwell.Control) {
 	<button
 		class={ "btn btn-sm " + variantClass(ctrl.Variant) }
 		disabled?={ ctrl.Disabled }
@@ -114,7 +114,7 @@ templ homeButton(ctrl hypermedia.Control) {
 	</button>
 }
 
-templ genericLink(ctrl hypermedia.Control) {
+templ genericLink(ctrl linkwell.Control) {
 	<a
 		href={ templ.URL(ctrl.Href) }
 		class={ "btn btn-sm " + variantClass(ctrl.Variant) }
@@ -124,7 +124,7 @@ templ genericLink(ctrl hypermedia.Control) {
 	</a>
 }
 
-templ genericDismiss(ctrl hypermedia.Control) {
+templ genericDismiss(ctrl linkwell.Control) {
 	<button
 		class={ "btn btn-sm " + variantClass(ctrl.Variant) }
 		_="on click set el to #error-message-content then set el's style.transition to 'opacity 0.3s ease' then set el's style.opacity to '0' then wait 300ms then remove el"
@@ -134,7 +134,7 @@ templ genericDismiss(ctrl hypermedia.Control) {
 	</button>
 }
 
-templ genericReportButton(ctrl hypermedia.Control) {
+templ genericReportButton(ctrl linkwell.Control) {
 	<button
 		{ hxAttrsFromControl(ctrl)... }
 		class="btn btn-sm btn-ghost"

--- a/web/components/core/controls_templ.go
+++ b/web/components/core/controls_templ.go
@@ -8,18 +8,18 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // variantClass maps a ControlVariant to the corresponding DaisyUI btn modifier class.
-func variantClass(v hypermedia.ControlVariant) string {
+func variantClass(v linkwell.ControlVariant) string {
 	switch v {
-	case hypermedia.VariantPrimary:
+	case linkwell.VariantPrimary:
 		return "btn-primary"
-	case hypermedia.VariantDanger:
+	case linkwell.VariantDanger:
 		return "btn-error"
-	case hypermedia.VariantGhost:
+	case linkwell.VariantGhost:
 		return "btn-ghost"
-	case hypermedia.VariantLink:
+	case linkwell.VariantLink:
 		return "btn-link"
 	default:
 		return "btn-secondary"
@@ -28,7 +28,7 @@ func variantClass(v hypermedia.ControlVariant) string {
 
 // InlineAlertControls renders controls styled for use inside DaisyUI alerts.
 // Buttons use btn-outline to inherit the alert's color context.
-func InlineAlertControls(controls []hypermedia.Control) templ.Component {
+func InlineAlertControls(controls []linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -69,7 +69,7 @@ func InlineAlertControls(controls []hypermedia.Control) templ.Component {
 	})
 }
 
-func inlineAlertControl(ctrl hypermedia.Control) templ.Component {
+func inlineAlertControl(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -91,7 +91,7 @@ func inlineAlertControl(ctrl hypermedia.Control) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		switch ctrl.Kind {
-		case hypermedia.ControlKindReport:
+		case linkwell.ControlKindReport:
 			templ_7745c5c3_Err = genericReportButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -106,7 +106,7 @@ func inlineAlertControl(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func inlineAlertButton(ctrl hypermedia.Control) templ.Component {
+func inlineAlertButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -172,7 +172,7 @@ func inlineAlertButton(ctrl hypermedia.Control) templ.Component {
 
 // Controls renders a flex row of generic DaisyUI-styled controls.
 // Use outside error contexts (CRUD action bars, form footers, empty states).
-func Controls(controls []hypermedia.Control) templ.Component {
+func Controls(controls []linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -213,7 +213,7 @@ func Controls(controls []hypermedia.Control) templ.Component {
 	})
 }
 
-func control(ctrl hypermedia.Control) templ.Component {
+func control(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -235,37 +235,37 @@ func control(ctrl hypermedia.Control) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		switch ctrl.Kind {
-		case hypermedia.ControlKindRetry:
+		case linkwell.ControlKindRetry:
 			templ_7745c5c3_Err = genericButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.ControlKindHTMX:
+		case linkwell.ControlKindHTMX:
 			templ_7745c5c3_Err = genericButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.ControlKindBack:
+		case linkwell.ControlKindBack:
 			templ_7745c5c3_Err = backButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.ControlKindHome:
+		case linkwell.ControlKindHome:
 			templ_7745c5c3_Err = homeButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.ControlKindLink:
+		case linkwell.ControlKindLink:
 			templ_7745c5c3_Err = genericLink(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.ControlKindDismiss:
+		case linkwell.ControlKindDismiss:
 			templ_7745c5c3_Err = genericDismiss(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.ControlKindReport:
+		case linkwell.ControlKindReport:
 			templ_7745c5c3_Err = genericReportButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -275,7 +275,7 @@ func control(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func genericButton(ctrl hypermedia.Control) templ.Component {
+func genericButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -357,7 +357,7 @@ func genericButton(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func backButton(ctrl hypermedia.Control) templ.Component {
+func backButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -431,7 +431,7 @@ func backButton(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func homeButton(ctrl hypermedia.Control) templ.Component {
+func homeButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -518,7 +518,7 @@ func homeButton(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func genericLink(ctrl hypermedia.Control) templ.Component {
+func genericLink(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -595,7 +595,7 @@ func genericLink(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func genericDismiss(ctrl hypermedia.Control) templ.Component {
+func genericDismiss(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -659,7 +659,7 @@ func genericDismiss(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func genericReportButton(ctrl hypermedia.Control) templ.Component {
+func genericReportButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/components/core/error_controls.templ
+++ b/web/components/core/error_controls.templ
@@ -1,26 +1,26 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // ErrorControls renders a row of hypermedia action controls for an error response.
-templ ErrorControls(controls []hypermedia.Control) {
+templ ErrorControls(controls []linkwell.Control) {
 	if len(controls) > 0 {
 		<div class="mt-2 flex flex-wrap gap-2">
 			for _, ctrl := range controls {
 				switch ctrl.Kind {
-					case hypermedia.ControlKindRetry:
+					case linkwell.ControlKindRetry:
 						@retryButton(ctrl)
-					case hypermedia.ControlKindLink:
+					case linkwell.ControlKindLink:
 						@linkControl(ctrl)
-					case hypermedia.ControlKindHTMX:
+					case linkwell.ControlKindHTMX:
 						@htmxButton(ctrl)
-					case hypermedia.ControlKindDismiss:
+					case linkwell.ControlKindDismiss:
 						@dismissButton(ctrl)
-					case hypermedia.ControlKindBack:
+					case linkwell.ControlKindBack:
 						@errorBackButton(ctrl)
-					case hypermedia.ControlKindHome:
+					case linkwell.ControlKindHome:
 						@errorHomeButton(ctrl)
-				case hypermedia.ControlKindReport:
+				case linkwell.ControlKindReport:
 					@reportButton(ctrl)
 				}
 			}
@@ -28,8 +28,8 @@ templ ErrorControls(controls []hypermedia.Control) {
 	}
 }
 
-templ retryButton(ctrl hypermedia.Control) {
-	if ctrl.Variant == hypermedia.VariantPrimary {
+templ retryButton(ctrl linkwell.Control) {
+	if ctrl.Variant == linkwell.VariantPrimary {
 		<button
 			{ hxAttrsFromControl(ctrl)... }
 			class="inline-flex items-center px-3 py-1 text-xs font-medium rounded bg-error text-error-content hover:bg-error/80 focus:outline-none disabled:opacity-50"
@@ -48,7 +48,7 @@ templ retryButton(ctrl hypermedia.Control) {
 	}
 }
 
-templ linkControl(ctrl hypermedia.Control) {
+templ linkControl(ctrl linkwell.Control) {
 	<a
 		href={ templ.URL(ctrl.Href) }
 		class="inline-flex items-center px-3 py-1 text-xs font-medium rounded border border-base-content/20 bg-base-100 text-base-content hover:bg-base-200 focus:outline-none"
@@ -57,7 +57,7 @@ templ linkControl(ctrl hypermedia.Control) {
 	</a>
 }
 
-templ htmxButton(ctrl hypermedia.Control) {
+templ htmxButton(ctrl linkwell.Control) {
 	<button
 		{ hxAttrsFromControl(ctrl)... }
 		class="inline-flex items-center px-3 py-1 text-xs font-medium rounded border border-base-content/20 bg-base-100 text-base-content hover:bg-base-200 focus:outline-none disabled:opacity-50"
@@ -67,7 +67,7 @@ templ htmxButton(ctrl hypermedia.Control) {
 	</button>
 }
 
-templ dismissButton(ctrl hypermedia.Control) {
+templ dismissButton(ctrl linkwell.Control) {
 	<button
 		class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded text-error-content/70 hover:text-error-content hover:underline focus:outline-none"
 		_="on click set #error-status.innerHTML to ''"
@@ -76,7 +76,7 @@ templ dismissButton(ctrl hypermedia.Control) {
 	</button>
 }
 
-templ errorBackButton(ctrl hypermedia.Control) {
+templ errorBackButton(ctrl linkwell.Control) {
 	<button
 		class="inline-flex items-center px-3 py-1 text-xs font-medium rounded border border-base-content/20 bg-base-100 text-base-content hover:bg-base-200 focus:outline-none"
 		_="on click send show-alert(detail:'Go Back intercepted — this is where navigation would happen') to window"
@@ -85,7 +85,7 @@ templ errorBackButton(ctrl hypermedia.Control) {
 	</button>
 }
 
-templ errorHomeButton(ctrl hypermedia.Control) {
+templ errorHomeButton(ctrl linkwell.Control) {
 	<button
 		{ hxAttrsFromControl(ctrl)... }
 		class="inline-flex items-center px-3 py-1 text-xs font-medium rounded border border-base-content/20 bg-base-100 text-base-content hover:bg-base-200 focus:outline-none"
@@ -94,7 +94,7 @@ templ errorHomeButton(ctrl hypermedia.Control) {
 	</button>
 }
 
-templ reportButton(ctrl hypermedia.Control) {
+templ reportButton(ctrl linkwell.Control) {
 	<button
 		{ hxAttrsFromControl(ctrl)... }
 		class="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded border border-error-content/30 bg-error-content/10 text-error-content hover:bg-error-content/20 focus:outline-none"

--- a/web/components/core/error_controls_templ.go
+++ b/web/components/core/error_controls_templ.go
@@ -8,10 +8,10 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // ErrorControls renders a row of hypermedia action controls for an error response.
-func ErrorControls(controls []hypermedia.Control) templ.Component {
+func ErrorControls(controls []linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -39,37 +39,37 @@ func ErrorControls(controls []hypermedia.Control) templ.Component {
 			}
 			for _, ctrl := range controls {
 				switch ctrl.Kind {
-				case hypermedia.ControlKindRetry:
+				case linkwell.ControlKindRetry:
 					templ_7745c5c3_Err = retryButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				case hypermedia.ControlKindLink:
+				case linkwell.ControlKindLink:
 					templ_7745c5c3_Err = linkControl(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				case hypermedia.ControlKindHTMX:
+				case linkwell.ControlKindHTMX:
 					templ_7745c5c3_Err = htmxButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				case hypermedia.ControlKindDismiss:
+				case linkwell.ControlKindDismiss:
 					templ_7745c5c3_Err = dismissButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				case hypermedia.ControlKindBack:
+				case linkwell.ControlKindBack:
 					templ_7745c5c3_Err = errorBackButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				case hypermedia.ControlKindHome:
+				case linkwell.ControlKindHome:
 					templ_7745c5c3_Err = errorHomeButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				case hypermedia.ControlKindReport:
+				case linkwell.ControlKindReport:
 					templ_7745c5c3_Err = reportButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
@@ -85,7 +85,7 @@ func ErrorControls(controls []hypermedia.Control) templ.Component {
 	})
 }
 
-func retryButton(ctrl hypermedia.Control) templ.Component {
+func retryButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -106,7 +106,7 @@ func retryButton(ctrl hypermedia.Control) templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		if ctrl.Variant == hypermedia.VariantPrimary {
+		if ctrl.Variant == linkwell.VariantPrimary {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<button")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -183,7 +183,7 @@ func retryButton(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func linkControl(ctrl hypermedia.Control) templ.Component {
+func linkControl(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -238,7 +238,7 @@ func linkControl(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func htmxButton(ctrl hypermedia.Control) templ.Component {
+func htmxButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -298,7 +298,7 @@ func htmxButton(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func dismissButton(ctrl hypermedia.Control) templ.Component {
+func dismissButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -340,7 +340,7 @@ func dismissButton(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func errorBackButton(ctrl hypermedia.Control) templ.Component {
+func errorBackButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -382,7 +382,7 @@ func errorBackButton(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func errorHomeButton(ctrl hypermedia.Control) templ.Component {
+func errorHomeButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -432,7 +432,7 @@ func errorHomeButton(ctrl hypermedia.Control) templ.Component {
 	})
 }
 
-func reportButton(ctrl hypermedia.Control) templ.Component {
+func reportButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/components/core/error_page.go
+++ b/web/components/core/error_page.go
@@ -1,8 +1,8 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
-func errorPageTheme(ec hypermedia.ErrorContext) string {
+func errorPageTheme(ec linkwell.ErrorContext) string {
 	if ec.Theme != "" {
 		return ec.Theme
 	}

--- a/web/components/core/error_page.templ
+++ b/web/components/core/error_page.templ
@@ -1,11 +1,11 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // ErrorPage renders a self-contained HTML error page for non-HTMX requests.
 // It includes its own HTML shell with Tailwind, DaisyUI, HTMX, and HyperScript
 // so it works outside the normal SPA layout.
-templ ErrorPage(ec hypermedia.ErrorContext) {
+templ ErrorPage(ec linkwell.ErrorContext) {
 	<!DOCTYPE html>
 	<html lang="en" data-theme={ errorPageTheme(ec) }>
 		<head>

--- a/web/components/core/error_page_templ.go
+++ b/web/components/core/error_page_templ.go
@@ -8,12 +8,12 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // ErrorPage renders a self-contained HTML error page for non-HTMX requests.
 // It includes its own HTML shell with Tailwind, DaisyUI, HTMX, and HyperScript
 // so it works outside the normal SPA layout.
-func ErrorPage(ec hypermedia.ErrorContext) templ.Component {
+func ErrorPage(ec linkwell.ErrorContext) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/components/core/error_status.templ
+++ b/web/components/core/error_status.templ
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"strconv"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 )
 
-func errorJSON(ec hypermedia.ErrorContext) string {
+func errorJSON(ec linkwell.ErrorContext) string {
 	m := map[string]string{
 		"status":     strconv.Itoa(ec.StatusCode) + " " + ec.Message,
 		"route":      ec.Route,
@@ -23,7 +23,7 @@ func errorJSON(ec hypermedia.ErrorContext) string {
 }
 
 // oobSwapValue builds the hx-swap-oob attribute value for OOB error placement.
-func oobSwapValue(ec hypermedia.ErrorContext) string {
+func oobSwapValue(ec linkwell.ErrorContext) string {
 	swap := ec.OOBSwap
 	if swap == "" {
 		swap = "innerHTML"
@@ -38,7 +38,7 @@ func oobSwapValue(ec hypermedia.ErrorContext) string {
 // It renders the full error panel from an ErrorContext, including action controls.
 // When ec.OOBTarget is set the div includes hx-swap-oob so HTMX routes it
 // out-of-band to the specified target.
-templ ErrorStatusFromContext(ec hypermedia.ErrorContext) {
+templ ErrorStatusFromContext(ec linkwell.ErrorContext) {
 	if ec.OOBTarget != "" {
 		<div
 			id="error-message-content"
@@ -57,7 +57,7 @@ templ ErrorStatusFromContext(ec hypermedia.ErrorContext) {
 	}
 }
 
-templ errorStatusBody(ec hypermedia.ErrorContext) {
+templ errorStatusBody(ec linkwell.ErrorContext) {
 	<p class="font-semibold text-sm mb-2">Something went wrong</p>
 	<div
 		x-data
@@ -104,29 +104,29 @@ templ errorStatusBody(ec hypermedia.ErrorContext) {
 
 // bannerControls returns only Dismiss and Report controls for the global error banner.
 // A Dismiss button is prepended when Closable is true and none already exists.
-func bannerControls(ec hypermedia.ErrorContext) []hypermedia.Control {
-	var out []hypermedia.Control
+func bannerControls(ec linkwell.ErrorContext) []linkwell.Control {
+	var out []linkwell.Control
 	hasDismiss := false
 	for _, ctrl := range ec.Controls {
-		if ctrl.Kind == hypermedia.ControlKindDismiss || ctrl.Kind == hypermedia.ControlKindReport {
+		if ctrl.Kind == linkwell.ControlKindDismiss || ctrl.Kind == linkwell.ControlKindReport {
 			out = append(out, ctrl)
-			if ctrl.Kind == hypermedia.ControlKindDismiss {
+			if ctrl.Kind == linkwell.ControlKindDismiss {
 				hasDismiss = true
 			}
 		}
 	}
 	if ec.Closable && !hasDismiss {
-		close := hypermedia.DismissButton(hypermedia.LabelDismiss)
-		out = append([]hypermedia.Control{close}, out...)
+		close := linkwell.DismissButton(linkwell.LabelDismiss)
+		out = append([]linkwell.Control{close}, out...)
 	}
 	return out
 }
 
 // bannerControlButtonsLeft renders non-dismiss buttons (Report Issue) on the left.
-templ bannerControlButtonsLeft(controls []hypermedia.Control) {
+templ bannerControlButtonsLeft(controls []linkwell.Control) {
 	<div class="flex flex-wrap gap-2">
 		for _, ctrl := range controls {
-			if ctrl.Kind == hypermedia.ControlKindReport {
+			if ctrl.Kind == linkwell.ControlKindReport {
 				@reportButton(ctrl)
 			}
 		}
@@ -134,10 +134,10 @@ templ bannerControlButtonsLeft(controls []hypermedia.Control) {
 }
 
 // bannerControlButtonsRight renders dismiss buttons on the right.
-templ bannerControlButtonsRight(controls []hypermedia.Control) {
+templ bannerControlButtonsRight(controls []linkwell.Control) {
 	<div class="flex flex-wrap gap-2">
 		for _, ctrl := range controls {
-			if ctrl.Kind == hypermedia.ControlKindDismiss {
+			if ctrl.Kind == linkwell.ControlKindDismiss {
 				@dismissButton(ctrl)
 			}
 		}
@@ -146,10 +146,10 @@ templ bannerControlButtonsRight(controls []hypermedia.Control) {
 
 // inlineActionControls returns controls that are NOT dismiss or report.
 // These are rendered as standalone buttons above the unified bar (e.g. Retry).
-func inlineActionControls(controls []hypermedia.Control) []hypermedia.Control {
-	var out []hypermedia.Control
+func inlineActionControls(controls []linkwell.Control) []linkwell.Control {
+	var out []linkwell.Control
 	for _, c := range controls {
-		if c.Kind != hypermedia.ControlKindDismiss && c.Kind != hypermedia.ControlKindReport {
+		if c.Kind != linkwell.ControlKindDismiss && c.Kind != linkwell.ControlKindReport {
 			out = append(out, c)
 		}
 	}
@@ -157,30 +157,30 @@ func inlineActionControls(controls []hypermedia.Control) []hypermedia.Control {
 }
 
 // inlineDismissControl returns the first Dismiss control.
-func inlineDismissControl(controls []hypermedia.Control) (hypermedia.Control, bool) {
+func inlineDismissControl(controls []linkwell.Control) (linkwell.Control, bool) {
 	for _, c := range controls {
-		if c.Kind == hypermedia.ControlKindDismiss {
+		if c.Kind == linkwell.ControlKindDismiss {
 			return c, true
 		}
 	}
-	return hypermedia.Control{}, false
+	return linkwell.Control{}, false
 }
 
 // inlineReportControl returns the first Report control.
-func inlineReportControl(controls []hypermedia.Control) (hypermedia.Control, bool) {
+func inlineReportControl(controls []linkwell.Control) (linkwell.Control, bool) {
 	for _, c := range controls {
-		if c.Kind == hypermedia.ControlKindReport {
+		if c.Kind == linkwell.ControlKindReport {
 			return c, true
 		}
 	}
-	return hypermedia.Control{}, false
+	return linkwell.Control{}, false
 }
 
 // InlineErrorPanel renders an inline error with a stacked layout.
 // Dismiss and Report are rendered as a unified joined button group on the last row.
 // Use this instead of ErrorStatusFromContext when the error replaces content
 // in-place (not the global banner).
-templ InlineErrorPanel(ec hypermedia.ErrorContext) {
+templ InlineErrorPanel(ec linkwell.ErrorContext) {
 	<div class="alert alert-error rounded-lg text-sm p-3 space-y-2">
 		<div class="space-y-1">
 			<p class="font-semibold">
@@ -200,7 +200,7 @@ templ InlineErrorPanel(ec hypermedia.ErrorContext) {
 
 // inlineErrorActions renders action controls (Retry, etc.) followed by a
 // unified Dismiss | Report joined button group on the last row.
-templ inlineErrorActions(controls []hypermedia.Control) {
+templ inlineErrorActions(controls []linkwell.Control) {
 	<div class="flex items-center justify-between gap-2">
 		<div class="flex flex-wrap gap-2">
 			for _, ctrl := range inlineActionControls(controls) {
@@ -239,7 +239,7 @@ templ inlineErrorActions(controls []hypermedia.Control) {
 
 // ErrorStatus is the backward-compatible wrapper. All existing call sites are unchanged.
 templ ErrorStatus(statusCode int, message string, err error, route string, requestID string, closable bool) {
-	@ErrorStatusFromContext(hypermedia.ErrorContext{
+	@ErrorStatusFromContext(linkwell.ErrorContext{
 		StatusCode: statusCode,
 		Message:    message,
 		Err:        err,

--- a/web/components/core/error_status_templ.go
+++ b/web/components/core/error_status_templ.go
@@ -12,10 +12,10 @@ import (
 	"encoding/json"
 	"strconv"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 )
 
-func errorJSON(ec hypermedia.ErrorContext) string {
+func errorJSON(ec linkwell.ErrorContext) string {
 	m := map[string]string{
 		"status": strconv.Itoa(ec.StatusCode) + " " + ec.Message,
 		"route":  ec.Route,
@@ -31,7 +31,7 @@ func errorJSON(ec hypermedia.ErrorContext) string {
 }
 
 // oobSwapValue builds the hx-swap-oob attribute value for OOB error placement.
-func oobSwapValue(ec hypermedia.ErrorContext) string {
+func oobSwapValue(ec linkwell.ErrorContext) string {
 	swap := ec.OOBSwap
 	if swap == "" {
 		swap = "innerHTML"
@@ -46,7 +46,7 @@ func oobSwapValue(ec hypermedia.ErrorContext) string {
 // It renders the full error panel from an ErrorContext, including action controls.
 // When ec.OOBTarget is set the div includes hx-swap-oob so HTMX routes it
 // out-of-band to the specified target.
-func ErrorStatusFromContext(ec hypermedia.ErrorContext) templ.Component {
+func ErrorStatusFromContext(ec linkwell.ErrorContext) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -111,7 +111,7 @@ func ErrorStatusFromContext(ec hypermedia.ErrorContext) templ.Component {
 	})
 }
 
-func errorStatusBody(ec hypermedia.ErrorContext) templ.Component {
+func errorStatusBody(ec linkwell.ErrorContext) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -259,26 +259,26 @@ func errorStatusBody(ec hypermedia.ErrorContext) templ.Component {
 
 // bannerControls returns only Dismiss and Report controls for the global error banner.
 // A Dismiss button is prepended when Closable is true and none already exists.
-func bannerControls(ec hypermedia.ErrorContext) []hypermedia.Control {
-	var out []hypermedia.Control
+func bannerControls(ec linkwell.ErrorContext) []linkwell.Control {
+	var out []linkwell.Control
 	hasDismiss := false
 	for _, ctrl := range ec.Controls {
-		if ctrl.Kind == hypermedia.ControlKindDismiss || ctrl.Kind == hypermedia.ControlKindReport {
+		if ctrl.Kind == linkwell.ControlKindDismiss || ctrl.Kind == linkwell.ControlKindReport {
 			out = append(out, ctrl)
-			if ctrl.Kind == hypermedia.ControlKindDismiss {
+			if ctrl.Kind == linkwell.ControlKindDismiss {
 				hasDismiss = true
 			}
 		}
 	}
 	if ec.Closable && !hasDismiss {
-		close := hypermedia.DismissButton(hypermedia.LabelDismiss)
-		out = append([]hypermedia.Control{close}, out...)
+		close := linkwell.DismissButton(linkwell.LabelDismiss)
+		out = append([]linkwell.Control{close}, out...)
 	}
 	return out
 }
 
 // bannerControlButtonsLeft renders non-dismiss buttons (Report Issue) on the left.
-func bannerControlButtonsLeft(controls []hypermedia.Control) templ.Component {
+func bannerControlButtonsLeft(controls []linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -304,7 +304,7 @@ func bannerControlButtonsLeft(controls []hypermedia.Control) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		for _, ctrl := range controls {
-			if ctrl.Kind == hypermedia.ControlKindReport {
+			if ctrl.Kind == linkwell.ControlKindReport {
 				templ_7745c5c3_Err = reportButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -320,7 +320,7 @@ func bannerControlButtonsLeft(controls []hypermedia.Control) templ.Component {
 }
 
 // bannerControlButtonsRight renders dismiss buttons on the right.
-func bannerControlButtonsRight(controls []hypermedia.Control) templ.Component {
+func bannerControlButtonsRight(controls []linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -346,7 +346,7 @@ func bannerControlButtonsRight(controls []hypermedia.Control) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		for _, ctrl := range controls {
-			if ctrl.Kind == hypermedia.ControlKindDismiss {
+			if ctrl.Kind == linkwell.ControlKindDismiss {
 				templ_7745c5c3_Err = dismissButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -363,10 +363,10 @@ func bannerControlButtonsRight(controls []hypermedia.Control) templ.Component {
 
 // inlineActionControls returns controls that are NOT dismiss or report.
 // These are rendered as standalone buttons above the unified bar (e.g. Retry).
-func inlineActionControls(controls []hypermedia.Control) []hypermedia.Control {
-	var out []hypermedia.Control
+func inlineActionControls(controls []linkwell.Control) []linkwell.Control {
+	var out []linkwell.Control
 	for _, c := range controls {
-		if c.Kind != hypermedia.ControlKindDismiss && c.Kind != hypermedia.ControlKindReport {
+		if c.Kind != linkwell.ControlKindDismiss && c.Kind != linkwell.ControlKindReport {
 			out = append(out, c)
 		}
 	}
@@ -374,30 +374,30 @@ func inlineActionControls(controls []hypermedia.Control) []hypermedia.Control {
 }
 
 // inlineDismissControl returns the first Dismiss control.
-func inlineDismissControl(controls []hypermedia.Control) (hypermedia.Control, bool) {
+func inlineDismissControl(controls []linkwell.Control) (linkwell.Control, bool) {
 	for _, c := range controls {
-		if c.Kind == hypermedia.ControlKindDismiss {
+		if c.Kind == linkwell.ControlKindDismiss {
 			return c, true
 		}
 	}
-	return hypermedia.Control{}, false
+	return linkwell.Control{}, false
 }
 
 // inlineReportControl returns the first Report control.
-func inlineReportControl(controls []hypermedia.Control) (hypermedia.Control, bool) {
+func inlineReportControl(controls []linkwell.Control) (linkwell.Control, bool) {
 	for _, c := range controls {
-		if c.Kind == hypermedia.ControlKindReport {
+		if c.Kind == linkwell.ControlKindReport {
 			return c, true
 		}
 	}
-	return hypermedia.Control{}, false
+	return linkwell.Control{}, false
 }
 
 // InlineErrorPanel renders an inline error with a stacked layout.
 // Dismiss and Report are rendered as a unified joined button group on the last row.
 // Use this instead of ErrorStatusFromContext when the error replaces content
 // in-place (not the global banner).
-func InlineErrorPanel(ec hypermedia.ErrorContext) templ.Component {
+func InlineErrorPanel(ec linkwell.ErrorContext) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -504,7 +504,7 @@ func InlineErrorPanel(ec hypermedia.ErrorContext) templ.Component {
 
 // inlineErrorActions renders action controls (Retry, etc.) followed by a
 // unified Dismiss | Report joined button group on the last row.
-func inlineErrorActions(controls []hypermedia.Control) templ.Component {
+func inlineErrorActions(controls []linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -646,7 +646,7 @@ func ErrorStatus(statusCode int, message string, err error, route string, reques
 			templ_7745c5c3_Var21 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = ErrorStatusFromContext(hypermedia.ErrorContext{
+		templ_7745c5c3_Err = ErrorStatusFromContext(linkwell.ErrorContext{
 			StatusCode: statusCode,
 			Message:    message,
 			Err:        err,

--- a/web/components/core/filter.templ
+++ b/web/components/core/filter.templ
@@ -1,13 +1,13 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // filterTrigger returns the default hx-trigger string for each FilterKind.
-func filterTrigger(kind hypermedia.FilterKind) string {
+func filterTrigger(kind linkwell.FilterKind) string {
 	switch kind {
-	case hypermedia.FilterKindSearch:
+	case linkwell.FilterKindSearch:
 		return "keyup changed delay:400ms, search"
-	case hypermedia.FilterKindRange:
+	case linkwell.FilterKindRange:
 		return "change delay:300ms"
 	default:
 		// select, checkbox, date
@@ -21,7 +21,7 @@ func filterTrigger(kind hypermedia.FilterKind) string {
 //	hx-trigger=filterTrigger(field.Kind)
 //
 // Merges field.HTMXAttrs overrides (with "hx-" prefix) last so they win.
-func filterHxAttrs(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Attributes {
+func filterHxAttrs(field linkwell.FilterField, bar linkwell.FilterBar) templ.Attributes {
 	attrs := templ.Attributes{
 		"hx-get":     bar.Action,
 		"hx-target":  bar.Target,
@@ -35,9 +35,9 @@ func filterHxAttrs(field hypermedia.FilterField, bar hypermedia.FilterBar) templ
 }
 
 // filterBarHasSearch returns true if any field in the bar is a search field.
-func filterBarHasSearch(bar hypermedia.FilterBar) bool {
+func filterBarHasSearch(bar linkwell.FilterBar) bool {
 	for _, f := range bar.Fields {
-		if f.Kind == hypermedia.FilterKindSearch {
+		if f.Kind == linkwell.FilterKindSearch {
 			return true
 		}
 	}
@@ -46,12 +46,12 @@ func filterBarHasSearch(bar hypermedia.FilterBar) bool {
 
 // FilterBar renders the filter form. When a search field is present, it splits
 // into two rows: search full-width on top, other fields in a flex row below.
-templ FilterBar(bar hypermedia.FilterBar) {
+templ FilterBar(bar linkwell.FilterBar) {
 	if filterBarHasSearch(bar) {
 		<search>
 			<form id={ bar.ID } class="space-y-3 mb-4">
 				for _, field := range bar.Fields {
-					if field.Kind == hypermedia.FilterKindSearch {
+					if field.Kind == linkwell.FilterKindSearch {
 						<div>
 							@FilterField(field, bar)
 						</div>
@@ -59,7 +59,7 @@ templ FilterBar(bar hypermedia.FilterBar) {
 				}
 				<div class="flex flex-wrap gap-3 items-end">
 					for _, field := range bar.Fields {
-						if field.Kind != hypermedia.FilterKindSearch {
+						if field.Kind != linkwell.FilterKindSearch {
 							@FilterField(field, bar)
 						}
 					}
@@ -77,23 +77,23 @@ templ FilterBar(bar hypermedia.FilterBar) {
 
 // FilterField dispatches to the correct field renderer by Kind.
 // Exported so apps can build custom filter layouts using the standard field renderers.
-templ FilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) {
+templ FilterField(field linkwell.FilterField, bar linkwell.FilterBar) {
 	switch field.Kind {
-		case hypermedia.FilterKindSearch:
+		case linkwell.FilterKindSearch:
 			@searchFilterField(field, bar)
-		case hypermedia.FilterKindSelect:
+		case linkwell.FilterKindSelect:
 			@selectFilterField(field, bar)
-		case hypermedia.FilterKindRange:
+		case linkwell.FilterKindRange:
 			@rangeFilterField(field, bar)
-		case hypermedia.FilterKindCheckbox:
+		case linkwell.FilterKindCheckbox:
 			@checkboxFilterField(field, bar)
-		case hypermedia.FilterKindDate:
+		case linkwell.FilterKindDate:
 			@dateFilterField(field, bar)
 	}
 }
 
 // searchFilterField renders a DaisyUI text search input with label.
-templ searchFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) {
+templ searchFilterField(field linkwell.FilterField, bar linkwell.FilterBar) {
 	<label class="fieldset w-full max-w-xs">
 		if field.Label != "" {
 			<label class="label">{ field.Label }</label>
@@ -115,7 +115,7 @@ templ searchFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) 
 
 // selectFilterField renders a DaisyUI <select> dropdown with label.
 // The wrapping label carries data-filter={name} for OOB targeting by FilterGroup.
-templ selectFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) {
+templ selectFilterField(field linkwell.FilterField, bar linkwell.FilterBar) {
 	<label class="fieldset w-full max-w-xs" data-filter={ field.Name }>
 		if field.Label != "" {
 			<label class="label">{ field.Label }</label>
@@ -125,7 +125,7 @@ templ selectFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) 
 }
 
 // selectFilterOptions renders just the <select> element, reusable for OOB swaps.
-templ selectFilterOptions(field hypermedia.FilterField, bar hypermedia.FilterBar) {
+templ selectFilterOptions(field linkwell.FilterField, bar linkwell.FilterBar) {
 	<select
 		name={ field.Name }
 		class="select select-sm"
@@ -140,7 +140,7 @@ templ selectFilterOptions(field hypermedia.FilterField, bar hypermedia.FilterBar
 
 // FilterGroupOOB renders OOB swap fragments for all select fields in a FilterGroup.
 // Each fragment targets [data-filter='{name}'] and replaces the <select> element.
-templ FilterGroupOOB(group hypermedia.FilterGroup) {
+templ FilterGroupOOB(group linkwell.FilterGroup) {
 	for _, field := range group.SelectFields() {
 		<div hx-swap-oob={ "innerHTML:[data-filter='" + field.Name + "']" }>
 			if field.Label != "" {
@@ -152,7 +152,7 @@ templ FilterGroupOOB(group hypermedia.FilterGroup) {
 }
 
 // rangeFilterField renders a DaisyUI range slider with live value display via HyperScript.
-templ rangeFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) {
+templ rangeFilterField(field linkwell.FilterField, bar linkwell.FilterBar) {
 	<label class="fieldset w-full max-w-xs">
 		if field.Label != "" {
 			<label class="label">{ field.Label }</label>
@@ -174,7 +174,7 @@ templ rangeFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) {
 }
 
 // checkboxFilterField renders a DaisyUI toggle checkbox.
-templ checkboxFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) {
+templ checkboxFilterField(field linkwell.FilterField, bar linkwell.FilterBar) {
 	<label class="label cursor-pointer gap-2">
 		if field.Label != "" {
 			<span class="label-text">{ field.Label }</span>
@@ -192,7 +192,7 @@ templ checkboxFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar
 }
 
 // dateFilterField renders a DaisyUI date input with label.
-templ dateFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) {
+templ dateFilterField(field linkwell.FilterField, bar linkwell.FilterBar) {
 	<label class="fieldset w-full max-w-xs">
 		if field.Label != "" {
 			<label class="label">{ field.Label }</label>

--- a/web/components/core/filter_templ.go
+++ b/web/components/core/filter_templ.go
@@ -8,14 +8,14 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // filterTrigger returns the default hx-trigger string for each FilterKind.
-func filterTrigger(kind hypermedia.FilterKind) string {
+func filterTrigger(kind linkwell.FilterKind) string {
 	switch kind {
-	case hypermedia.FilterKindSearch:
+	case linkwell.FilterKindSearch:
 		return "keyup changed delay:400ms, search"
-	case hypermedia.FilterKindRange:
+	case linkwell.FilterKindRange:
 		return "change delay:300ms"
 	default:
 		// select, checkbox, date
@@ -29,7 +29,7 @@ func filterTrigger(kind hypermedia.FilterKind) string {
 //	hx-trigger=filterTrigger(field.Kind)
 //
 // Merges field.HTMXAttrs overrides (with "hx-" prefix) last so they win.
-func filterHxAttrs(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Attributes {
+func filterHxAttrs(field linkwell.FilterField, bar linkwell.FilterBar) templ.Attributes {
 	attrs := templ.Attributes{
 		"hx-get":     bar.Action,
 		"hx-target":  bar.Target,
@@ -43,9 +43,9 @@ func filterHxAttrs(field hypermedia.FilterField, bar hypermedia.FilterBar) templ
 }
 
 // filterBarHasSearch returns true if any field in the bar is a search field.
-func filterBarHasSearch(bar hypermedia.FilterBar) bool {
+func filterBarHasSearch(bar linkwell.FilterBar) bool {
 	for _, f := range bar.Fields {
-		if f.Kind == hypermedia.FilterKindSearch {
+		if f.Kind == linkwell.FilterKindSearch {
 			return true
 		}
 	}
@@ -54,7 +54,7 @@ func filterBarHasSearch(bar hypermedia.FilterBar) bool {
 
 // FilterBar renders the filter form. When a search field is present, it splits
 // into two rows: search full-width on top, other fields in a flex row below.
-func FilterBar(bar hypermedia.FilterBar) templ.Component {
+func FilterBar(bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -94,7 +94,7 @@ func FilterBar(bar hypermedia.FilterBar) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			for _, field := range bar.Fields {
-				if field.Kind == hypermedia.FilterKindSearch {
+				if field.Kind == linkwell.FilterKindSearch {
 					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
@@ -114,7 +114,7 @@ func FilterBar(bar hypermedia.FilterBar) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			for _, field := range bar.Fields {
-				if field.Kind != hypermedia.FilterKindSearch {
+				if field.Kind != linkwell.FilterKindSearch {
 					templ_7745c5c3_Err = FilterField(field, bar).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
@@ -160,7 +160,7 @@ func FilterBar(bar hypermedia.FilterBar) templ.Component {
 
 // FilterField dispatches to the correct field renderer by Kind.
 // Exported so apps can build custom filter layouts using the standard field renderers.
-func FilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Component {
+func FilterField(field linkwell.FilterField, bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -182,27 +182,27 @@ func FilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.C
 		}
 		ctx = templ.ClearChildren(ctx)
 		switch field.Kind {
-		case hypermedia.FilterKindSearch:
+		case linkwell.FilterKindSearch:
 			templ_7745c5c3_Err = searchFilterField(field, bar).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.FilterKindSelect:
+		case linkwell.FilterKindSelect:
 			templ_7745c5c3_Err = selectFilterField(field, bar).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.FilterKindRange:
+		case linkwell.FilterKindRange:
 			templ_7745c5c3_Err = rangeFilterField(field, bar).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.FilterKindCheckbox:
+		case linkwell.FilterKindCheckbox:
 			templ_7745c5c3_Err = checkboxFilterField(field, bar).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		case hypermedia.FilterKindDate:
+		case linkwell.FilterKindDate:
 			templ_7745c5c3_Err = dateFilterField(field, bar).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -213,7 +213,7 @@ func FilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.C
 }
 
 // searchFilterField renders a DaisyUI text search input with label.
-func searchFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Component {
+func searchFilterField(field linkwell.FilterField, bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -320,7 +320,7 @@ func searchFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) t
 
 // selectFilterField renders a DaisyUI <select> dropdown with label.
 // The wrapping label carries data-filter={name} for OOB targeting by FilterGroup.
-func selectFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Component {
+func selectFilterField(field linkwell.FilterField, bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -390,7 +390,7 @@ func selectFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) t
 }
 
 // selectFilterOptions renders just the <select> element, reusable for OOB swaps.
-func selectFilterOptions(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Component {
+func selectFilterOptions(field linkwell.FilterField, bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -494,7 +494,7 @@ func selectFilterOptions(field hypermedia.FilterField, bar hypermedia.FilterBar)
 
 // FilterGroupOOB renders OOB swap fragments for all select fields in a FilterGroup.
 // Each fragment targets [data-filter='{name}'] and replaces the <select> element.
-func FilterGroupOOB(group hypermedia.FilterGroup) templ.Component {
+func FilterGroupOOB(group linkwell.FilterGroup) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -566,7 +566,7 @@ func FilterGroupOOB(group hypermedia.FilterGroup) templ.Component {
 }
 
 // rangeFilterField renders a DaisyUI range slider with live value display via HyperScript.
-func rangeFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Component {
+func rangeFilterField(field linkwell.FilterField, bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -711,7 +711,7 @@ func rangeFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) te
 }
 
 // checkboxFilterField renders a DaisyUI toggle checkbox.
-func checkboxFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Component {
+func checkboxFilterField(field linkwell.FilterField, bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -797,7 +797,7 @@ func checkboxFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar)
 }
 
 // dateFilterField renders a DaisyUI date input with label.
-func dateFilterField(field hypermedia.FilterField, bar hypermedia.FilterBar) templ.Component {
+func dateFilterField(field linkwell.FilterField, bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/components/core/modal.templ
+++ b/web/components/core/modal.templ
@@ -1,17 +1,17 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // modalButtonClass returns the CSS class for a modal button based on its variant.
-func modalButtonClass(variant hypermedia.ControlVariant) string {
+func modalButtonClass(variant linkwell.ControlVariant) string {
 	switch variant {
-	case hypermedia.VariantPrimary:
+	case linkwell.VariantPrimary:
 		return "btn btn-primary btn-sm"
-	case hypermedia.VariantDanger:
+	case linkwell.VariantDanger:
 		return "btn btn-error btn-sm"
-	case hypermedia.VariantSecondary:
+	case linkwell.VariantSecondary:
 		return "btn btn-secondary btn-sm"
-	case hypermedia.VariantGhost:
+	case linkwell.VariantGhost:
 		return "btn btn-ghost btn-sm"
 	default:
 		return "btn btn-ghost btn-sm"
@@ -22,7 +22,7 @@ func modalButtonClass(variant hypermedia.ControlVariant) string {
 // Opened via Alpine: `x-on:click="$refs.modal.showModal()"` or getElementById.
 // Closed via `<form method="dialog">` buttons or ESC key.
 // Child content is rendered inside the modal body between the title and action buttons.
-templ Modal(cfg hypermedia.ModalConfig) {
+templ Modal(cfg linkwell.ModalConfig) {
 	<dialog id={ cfg.ID } class="modal">
 		<div class="modal-box bg-base-100 text-base-content">
 			<form method="dialog">
@@ -34,13 +34,13 @@ templ Modal(cfg hypermedia.ModalConfig) {
 			</div>
 			<div class="modal-action">
 				for _, btn := range cfg.Buttons {
-					if btn.Role == hypermedia.ModalRoleCancel {
+					if btn.Role == linkwell.ModalRoleCancel {
 						<form method="dialog">
 							<button class={ modalButtonClass(btn.Variant) }>
 								{ btn.Label }
 							</button>
 						</form>
-					} else if btn.Role == hypermedia.ModalRolePrimary && cfg.HxPost != "" {
+					} else if btn.Role == linkwell.ModalRolePrimary && cfg.HxPost != "" {
 						<button
 							class={ modalButtonClass(btn.Variant) }
 							hx-post={ cfg.HxPost }
@@ -55,7 +55,7 @@ templ Modal(cfg hypermedia.ModalConfig) {
 						>
 							{ btn.Label }
 						</button>
-					} else if btn.Role == hypermedia.ModalRoleSecondary {
+					} else if btn.Role == linkwell.ModalRoleSecondary {
 						<button
 							type="reset"
 							class={ modalButtonClass(btn.Variant) }

--- a/web/components/core/modal_templ.go
+++ b/web/components/core/modal_templ.go
@@ -8,18 +8,18 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // modalButtonClass returns the CSS class for a modal button based on its variant.
-func modalButtonClass(variant hypermedia.ControlVariant) string {
+func modalButtonClass(variant linkwell.ControlVariant) string {
 	switch variant {
-	case hypermedia.VariantPrimary:
+	case linkwell.VariantPrimary:
 		return "btn btn-primary btn-sm"
-	case hypermedia.VariantDanger:
+	case linkwell.VariantDanger:
 		return "btn btn-error btn-sm"
-	case hypermedia.VariantSecondary:
+	case linkwell.VariantSecondary:
 		return "btn btn-secondary btn-sm"
-	case hypermedia.VariantGhost:
+	case linkwell.VariantGhost:
 		return "btn btn-ghost btn-sm"
 	default:
 		return "btn btn-ghost btn-sm"
@@ -30,7 +30,7 @@ func modalButtonClass(variant hypermedia.ControlVariant) string {
 // Opened via Alpine: `x-on:click="$refs.modal.showModal()"` or getElementById.
 // Closed via `<form method="dialog">` buttons or ESC key.
 // Child content is rendered inside the modal body between the title and action buttons.
-func Modal(cfg hypermedia.ModalConfig) templ.Component {
+func Modal(cfg linkwell.ModalConfig) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -90,7 +90,7 @@ func Modal(cfg hypermedia.ModalConfig) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		for _, btn := range cfg.Buttons {
-			if btn.Role == hypermedia.ModalRoleCancel {
+			if btn.Role == linkwell.ModalRoleCancel {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<form method=\"dialog\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -130,7 +130,7 @@ func Modal(cfg hypermedia.ModalConfig) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-			} else if btn.Role == hypermedia.ModalRolePrimary && cfg.HxPost != "" {
+			} else if btn.Role == linkwell.ModalRolePrimary && cfg.HxPost != "" {
 				var templ_7745c5c3_Var7 = []any{modalButtonClass(btn.Variant)}
 				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var7...)
 				if templ_7745c5c3_Err != nil {
@@ -234,7 +234,7 @@ func Modal(cfg hypermedia.ModalConfig) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-			} else if btn.Role == hypermedia.ModalRoleSecondary {
+			} else if btn.Role == linkwell.ModalRoleSecondary {
 				var templ_7745c5c3_Var14 = []any{modalButtonClass(btn.Variant)}
 				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var14...)
 				if templ_7745c5c3_Err != nil {

--- a/web/components/core/nav.templ
+++ b/web/components/core/nav.templ
@@ -1,9 +1,9 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // navHxAttrs converts a NavItem's HTMXAttrs map to templ.Attributes with "hx-" prefix.
-func navHxAttrs(item hypermedia.NavItem) templ.Attributes {
+func navHxAttrs(item linkwell.NavItem) templ.Attributes {
 	attrs := make(templ.Attributes, len(item.HTMXAttrs))
 	for k, v := range item.HTMXAttrs {
 		attrs["hx-"+k] = v
@@ -21,7 +21,7 @@ func navActiveClass(active bool) string {
 
 // NavBar renders a DaisyUI horizontal navbar with optional HTMX enhancement.
 // Active state should be set server-side via SetActiveNavItem or SetActiveNavItemPrefix.
-templ NavBar(items []hypermedia.NavItem) {
+templ NavBar(items []linkwell.NavItem) {
 	<nav
 		class="navbar bg-base-200 shadow-sm"
 		x-data
@@ -37,7 +37,7 @@ templ NavBar(items []hypermedia.NavItem) {
 	</nav>
 }
 
-templ navMenuItem(item hypermedia.NavItem) {
+templ navMenuItem(item linkwell.NavItem) {
 	if len(item.Children) > 0 {
 		<li>
 			<details
@@ -70,7 +70,7 @@ templ navMenuItem(item hypermedia.NavItem) {
 
 // Breadcrumbs renders a DaisyUI breadcrumb trail.
 // Non-terminal crumbs render as anchors; the terminal crumb renders as plain text.
-templ Breadcrumbs(crumbs []hypermedia.Breadcrumb) {
+templ Breadcrumbs(crumbs []linkwell.Breadcrumb) {
 	<div class="breadcrumbs text-sm">
 		<ul>
 			for _, crumb := range crumbs {

--- a/web/components/core/nav_templ.go
+++ b/web/components/core/nav_templ.go
@@ -8,10 +8,10 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // navHxAttrs converts a NavItem's HTMXAttrs map to templ.Attributes with "hx-" prefix.
-func navHxAttrs(item hypermedia.NavItem) templ.Attributes {
+func navHxAttrs(item linkwell.NavItem) templ.Attributes {
 	attrs := make(templ.Attributes, len(item.HTMXAttrs))
 	for k, v := range item.HTMXAttrs {
 		attrs["hx-"+k] = v
@@ -29,7 +29,7 @@ func navActiveClass(active bool) string {
 
 // NavBar renders a DaisyUI horizontal navbar with optional HTMX enhancement.
 // Active state should be set server-side via SetActiveNavItem or SetActiveNavItemPrefix.
-func NavBar(items []hypermedia.NavItem) templ.Component {
+func NavBar(items []linkwell.NavItem) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -68,7 +68,7 @@ func NavBar(items []hypermedia.NavItem) templ.Component {
 	})
 }
 
-func navMenuItem(item hypermedia.NavItem) templ.Component {
+func navMenuItem(item linkwell.NavItem) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -215,7 +215,7 @@ func navMenuItem(item hypermedia.NavItem) templ.Component {
 
 // Breadcrumbs renders a DaisyUI breadcrumb trail.
 // Non-terminal crumbs render as anchors; the terminal crumb renders as plain text.
-func Breadcrumbs(crumbs []hypermedia.Breadcrumb) templ.Component {
+func Breadcrumbs(crumbs []linkwell.Breadcrumb) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/components/core/report_issue.templ
+++ b/web/components/core/report_issue.templ
@@ -1,11 +1,11 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // ReportIssueModal renders the Report Issue modal with a textarea for user context.
 // Log data is retrieved from the ring buffer server-side when the report is submitted.
 // When fetched dynamically via HTMX the dialog auto-opens on load.
-templ ReportIssueModal(cfg hypermedia.ModalConfig) {
+templ ReportIssueModal(cfg linkwell.ModalConfig) {
 	<div _={ "init call #" + cfg.ID + ".showModal()" }>
 	@Modal(cfg) {
 		<p class="text-sm text-base-content/70 mb-3">This will send error details to our support team for investigation.</p>

--- a/web/components/core/report_issue_templ.go
+++ b/web/components/core/report_issue_templ.go
@@ -8,12 +8,12 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // ReportIssueModal renders the Report Issue modal with a textarea for user context.
 // Log data is retrieved from the ring buffer server-side when the report is submitted.
 // When fetched dynamically via HTMX the dialog auto-opens on load.
-func ReportIssueModal(cfg hypermedia.ModalConfig) templ.Component {
+func ReportIssueModal(cfg linkwell.ModalConfig) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/components/core/sitemap.templ
+++ b/web/components/core/sitemap.templ
@@ -1,10 +1,10 @@
 // setup:feature:demo
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // SiteMap renders a footer site map grid from the hub/spoke topology.
-templ SiteMap(hubs []hypermedia.HubEntry) {
+templ SiteMap(hubs []linkwell.HubEntry) {
 	if len(hubs) > 1 {
 		<div class="border-t border-base-300 bg-base-200/30 px-4 py-6">
 			<div class="max-w-6xl mx-auto">

--- a/web/components/core/sitemap_templ.go
+++ b/web/components/core/sitemap_templ.go
@@ -10,10 +10,10 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // SiteMap renders a footer site map grid from the hub/spoke topology.
-func SiteMap(hubs []hypermedia.HubEntry) templ.Component {
+func SiteMap(hubs []linkwell.HubEntry) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/components/core/table.templ
+++ b/web/components/core/table.templ
@@ -1,16 +1,16 @@
 package components
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // sortIndicator returns the sort direction indicator character for a column.
-func sortIndicator(col hypermedia.TableCol) string {
+func sortIndicator(col linkwell.TableCol) string {
 	if !col.Sortable {
 		return ""
 	}
 	switch col.SortDir {
-	case hypermedia.SortAsc:
+	case linkwell.SortAsc:
 		return " ↑"
-	case hypermedia.SortDesc:
+	case linkwell.SortDesc:
 		return " ↓"
 	default:
 		return " ⇅"
@@ -18,7 +18,7 @@ func sortIndicator(col hypermedia.TableCol) string {
 }
 
 // sortLinkAttrs builds templ.Attributes for a sortable column header link.
-func sortLinkAttrs(col hypermedia.TableCol) templ.Attributes {
+func sortLinkAttrs(col linkwell.TableCol) templ.Attributes {
 	attrs := templ.Attributes{
 		"hx-get":    col.SortURL,
 		"hx-target": col.Target,
@@ -31,7 +31,7 @@ func sortLinkAttrs(col hypermedia.TableCol) templ.Attributes {
 
 // Table renders an overflow-x-auto wrapper containing a table with header,
 // body slot, and optional pagination bar.
-templ Table(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) {
+templ Table(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) {
 	<div class="overflow-x-auto">
 		<table class="table table-zebra w-full">
 			@TableHeader(cols)
@@ -46,7 +46,7 @@ templ Table(cols []hypermedia.TableCol, body templ.Component, info hypermedia.Pa
 // TableHeader renders <thead> with optional sort links.
 // Sortable columns wrap the label in an <a> with HTMX sort attributes.
 // Sort indicator: "↑" SortAsc, "↓" SortDesc, "⇅" SortNone on sortable cols.
-templ TableHeader(cols []hypermedia.TableCol) {
+templ TableHeader(cols []linkwell.TableCol) {
 	<thead>
 		<tr>
 			for _, col := range cols {
@@ -72,11 +72,11 @@ templ TableHeader(cols []hypermedia.TableCol) {
 }
 
 // PaginationBar renders a DaisyUI join-based pagination control.
-// Calls hypermedia.PaginationControls(info) internally.
-templ PaginationBar(info hypermedia.PageInfo) {
+// Calls linkwell.PaginationControls(info) internally.
+templ PaginationBar(info linkwell.PageInfo) {
 	<div class="flex justify-center mt-4">
 		<div class="join">
-			for _, ctrl := range hypermedia.PaginationControls(info) {
+			for _, ctrl := range linkwell.PaginationControls(info) {
 				@paginationButton(ctrl)
 			}
 		</div>
@@ -87,8 +87,8 @@ templ PaginationBar(info hypermedia.PageInfo) {
 // Disabled+VariantPrimary → active (current page, no click)
 // Disabled only           → disabled
 // Normal                  → clickable with HTMX attrs
-templ paginationButton(ctrl hypermedia.Control) {
-	if ctrl.Disabled && ctrl.Variant == hypermedia.VariantPrimary {
+templ paginationButton(ctrl linkwell.Control) {
+	if ctrl.Disabled && ctrl.Variant == linkwell.VariantPrimary {
 		<button class="join-item btn btn-sm btn-active" aria-current="page">
 			{ ctrl.Label }
 		</button>

--- a/web/components/core/table_templ.go
+++ b/web/components/core/table_templ.go
@@ -8,17 +8,17 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import hypermedia "github.com/catgoose/linkwell"
+import "github.com/catgoose/linkwell"
 
 // sortIndicator returns the sort direction indicator character for a column.
-func sortIndicator(col hypermedia.TableCol) string {
+func sortIndicator(col linkwell.TableCol) string {
 	if !col.Sortable {
 		return ""
 	}
 	switch col.SortDir {
-	case hypermedia.SortAsc:
+	case linkwell.SortAsc:
 		return " ↑"
-	case hypermedia.SortDesc:
+	case linkwell.SortDesc:
 		return " ↓"
 	default:
 		return " ⇅"
@@ -26,7 +26,7 @@ func sortIndicator(col hypermedia.TableCol) string {
 }
 
 // sortLinkAttrs builds templ.Attributes for a sortable column header link.
-func sortLinkAttrs(col hypermedia.TableCol) templ.Attributes {
+func sortLinkAttrs(col linkwell.TableCol) templ.Attributes {
 	attrs := templ.Attributes{
 		"hx-get":    col.SortURL,
 		"hx-target": col.Target,
@@ -39,7 +39,7 @@ func sortLinkAttrs(col hypermedia.TableCol) templ.Attributes {
 
 // Table renders an overflow-x-auto wrapper containing a table with header,
 // body slot, and optional pagination bar.
-func Table(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) templ.Component {
+func Table(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -89,7 +89,7 @@ func Table(cols []hypermedia.TableCol, body templ.Component, info hypermedia.Pag
 // TableHeader renders <thead> with optional sort links.
 // Sortable columns wrap the label in an <a> with HTMX sort attributes.
 // Sort indicator: "↑" SortAsc, "↓" SortDesc, "⇅" SortNone on sortable cols.
-func TableHeader(cols []hypermedia.TableCol) templ.Component {
+func TableHeader(cols []linkwell.TableCol) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -202,8 +202,8 @@ func TableHeader(cols []hypermedia.TableCol) templ.Component {
 }
 
 // PaginationBar renders a DaisyUI join-based pagination control.
-// Calls hypermedia.PaginationControls(info) internally.
-func PaginationBar(info hypermedia.PageInfo) templ.Component {
+// Calls linkwell.PaginationControls(info) internally.
+func PaginationBar(info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -228,7 +228,7 @@ func PaginationBar(info hypermedia.PageInfo) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, ctrl := range hypermedia.PaginationControls(info) {
+		for _, ctrl := range linkwell.PaginationControls(info) {
 			templ_7745c5c3_Err = paginationButton(ctrl).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -246,7 +246,7 @@ func PaginationBar(info hypermedia.PageInfo) templ.Component {
 // Disabled+VariantPrimary → active (current page, no click)
 // Disabled only           → disabled
 // Normal                  → clickable with HTMX attrs
-func paginationButton(ctrl hypermedia.Control) templ.Component {
+func paginationButton(ctrl linkwell.Control) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -267,7 +267,7 @@ func paginationButton(ctrl hypermedia.Control) templ.Component {
 			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		if ctrl.Disabled && ctrl.Variant == hypermedia.VariantPrimary {
+		if ctrl.Disabled && ctrl.Variant == linkwell.VariantPrimary {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<button class=\"join-item btn btn-sm btn-active\" aria-current=\"page\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err

--- a/web/views/admin_error_reports.templ
+++ b/web/views/admin_error_reports.templ
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // AdminErrorReportsPage is the full page for /admin/error-reports.
-templ AdminErrorReportsPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
+templ AdminErrorReportsPage(bar linkwell.FilterBar, tableContainer templ.Component) {
 	<div class="p-4 space-y-4">
 		<div class="flex items-center justify-between">
 			<h1 class="text-2xl font-bold">Error Reports</h1>
@@ -24,7 +24,7 @@ templ AdminErrorReportsPage(bar hypermedia.FilterBar, tableContainer templ.Compo
 }
 
 // AdminErrorReportsTableContainer is the replaceable HTMX fragment.
-templ AdminErrorReportsTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) {
+templ AdminErrorReportsTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) {
 	<div id="error-reports-table-container">
 		@components.Table(cols, body, info)
 	</div>

--- a/web/views/admin_error_reports_templ.go
+++ b/web/views/admin_error_reports_templ.go
@@ -14,12 +14,12 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // AdminErrorReportsPage is the full page for /admin/error-reports.
-func AdminErrorReportsPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ.Component {
+func AdminErrorReportsPage(bar linkwell.FilterBar, tableContainer templ.Component) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -61,7 +61,7 @@ func AdminErrorReportsPage(bar hypermedia.FilterBar, tableContainer templ.Compon
 }
 
 // AdminErrorReportsTableContainer is the replaceable HTMX fragment.
-func AdminErrorReportsTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) templ.Component {
+func AdminErrorReportsTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/admin_settings.templ
+++ b/web/views/admin_settings.templ
@@ -3,7 +3,7 @@
 package views
 
 import (
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"fmt"
 )
 
@@ -13,7 +13,7 @@ type AdminPanelData struct {
 	Version   string
 	Uptime    string
 	Status    string
-	Stats     ssebroker.SystemStats
+	Stats     tavern.SystemStats
 	SSECounts map[string]int
 	Features  []FeatureFlag
 	Routes    []RouteInfo
@@ -161,7 +161,7 @@ templ AdminSettingsPage(data AdminPanelData) {
 
 // --- Fragments for auto-refresh ---
 
-templ AdminSettingsSystemFragment(stats ssebroker.SystemStats, uptime string) {
+templ AdminSettingsSystemFragment(stats tavern.SystemStats, uptime string) {
 	@adminSystemMetrics(stats, uptime)
 }
 
@@ -171,7 +171,7 @@ templ AdminSettingsSSEFragment(counts map[string]int) {
 
 // --- Internal components ---
 
-templ adminSystemMetrics(stats ssebroker.SystemStats, uptime string) {
+templ adminSystemMetrics(stats tavern.SystemStats, uptime string) {
 	<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
 		@metricCard("Uptime", uptime)
 		@metricCard("Goroutines", fmt.Sprintf("%d", stats.Goroutines))

--- a/web/views/admin_settings_templ.go
+++ b/web/views/admin_settings_templ.go
@@ -11,7 +11,7 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"fmt"
 )
 
@@ -21,7 +21,7 @@ type AdminPanelData struct {
 	Version   string
 	Uptime    string
 	Status    string
-	Stats     ssebroker.SystemStats
+	Stats     tavern.SystemStats
 	SSECounts map[string]int
 	Features  []FeatureFlag
 	Routes    []RouteInfo
@@ -242,7 +242,7 @@ func AdminSettingsPage(data AdminPanelData) templ.Component {
 }
 
 // --- Fragments for auto-refresh ---
-func AdminSettingsSystemFragment(stats ssebroker.SystemStats, uptime string) templ.Component {
+func AdminSettingsSystemFragment(stats tavern.SystemStats, uptime string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -301,7 +301,7 @@ func AdminSettingsSSEFragment(counts map[string]int) templ.Component {
 }
 
 // --- Internal components ---
-func adminSystemMetrics(stats ssebroker.SystemStats, uptime string) templ.Component {
+func adminSystemMetrics(stats tavern.SystemStats, uptime string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/app_nav_layout.templ
+++ b/web/views/app_nav_layout.templ
@@ -1,14 +1,14 @@
 package views
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // AppNavLayout is a responsive page layout with CSS-driven auto-positioning:
 // bottom nav bar on mobile, sticky top bar on desktop. Derived apps opt in
 // via handler.SetLayout(handler.AppNavLayoutFunc(...)).
-templ AppNavLayout(content templ.Component, cfg hypermedia.NavConfig, csrfToken string, devMode bool, theme string, crumbs []hypermedia.Breadcrumb, links []hypermedia.LinkRelation, currentPath string, version string, hubs []hypermedia.HubEntry) {
+templ AppNavLayout(content templ.Component, cfg linkwell.NavConfig, csrfToken string, devMode bool, theme string, crumbs []linkwell.Breadcrumb, links []linkwell.LinkRelation, currentPath string, version string, hubs []linkwell.HubEntry) {
 	<!DOCTYPE html>
 	<html lang="en" data-theme={ theme }>
 		@header(csrfToken, devMode, cfg.AppName, []string{"/public/css/app-layout.css"})
@@ -54,7 +54,7 @@ templ AppNavLayout(content templ.Component, cfg hypermedia.NavConfig, csrfToken 
 }
 
 // appNav renders a single nav element that CSS repositions based on screen size.
-templ appNav(cfg hypermedia.NavConfig) {
+templ appNav(cfg linkwell.NavConfig) {
 	<nav class="app-nav" x-data>
 		<div class="nav-tabs flex items-stretch">
 			<!-- Brand (desktop only, hidden on mobile via CSS) -->
@@ -80,7 +80,7 @@ templ appNav(cfg hypermedia.NavConfig) {
 }
 
 // appNavLink renders a single nav link with an inline SVG icon.
-templ appNavLink(item hypermedia.NavItem, promoted bool) {
+templ appNavLink(item linkwell.NavItem, promoted bool) {
 	<a
 		href={ templ.URL(item.Href) }
 		class={ "nav-link", appNavActiveClass(item.Active), templ.KV("promoted", promoted) }
@@ -115,7 +115,7 @@ func appNavActiveClass(active bool) string {
 
 // navMaxVisible returns the effective max-visible count, defaulting to
 // the total number of items when MaxVisible is zero.
-func navMaxVisible(cfg hypermedia.NavConfig) int {
+func navMaxVisible(cfg linkwell.NavConfig) int {
 	if cfg.MaxVisible <= 0 {
 		return len(cfg.Items)
 	}
@@ -124,7 +124,7 @@ func navMaxVisible(cfg hypermedia.NavConfig) int {
 
 // promotedAfterIndex returns the index after which the promoted item should
 // be inserted so it appears centered in the nav bar.
-func promotedAfterIndex(cfg hypermedia.NavConfig) int {
+func promotedAfterIndex(cfg linkwell.NavConfig) int {
 	vis := navMaxVisible(cfg)
 	if vis <= 1 {
 		return 0

--- a/web/views/app_nav_layout_templ.go
+++ b/web/views/app_nav_layout_templ.go
@@ -9,14 +9,14 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // AppNavLayout is a responsive page layout with CSS-driven auto-positioning:
 // bottom nav bar on mobile, sticky top bar on desktop. Derived apps opt in
 // via handler.SetLayout(handler.AppNavLayoutFunc(...)).
-func AppNavLayout(content templ.Component, cfg hypermedia.NavConfig, csrfToken string, devMode bool, theme string, crumbs []hypermedia.Breadcrumb, links []hypermedia.LinkRelation, currentPath string, version string, hubs []hypermedia.HubEntry) templ.Component {
+func AppNavLayout(content templ.Component, cfg linkwell.NavConfig, csrfToken string, devMode bool, theme string, crumbs []linkwell.Breadcrumb, links []linkwell.LinkRelation, currentPath string, version string, hubs []linkwell.HubEntry) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -158,7 +158,7 @@ func AppNavLayout(content templ.Component, cfg hypermedia.NavConfig, csrfToken s
 }
 
 // appNav renders a single nav element that CSS repositions based on screen size.
-func appNav(cfg hypermedia.NavConfig) templ.Component {
+func appNav(cfg linkwell.NavConfig) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -247,7 +247,7 @@ func appNav(cfg hypermedia.NavConfig) templ.Component {
 }
 
 // appNavLink renders a single nav link with an inline SVG icon.
-func appNavLink(item hypermedia.NavItem, promoted bool) templ.Component {
+func appNavLink(item linkwell.NavItem, promoted bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -398,7 +398,7 @@ func appNavActiveClass(active bool) string {
 
 // navMaxVisible returns the effective max-visible count, defaulting to
 // the total number of items when MaxVisible is zero.
-func navMaxVisible(cfg hypermedia.NavConfig) int {
+func navMaxVisible(cfg linkwell.NavConfig) int {
 	if cfg.MaxVisible <= 0 {
 		return len(cfg.Items)
 	}
@@ -407,7 +407,7 @@ func navMaxVisible(cfg hypermedia.NavConfig) int {
 
 // promotedAfterIndex returns the index after which the promoted item should
 // be inserted so it appears centered in the nav bar.
-func promotedAfterIndex(cfg hypermedia.NavConfig) int {
+func promotedAfterIndex(cfg linkwell.NavConfig) int {
 	vis := navMaxVisible(cfg)
 	if vis <= 1 {
 		return 0

--- a/web/views/approvals.templ
+++ b/web/views/approvals.templ
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -67,29 +67,29 @@ templ ApprovalCard(r demo.ApprovalRequest) {
 	</div>
 }
 
-func approvalControls(id int, actions []string) []hypermedia.Control {
-	var controls []hypermedia.Control
+func approvalControls(id int, actions []string) []linkwell.Control {
+	var controls []linkwell.Control
 	url := fmt.Sprintf("/demo/approvals/%d", id)
 	target := fmt.Sprintf("#approval-%d", id)
 	for _, action := range actions {
-		variant := hypermedia.VariantSecondary
+		variant := linkwell.VariantSecondary
 		switch action {
 		case "approve":
-			variant = hypermedia.VariantPrimary
+			variant = linkwell.VariantPrimary
 		case "reject":
-			variant = hypermedia.VariantDanger
+			variant = linkwell.VariantDanger
 		case "escalate":
-			variant = hypermedia.VariantSecondary
+			variant = linkwell.VariantSecondary
 		case "resubmit":
-			variant = hypermedia.VariantPrimary
+			variant = linkwell.VariantPrimary
 		}
-		controls = append(controls, hypermedia.Control{
-			Kind:    hypermedia.ControlKindHTMX,
+		controls = append(controls, linkwell.Control{
+			Kind:    linkwell.ControlKindHTMX,
 			Label:   capitalizeAction(action),
 			Variant: variant,
-			Swap:    hypermedia.SwapOuterHTML,
-			HxRequest: hypermedia.HxRequestConfig{
-				Method: hypermedia.HxMethodPatch,
+			Swap:    linkwell.SwapOuterHTML,
+			HxRequest: linkwell.HxRequestConfig{
+				Method: linkwell.HxMethodPatch,
 				URL:    url,
 				Target: target,
 				Vals:   `{"action":"` + action + `"}`,

--- a/web/views/approvals_templ.go
+++ b/web/views/approvals_templ.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -283,29 +283,29 @@ func ApprovalCard(r demo.ApprovalRequest) templ.Component {
 	})
 }
 
-func approvalControls(id int, actions []string) []hypermedia.Control {
-	var controls []hypermedia.Control
+func approvalControls(id int, actions []string) []linkwell.Control {
+	var controls []linkwell.Control
 	url := fmt.Sprintf("/demo/approvals/%d", id)
 	target := fmt.Sprintf("#approval-%d", id)
 	for _, action := range actions {
-		variant := hypermedia.VariantSecondary
+		variant := linkwell.VariantSecondary
 		switch action {
 		case "approve":
-			variant = hypermedia.VariantPrimary
+			variant = linkwell.VariantPrimary
 		case "reject":
-			variant = hypermedia.VariantDanger
+			variant = linkwell.VariantDanger
 		case "escalate":
-			variant = hypermedia.VariantSecondary
+			variant = linkwell.VariantSecondary
 		case "resubmit":
-			variant = hypermedia.VariantPrimary
+			variant = linkwell.VariantPrimary
 		}
-		controls = append(controls, hypermedia.Control{
-			Kind:    hypermedia.ControlKindHTMX,
+		controls = append(controls, linkwell.Control{
+			Kind:    linkwell.ControlKindHTMX,
 			Label:   capitalizeAction(action),
 			Variant: variant,
-			Swap:    hypermedia.SwapOuterHTML,
-			HxRequest: hypermedia.HxRequestConfig{
-				Method: hypermedia.HxMethodPatch,
+			Swap:    linkwell.SwapOuterHTML,
+			HxRequest: linkwell.HxRequestConfig{
+				Method: linkwell.HxMethodPatch,
 				URL:    url,
 				Target: target,
 				Vals:   `{"action":"` + action + `"}`,

--- a/web/views/bulk.templ
+++ b/web/views/bulk.templ
@@ -6,12 +6,12 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // bulkColAttrs builds templ.Attributes for a sortable column header link in the bulk table.
-func bulkColAttrs(col hypermedia.TableCol) templ.Attributes {
+func bulkColAttrs(col linkwell.TableCol) templ.Attributes {
 	attrs := templ.Attributes{
 		"hx-get":    col.SortURL,
 		"hx-target": col.Target,
@@ -23,14 +23,14 @@ func bulkColAttrs(col hypermedia.TableCol) templ.Attributes {
 }
 
 // bulkSortIndicator returns the sort direction indicator for a column.
-func bulkSortIndicator(col hypermedia.TableCol) string {
+func bulkSortIndicator(col linkwell.TableCol) string {
 	if !col.Sortable {
 		return ""
 	}
 	switch col.SortDir {
-	case hypermedia.SortAsc:
+	case linkwell.SortAsc:
 		return " ↑"
-	case hypermedia.SortDesc:
+	case linkwell.SortDesc:
 		return " ↓"
 	default:
 		return " ⇅"
@@ -39,11 +39,11 @@ func bulkSortIndicator(col hypermedia.TableCol) string {
 
 // BulkPage is the full page for /demo/bulk.
 // The toolbar and FilterBar live outside the table container so they survive swaps.
-templ BulkPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
+templ BulkPage(bar linkwell.FilterBar, tableContainer templ.Component) {
 	<div class="p-4 space-y-4">
 		<div class="flex items-center justify-between">
 			<h1 class="text-2xl font-bold">☑ Bulk Operations</h1>
-			@components.Controls(hypermedia.BulkActions(hypermedia.BulkActionCfg{
+			@components.Controls(linkwell.BulkActions(linkwell.BulkActionCfg{
 				DeleteURL:        "/demo/bulk/items",
 				ActivateURL:      "/demo/bulk/items/activate",
 				DeactivateURL:    "/demo/bulk/items/deactivate",
@@ -58,7 +58,7 @@ templ BulkPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
 
 // BulkTableContainer is the replaceable fragment. It renders a custom table with a
 // leading checkbox column that cannot reuse components.Table (sortLinkAttrs is unexported).
-templ BulkTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) {
+templ BulkTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) {
 	<div id="bulk-table-container">
 		<div class="overflow-x-auto">
 			<table class="table table-sm w-full">

--- a/web/views/bulk_templ.go
+++ b/web/views/bulk_templ.go
@@ -15,12 +15,12 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // bulkColAttrs builds templ.Attributes for a sortable column header link in the bulk table.
-func bulkColAttrs(col hypermedia.TableCol) templ.Attributes {
+func bulkColAttrs(col linkwell.TableCol) templ.Attributes {
 	attrs := templ.Attributes{
 		"hx-get":    col.SortURL,
 		"hx-target": col.Target,
@@ -32,14 +32,14 @@ func bulkColAttrs(col hypermedia.TableCol) templ.Attributes {
 }
 
 // bulkSortIndicator returns the sort direction indicator for a column.
-func bulkSortIndicator(col hypermedia.TableCol) string {
+func bulkSortIndicator(col linkwell.TableCol) string {
 	if !col.Sortable {
 		return ""
 	}
 	switch col.SortDir {
-	case hypermedia.SortAsc:
+	case linkwell.SortAsc:
 		return " ↑"
-	case hypermedia.SortDesc:
+	case linkwell.SortDesc:
 		return " ↓"
 	default:
 		return " ⇅"
@@ -48,7 +48,7 @@ func bulkSortIndicator(col hypermedia.TableCol) string {
 
 // BulkPage is the full page for /demo/bulk.
 // The toolbar and FilterBar live outside the table container so they survive swaps.
-func BulkPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ.Component {
+func BulkPage(bar linkwell.FilterBar, tableContainer templ.Component) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -73,7 +73,7 @@ func BulkPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ.Co
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls(hypermedia.BulkActions(hypermedia.BulkActionCfg{
+		templ_7745c5c3_Err = components.Controls(linkwell.BulkActions(linkwell.BulkActionCfg{
 			DeleteURL:        "/demo/bulk/items",
 			ActivateURL:      "/demo/bulk/items/activate",
 			DeactivateURL:    "/demo/bulk/items/deactivate",
@@ -105,7 +105,7 @@ func BulkPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ.Co
 
 // BulkTableContainer is the replaceable fragment. It renders a custom table with a
 // leading checkbox column that cannot reuse components.Table (sortLinkAttrs is unexported).
-func BulkTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) templ.Component {
+func BulkTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/catalog.templ
+++ b/web/views/catalog.templ
@@ -6,13 +6,13 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // CatalogPage is the full page content for /demo/catalog.
 // The FilterBar lives outside the table container so it is never replaced by HTMX swaps.
-templ CatalogPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
+templ CatalogPage(bar linkwell.FilterBar, tableContainer templ.Component) {
 	<div class="p-4 space-y-4">
 		<div class="flex items-center justify-between">
 			<h1 class="text-2xl font-bold">📖 Product Catalog</h1>
@@ -23,7 +23,7 @@ templ CatalogPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
 }
 
 // CatalogTableContainer is the replaceable fragment targeted by filter/sort/page HTMX requests.
-templ CatalogTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) {
+templ CatalogTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) {
 	<div id="catalog-table-container">
 		@components.Table(cols, body, info)
 	</div>
@@ -58,8 +58,8 @@ templ CatalogItemRow(item demo.Item) {
 			}
 		</td>
 		<td>
-			@components.Controls([]hypermedia.Control{
-				hypermedia.CatalogRowAction(detailURL, detailRowTarget),
+			@components.Controls([]linkwell.Control{
+				linkwell.CatalogRowAction(detailURL, detailRowTarget),
 			})
 		</td>
 	</tr>

--- a/web/views/catalog_templ.go
+++ b/web/views/catalog_templ.go
@@ -15,13 +15,13 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // CatalogPage is the full page content for /demo/catalog.
 // The FilterBar lives outside the table container so it is never replaced by HTMX swaps.
-func CatalogPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ.Component {
+func CatalogPage(bar linkwell.FilterBar, tableContainer templ.Component) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -63,7 +63,7 @@ func CatalogPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ
 }
 
 // CatalogTableContainer is the replaceable fragment targeted by filter/sort/page HTMX requests.
-func CatalogTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) templ.Component {
+func CatalogTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -280,8 +280,8 @@ func CatalogItemRow(item demo.Item) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
-			hypermedia.CatalogRowAction(detailURL, detailRowTarget),
+		templ_7745c5c3_Err = components.Controls([]linkwell.Control{
+			linkwell.CatalogRowAction(detailURL, detailRowTarget),
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/web/views/dashboard.templ
+++ b/web/views/dashboard.templ
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 )
 
 // dashFromMask is the breadcrumb bitmask for links originating from the dashboard.
 // Home (bit 0) + Dashboard (bit 1) = 3. Used as ?from=3 in dashboard link hrefs.
-const dashFromMask = hypermedia.FromHome | hypermedia.FromDashboard // = 3
+const dashFromMask = linkwell.FromHome | linkwell.FromDashboard // = 3
 
 // DashboardStats holds aggregate data for the dashboard.
 type DashboardStats struct {

--- a/web/views/dashboard_templ.go
+++ b/web/views/dashboard_templ.go
@@ -14,12 +14,12 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 )
 
 // dashFromMask is the breadcrumb bitmask for links originating from the dashboard.
 // Home (bit 0) + Dashboard (bit 1) = 3. Used as ?from=3 in dashboard link hrefs.
-const dashFromMask = hypermedia.FromHome | hypermedia.FromDashboard // = 3
+const dashFromMask = linkwell.FromHome | linkwell.FromDashboard // = 3
 
 // DashboardStats holds aggregate data for the dashboard.
 type DashboardStats struct {

--- a/web/views/error_traces.templ
+++ b/web/views/error_traces.templ
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/catgoose/promolog"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -25,7 +25,7 @@ func parseAttrs(attrs string) [][]string {
 }
 
 // ErrorTracesPage is the full page for /admin/error-traces.
-templ ErrorTracesPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
+templ ErrorTracesPage(bar linkwell.FilterBar, tableContainer templ.Component) {
 	<div class="p-4 space-y-4">
 		<div class="flex items-center justify-between">
 			<h1 class="text-2xl font-bold">Error Traces</h1>
@@ -39,7 +39,7 @@ templ ErrorTracesPage(bar hypermedia.FilterBar, tableContainer templ.Component) 
 }
 
 // ErrorTracesTableContainer is the HTMX-replaceable fragment.
-templ ErrorTracesTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) {
+templ ErrorTracesTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) {
 	<div id="error-traces-table-container">
 		@components.Table(cols, body, info)
 	</div>

--- a/web/views/error_traces_templ.go
+++ b/web/views/error_traces_templ.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 	"github.com/catgoose/promolog"
 )
@@ -33,7 +33,7 @@ func parseAttrs(attrs string) [][]string {
 }
 
 // ErrorTracesPage is the full page for /admin/error-traces.
-func ErrorTracesPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ.Component {
+func ErrorTracesPage(bar linkwell.FilterBar, tableContainer templ.Component) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -75,7 +75,7 @@ func ErrorTracesPage(bar hypermedia.FilterBar, tableContainer templ.Component) t
 }
 
 // ErrorTracesTableContainer is the HTMX-replaceable fragment.
-func ErrorTracesTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) templ.Component {
+func ErrorTracesTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/hypermedia_controls.templ
+++ b/web/views/hypermedia_controls.templ
@@ -2,7 +2,7 @@
 package views
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -17,17 +17,17 @@ templ HypermediaControlsPage() {
 		// ─── 1. Button Variants ──────────────────────────────────────────────
 		@controlsSection("1. Button Variants") {
 			<p class="text-sm text-base-content/70 mb-3">Click any button — each <code class="text-xs bg-base-200 px-1 rounded">POST</code>s to the server and the response shows which variant was clicked.</p>
-			@components.Controls([]hypermedia.Control{
-				{Kind: hypermedia.ControlKindHTMX, Label: "Primary", Variant: hypermedia.VariantPrimary,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=primary", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
-				{Kind: hypermedia.ControlKindHTMX, Label: "Secondary", Variant: hypermedia.VariantSecondary,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=secondary", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
-				{Kind: hypermedia.ControlKindHTMX, Label: "Danger", Variant: hypermedia.VariantDanger,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=danger", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
-				{Kind: hypermedia.ControlKindHTMX, Label: "Ghost", Variant: hypermedia.VariantGhost,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=ghost", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
-				{Kind: hypermedia.ControlKindHTMX, Label: "Link", Variant: hypermedia.VariantLink,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=link", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
+			@components.Controls([]linkwell.Control{
+				{Kind: linkwell.ControlKindHTMX, Label: "Primary", Variant: linkwell.VariantPrimary,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=primary", "#variant-result"), Swap: linkwell.SwapInnerHTML},
+				{Kind: linkwell.ControlKindHTMX, Label: "Secondary", Variant: linkwell.VariantSecondary,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=secondary", "#variant-result"), Swap: linkwell.SwapInnerHTML},
+				{Kind: linkwell.ControlKindHTMX, Label: "Danger", Variant: linkwell.VariantDanger,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=danger", "#variant-result"), Swap: linkwell.SwapInnerHTML},
+				{Kind: linkwell.ControlKindHTMX, Label: "Ghost", Variant: linkwell.VariantGhost,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=ghost", "#variant-result"), Swap: linkwell.SwapInnerHTML},
+				{Kind: linkwell.ControlKindHTMX, Label: "Link", Variant: linkwell.VariantLink,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=link", "#variant-result"), Swap: linkwell.SwapInnerHTML},
 			})
 			<div id="variant-result" class="mt-3 text-sm text-base-content/50 italic">Click a button above…</div>
 		}
@@ -35,11 +35,11 @@ templ HypermediaControlsPage() {
 		@controlsSection("2. Control Kinds") {
 			<p class="text-sm text-base-content/70 mb-3">Each kind uses a different mechanism: HTMX request, HyperScript, or plain navigation.</p>
 			<div class="space-y-3">
-				@components.Controls([]hypermedia.Control{
-					hypermedia.RetryButton("Retry", hypermedia.HxMethodGet, "/hypermedia/controls/retry", "#kind-result"),
-					hypermedia.HTMXAction("HTMX Action", hypermedia.HxPost("/hypermedia/controls/action", "#kind-result")),
-					hypermedia.BackButton("Go Back"),
-					hypermedia.RedirectLink("Link", "/"),
+				@components.Controls([]linkwell.Control{
+					linkwell.RetryButton("Retry", linkwell.HxMethodGet, "/hypermedia/controls/retry", "#kind-result"),
+					linkwell.HTMXAction("HTMX Action", linkwell.HxPost("/hypermedia/controls/action", "#kind-result")),
+					linkwell.BackButton("Go Back"),
+					linkwell.RedirectLink("Link", "/"),
 				})
 				<div id="kind-result" class="text-sm text-base-content/50 italic">Click Retry or HTMX Action…</div>
 				<p class="text-xs font-medium text-base-content/60 mt-1">Dismiss demo:</p>
@@ -86,27 +86,27 @@ templ HypermediaControlsPage() {
 		@controlsSection("6. Error Status") {
 			<div class="space-y-4">
 				<p class="text-sm font-medium text-base-content/60">404 Not Found (closable):</p>
-				@components.ErrorStatusFromContext(hypermedia.ErrorContext{
+				@components.ErrorStatusFromContext(linkwell.ErrorContext{
 					StatusCode: 404,
 					Message:    "Page not found",
 					Route:      "/example/missing",
 					RequestID:  "req-abc-123",
 					Closable:   true,
 					Controls: append(
-						hypermedia.NotFoundControls("/"),
-						hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, "req-abc-123"),
+						linkwell.NotFoundControls("/"),
+						linkwell.ReportIssueButton(linkwell.LabelReportIssue, "req-abc-123"),
 					),
 				})
 				<p class="text-sm font-medium text-base-content/60 mt-4">500 Internal Error:</p>
-				@components.ErrorStatusFromContext(hypermedia.ErrorContext{
+				@components.ErrorStatusFromContext(linkwell.ErrorContext{
 					StatusCode: 500,
 					Message:    "Internal server error",
 					Route:      "/api/data",
 					RequestID:  "req-def-456",
 					Closable:   true,
 					Controls: append(
-						hypermedia.InternalErrorControls(hypermedia.ErrorControlOpts{}),
-						hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, "req-def-456"),
+						linkwell.InternalErrorControls(linkwell.ErrorControlOpts{}),
+						linkwell.ReportIssueButton(linkwell.LabelReportIssue, "req-def-456"),
 					),
 				})
 			</div>
@@ -115,10 +115,10 @@ templ HypermediaControlsPage() {
 		@controlsSection("7. Error Controls") {
 			<div class="space-y-4">
 				<p class="text-sm font-medium text-base-content/60">404 Not Found controls (Back + Go Home):</p>
-				@components.ErrorControls(hypermedia.NotFoundControls("/"))
+				@components.ErrorControls(linkwell.NotFoundControls("/"))
 				<p class="text-sm font-medium text-base-content/60 mt-2">500 Internal Error controls (Retry + Dismiss):</p>
 				<div id="error-retry-demo">
-					@components.ErrorControls(hypermedia.InternalErrorControls(hypermedia.ErrorControlOpts{
+					@components.ErrorControls(linkwell.InternalErrorControls(linkwell.ErrorControlOpts{
 						RetryURL:    "/hypermedia/controls/retry",
 						RetryTarget: "#error-retry-demo",
 					}))
@@ -128,10 +128,10 @@ templ HypermediaControlsPage() {
 		// ─── 8. Navigation ───────────────────────────────────────────────────
 		@controlsSection("8. Navigation") {
 			<div class="space-y-4">
-				@components.NavBar(hypermedia.SetActiveNavItem([]hypermedia.NavItem{
+				@components.NavBar(linkwell.SetActiveNavItem([]linkwell.NavItem{
 					{
 						Label: "Tables",
-						Children: []hypermedia.NavItem{
+						Children: []linkwell.NavItem{
 							{Label: "Inventory", Href: "/demo/inventory"},
 							{Label: "Catalog", Href: "/demo/catalog"},
 							{Label: "Bulk", Href: "/demo/bulk"},
@@ -139,29 +139,29 @@ templ HypermediaControlsPage() {
 					},
 					{
 						Label: "Hypermedia Controls",
-						Children: []hypermedia.NavItem{
+						Children: []linkwell.NavItem{
 							{Label: "Controls", Href: "/hypermedia/controls"},
 						},
 					},
 				}, "/hypermedia/controls"))
-				@components.Breadcrumbs(hypermedia.BreadcrumbsFromPath("/demo/inventory", map[int]string{0: "Tables", 1: "Inventory"}))
+				@components.Breadcrumbs(linkwell.BreadcrumbsFromPath("/demo/inventory", map[int]string{0: "Tables", 1: "Inventory"}))
 			</div>
 		}
 		// ─── 9. Filter Fields ────────────────────────────────────────────────
 		@controlsSection("9. Filter Fields") {
 			<p class="text-sm text-base-content/70 mb-3">Adjust any filter to see results update live. Each field fires <code class="text-xs bg-base-200 px-1 rounded">hx-get</code> with <code class="text-xs bg-base-200 px-1 rounded">hx-include</code> to send all field values.</p>
-			@components.FilterBar(hypermedia.NewFilterBar("/hypermedia/controls/filter", "#filter-results",
-				hypermedia.SearchField("q", "Search\u2026", ""),
-				hypermedia.SelectField("cat", "Category", "",
-					hypermedia.SelectOptions("",
+			@components.FilterBar(linkwell.NewFilterBar("/hypermedia/controls/filter", "#filter-results",
+				linkwell.SearchField("q", "Search\u2026", ""),
+				linkwell.SelectField("cat", "Category", "",
+					linkwell.SelectOptions("",
 						"", "All",
 						"Electronics", "Electronics",
 						"Sports", "Sports",
 						"Books", "Books",
 						"Clothing", "Clothing",
 					)),
-				hypermedia.RangeField("price", "Max Price", "500", "0", "500", "10"),
-				hypermedia.CheckboxField("active", "Active only", ""),
+				linkwell.RangeField("price", "Max Price", "500", "0", "500", "10"),
+				linkwell.CheckboxField("active", "Active only", ""),
 			))
 			<div
 				id="filter-results"

--- a/web/views/hypermedia_controls_fragments.templ
+++ b/web/views/hypermedia_controls_fragments.templ
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -89,7 +89,7 @@ templ ResourceViewFragment(name, desc string) {
 			<p class="font-semibold">{ name }</p>
 			<p class="text-sm text-base-content/70">{ desc }</p>
 		</div>
-		@components.Controls(hypermedia.ResourceActions(hypermedia.ResourceActionCfg{
+		@components.Controls(linkwell.ResourceActions(linkwell.ResourceActionCfg{
 			EditURL:    "/hypermedia/controls/resource/edit",
 			DeleteURL:  "/hypermedia/controls/resource",
 			ConfirmMsg: "Delete this resource?",
@@ -156,7 +156,7 @@ templ FormDemoFragment() {
 				<input name="value" class="input input-sm" value="42"/>
 			</div>
 		</div>
-		@components.Controls(hypermedia.FormActions("/hypermedia/controls"))
+		@components.Controls(linkwell.FormActions("/hypermedia/controls"))
 	</form>
 }
 
@@ -180,13 +180,13 @@ templ FormSubmitResultFragment(label, value string) {
 templ EmptyStateFragment() {
 	<div class="text-center py-6 text-base-content/50">
 		<p class="mb-3">No items yet.</p>
-		@components.Controls([]hypermedia.Control{
+		@components.Controls([]linkwell.Control{
 			{
-				Kind:      hypermedia.ControlKindHTMX,
+				Kind:      linkwell.ControlKindHTMX,
 				Label:     "Create Item",
-				Variant:   hypermedia.VariantPrimary,
-				HxRequest: hypermedia.HxPost("/hypermedia/controls/items", "#items-demo"),
-				Swap:      hypermedia.SwapInnerHTML,
+				Variant:   linkwell.VariantPrimary,
+				HxRequest: linkwell.HxPost("/hypermedia/controls/items", "#items-demo"),
+				Swap:      linkwell.SwapInnerHTML,
 			},
 		})
 	</div>
@@ -274,7 +274,7 @@ templ RowViewFragment(item GalleryRowItem) {
 			}
 		</td>
 		<td>
-			@components.Controls(hypermedia.RowActions(hypermedia.RowActionCfg{
+			@components.Controls(linkwell.RowActions(linkwell.RowActionCfg{
 				EditURL:    fmt.Sprintf("/hypermedia/controls/rows/%d/edit", item.ID),
 				DeleteURL:  fmt.Sprintf("/hypermedia/controls/rows/%d", item.ID),
 				RowTarget:  fmt.Sprintf("#cg-row-%d", item.ID),
@@ -299,7 +299,7 @@ templ RowEditFragment(item GalleryRowItem) {
 		<td><input type="number" name="price" step="0.01" class="input input-sm w-24" value={ item.Price }/></td>
 		<td><input type="checkbox" name="active" value="true" class="toggle toggle-sm" checked?={ item.Active }/></td>
 		<td>
-			@components.Controls(hypermedia.RowFormActions(hypermedia.RowFormActionCfg{
+			@components.Controls(linkwell.RowFormActions(linkwell.RowFormActionCfg{
 				SaveURL:      fmt.Sprintf("/hypermedia/controls/rows/%d", item.ID),
 				CancelURL:    fmt.Sprintf("/hypermedia/controls/rows/%d", item.ID),
 				SaveTarget:   fmt.Sprintf("#cg-row-%d", item.ID),
@@ -314,7 +314,7 @@ templ RowEditFragment(item GalleryRowItem) {
 // GalleryErrorPanel renders an inline error with a stacked layout and a unified
 // Dismiss + Report joined button group. Each panel has its own ID so multiple
 // can coexist.
-templ GalleryErrorPanel(panelID string, ec hypermedia.ErrorContext) {
+templ GalleryErrorPanel(panelID string, ec linkwell.ErrorContext) {
 	<div id={ panelID }>
 		@components.InlineErrorPanel(ec)
 	</div>

--- a/web/views/hypermedia_controls_fragments_templ.go
+++ b/web/views/hypermedia_controls_fragments_templ.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"strconv"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -301,7 +301,7 @@ func ResourceViewFragment(name, desc string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls(hypermedia.ResourceActions(hypermedia.ResourceActionCfg{
+		templ_7745c5c3_Err = components.Controls(linkwell.ResourceActions(linkwell.ResourceActionCfg{
 			EditURL:    "/hypermedia/controls/resource/edit",
 			DeleteURL:  "/hypermedia/controls/resource",
 			ConfirmMsg: "Delete this resource?",
@@ -428,7 +428,7 @@ func FormDemoFragment() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls(hypermedia.FormActions("/hypermedia/controls")).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.Controls(linkwell.FormActions("/hypermedia/controls")).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -521,13 +521,13 @@ func EmptyStateFragment() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+		templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 			{
-				Kind:      hypermedia.ControlKindHTMX,
+				Kind:      linkwell.ControlKindHTMX,
 				Label:     "Create Item",
-				Variant:   hypermedia.VariantPrimary,
-				HxRequest: hypermedia.HxPost("/hypermedia/controls/items", "#items-demo"),
-				Swap:      hypermedia.SwapInnerHTML,
+				Variant:   linkwell.VariantPrimary,
+				HxRequest: linkwell.HxPost("/hypermedia/controls/items", "#items-demo"),
+				Swap:      linkwell.SwapInnerHTML,
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -830,7 +830,7 @@ func RowViewFragment(item GalleryRowItem) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls(hypermedia.RowActions(hypermedia.RowActionCfg{
+		templ_7745c5c3_Err = components.Controls(linkwell.RowActions(linkwell.RowActionCfg{
 			EditURL:    fmt.Sprintf("/hypermedia/controls/rows/%d/edit", item.ID),
 			DeleteURL:  fmt.Sprintf("/hypermedia/controls/rows/%d", item.ID),
 			RowTarget:  fmt.Sprintf("#cg-row-%d", item.ID),
@@ -971,7 +971,7 @@ func RowEditFragment(item GalleryRowItem) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls(hypermedia.RowFormActions(hypermedia.RowFormActionCfg{
+		templ_7745c5c3_Err = components.Controls(linkwell.RowFormActions(linkwell.RowFormActionCfg{
 			SaveURL:      fmt.Sprintf("/hypermedia/controls/rows/%d", item.ID),
 			CancelURL:    fmt.Sprintf("/hypermedia/controls/rows/%d", item.ID),
 			SaveTarget:   fmt.Sprintf("#cg-row-%d", item.ID),
@@ -993,7 +993,7 @@ func RowEditFragment(item GalleryRowItem) templ.Component {
 // GalleryErrorPanel renders an inline error with a stacked layout and a unified
 // Dismiss + Report joined button group. Each panel has its own ID so multiple
 // can coexist.
-func GalleryErrorPanel(panelID string, ec hypermedia.ErrorContext) templ.Component {
+func GalleryErrorPanel(panelID string, ec linkwell.ErrorContext) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/hypermedia_controls_templ.go
+++ b/web/views/hypermedia_controls_templ.go
@@ -11,7 +11,7 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -58,17 +58,17 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
-				{Kind: hypermedia.ControlKindHTMX, Label: "Primary", Variant: hypermedia.VariantPrimary,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=primary", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
-				{Kind: hypermedia.ControlKindHTMX, Label: "Secondary", Variant: hypermedia.VariantSecondary,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=secondary", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
-				{Kind: hypermedia.ControlKindHTMX, Label: "Danger", Variant: hypermedia.VariantDanger,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=danger", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
-				{Kind: hypermedia.ControlKindHTMX, Label: "Ghost", Variant: hypermedia.VariantGhost,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=ghost", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
-				{Kind: hypermedia.ControlKindHTMX, Label: "Link", Variant: hypermedia.VariantLink,
-					HxRequest: hypermedia.HxPost("/hypermedia/controls/echo?v=link", "#variant-result"), Swap: hypermedia.SwapInnerHTML},
+			templ_7745c5c3_Err = components.Controls([]linkwell.Control{
+				{Kind: linkwell.ControlKindHTMX, Label: "Primary", Variant: linkwell.VariantPrimary,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=primary", "#variant-result"), Swap: linkwell.SwapInnerHTML},
+				{Kind: linkwell.ControlKindHTMX, Label: "Secondary", Variant: linkwell.VariantSecondary,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=secondary", "#variant-result"), Swap: linkwell.SwapInnerHTML},
+				{Kind: linkwell.ControlKindHTMX, Label: "Danger", Variant: linkwell.VariantDanger,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=danger", "#variant-result"), Swap: linkwell.SwapInnerHTML},
+				{Kind: linkwell.ControlKindHTMX, Label: "Ghost", Variant: linkwell.VariantGhost,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=ghost", "#variant-result"), Swap: linkwell.SwapInnerHTML},
+				{Kind: linkwell.ControlKindHTMX, Label: "Link", Variant: linkwell.VariantLink,
+					HxRequest: linkwell.HxPost("/hypermedia/controls/echo?v=link", "#variant-result"), Swap: linkwell.SwapInnerHTML},
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -99,11 +99,11 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
-				hypermedia.RetryButton("Retry", hypermedia.HxMethodGet, "/hypermedia/controls/retry", "#kind-result"),
-				hypermedia.HTMXAction("HTMX Action", hypermedia.HxPost("/hypermedia/controls/action", "#kind-result")),
-				hypermedia.BackButton("Go Back"),
-				hypermedia.RedirectLink("Link", "/"),
+			templ_7745c5c3_Err = components.Controls([]linkwell.Control{
+				linkwell.RetryButton("Retry", linkwell.HxMethodGet, "/hypermedia/controls/retry", "#kind-result"),
+				linkwell.HTMXAction("HTMX Action", linkwell.HxPost("/hypermedia/controls/action", "#kind-result")),
+				linkwell.BackButton("Go Back"),
+				linkwell.RedirectLink("Link", "/"),
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -232,15 +232,15 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.ErrorStatusFromContext(hypermedia.ErrorContext{
+			templ_7745c5c3_Err = components.ErrorStatusFromContext(linkwell.ErrorContext{
 				StatusCode: 404,
 				Message:    "Page not found",
 				Route:      "/example/missing",
 				RequestID:  "req-abc-123",
 				Closable:   true,
 				Controls: append(
-					hypermedia.NotFoundControls("/"),
-					hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, "req-abc-123"),
+					linkwell.NotFoundControls("/"),
+					linkwell.ReportIssueButton(linkwell.LabelReportIssue, "req-abc-123"),
 				),
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
@@ -250,15 +250,15 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.ErrorStatusFromContext(hypermedia.ErrorContext{
+			templ_7745c5c3_Err = components.ErrorStatusFromContext(linkwell.ErrorContext{
 				StatusCode: 500,
 				Message:    "Internal server error",
 				Route:      "/api/data",
 				RequestID:  "req-def-456",
 				Closable:   true,
 				Controls: append(
-					hypermedia.InternalErrorControls(hypermedia.ErrorControlOpts{}),
-					hypermedia.ReportIssueButton(hypermedia.LabelReportIssue, "req-def-456"),
+					linkwell.InternalErrorControls(linkwell.ErrorControlOpts{}),
+					linkwell.ReportIssueButton(linkwell.LabelReportIssue, "req-def-456"),
 				),
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
@@ -290,7 +290,7 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.ErrorControls(hypermedia.NotFoundControls("/")).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = components.ErrorControls(linkwell.NotFoundControls("/")).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -298,7 +298,7 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.ErrorControls(hypermedia.InternalErrorControls(hypermedia.ErrorControlOpts{
+			templ_7745c5c3_Err = components.ErrorControls(linkwell.InternalErrorControls(linkwell.ErrorControlOpts{
 				RetryURL:    "/hypermedia/controls/retry",
 				RetryTarget: "#error-retry-demo",
 			})).Render(ctx, templ_7745c5c3_Buffer)
@@ -331,10 +331,10 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.NavBar(hypermedia.SetActiveNavItem([]hypermedia.NavItem{
+			templ_7745c5c3_Err = components.NavBar(linkwell.SetActiveNavItem([]linkwell.NavItem{
 				{
 					Label: "Tables",
-					Children: []hypermedia.NavItem{
+					Children: []linkwell.NavItem{
 						{Label: "Inventory", Href: "/demo/inventory"},
 						{Label: "Catalog", Href: "/demo/catalog"},
 						{Label: "Bulk", Href: "/demo/bulk"},
@@ -342,7 +342,7 @@ func HypermediaControlsPage() templ.Component {
 				},
 				{
 					Label: "Hypermedia Controls",
-					Children: []hypermedia.NavItem{
+					Children: []linkwell.NavItem{
 						{Label: "Controls", Href: "/hypermedia/controls"},
 					},
 				},
@@ -350,7 +350,7 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.Breadcrumbs(hypermedia.BreadcrumbsFromPath("/demo/inventory", map[int]string{0: "Tables", 1: "Inventory"})).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = components.Breadcrumbs(linkwell.BreadcrumbsFromPath("/demo/inventory", map[int]string{0: "Tables", 1: "Inventory"})).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -380,18 +380,18 @@ func HypermediaControlsPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.FilterBar(hypermedia.NewFilterBar("/hypermedia/controls/filter", "#filter-results",
-				hypermedia.SearchField("q", "Search\u2026", ""),
-				hypermedia.SelectField("cat", "Category", "",
-					hypermedia.SelectOptions("",
+			templ_7745c5c3_Err = components.FilterBar(linkwell.NewFilterBar("/hypermedia/controls/filter", "#filter-results",
+				linkwell.SearchField("q", "Search\u2026", ""),
+				linkwell.SelectField("cat", "Category", "",
+					linkwell.SelectOptions("",
 						"", "All",
 						"Electronics", "Electronics",
 						"Sports", "Sports",
 						"Books", "Books",
 						"Clothing", "Clothing",
 					)),
-				hypermedia.RangeField("price", "Max Price", "500", "0", "500", "10"),
-				hypermedia.CheckboxField("active", "Active only", ""),
+				linkwell.RangeField("price", "Max Price", "500", "0", "500", "10"),
+				linkwell.CheckboxField("active", "Active only", ""),
 			)).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err

--- a/web/views/hypermedia_links.go
+++ b/web/views/hypermedia_links.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 )
 
-func linksRowspan(links []hypermedia.LinkRelation) string {
+func linksRowspan(links []linkwell.LinkRelation) string {
 	return fmt.Sprintf("%d", len(links))
 }
 
-func linksCount(links map[string][]hypermedia.LinkRelation) string {
+func linksCount(links map[string][]linkwell.LinkRelation) string {
 	n := 0
 	for _, v := range links {
 		n += len(v)
@@ -20,7 +20,7 @@ func linksCount(links map[string][]hypermedia.LinkRelation) string {
 	return fmt.Sprintf("%d", n)
 }
 
-func pathsCount(links map[string][]hypermedia.LinkRelation) string {
+func pathsCount(links map[string][]linkwell.LinkRelation) string {
 	return fmt.Sprintf("%d", len(links))
 }
 
@@ -41,25 +41,25 @@ func linkDeleteURL(id int) string {
 }
 
 func codeLinkExample() string {
-	return `hypermedia.Link("/demo/inventory", "related", "/demo/people", "People")
+	return `linkwell.Link("/demo/inventory", "related", "/demo/people", "People")
 // Result: inventory <-> people (bidirectional)`
 }
 
 func codeRingExample() string {
-	return `hypermedia.Ring(
-    hypermedia.Rel("/admin/health", "Health"),
-    hypermedia.Rel("/admin/error-traces", "Error Traces"),
-    hypermedia.Rel("/admin/sessions", "Sessions"),
-    hypermedia.Rel("/admin/settings", "Control Panel"),
+	return `linkwell.Ring(
+    linkwell.Rel("/admin/health", "Health"),
+    linkwell.Rel("/admin/error-traces", "Error Traces"),
+    linkwell.Rel("/admin/sessions", "Sessions"),
+    linkwell.Rel("/admin/settings", "Control Panel"),
 )
 // Result: 4 pages, each links to the other 3 = 12 directed links`
 }
 
 func codeHubExample() string {
-	return `hypermedia.Hub("/dashboard", "Dashboard",
-    hypermedia.Rel("/demo/inventory", "Inventory"),
-    hypermedia.Rel("/demo/people", "People"),
-    hypermedia.Rel("/demo/kanban", "Kanban"),
+	return `linkwell.Hub("/dashboard", "Dashboard",
+    linkwell.Rel("/demo/inventory", "Inventory"),
+    linkwell.Rel("/demo/people", "People"),
+    linkwell.Rel("/demo/kanban", "Kanban"),
 )
 // Result: dashboard -> inventory, people, kanban
 //         inventory -> dashboard (only)
@@ -81,14 +81,14 @@ func Rel(path, title string) RelEntry {
 func codeDedupExample() string {
 	return `// These two calls share /admin/health and /admin/error-traces.
 // hasLink prevents duplicate links on the shared pages.
-hypermedia.Ring(
-    hypermedia.Rel("/admin/health", "Health"),
-    hypermedia.Rel("/admin/error-traces", "Error Traces"),
-    hypermedia.Rel("/admin/sessions", "Sessions"),
+linkwell.Ring(
+    linkwell.Rel("/admin/health", "Health"),
+    linkwell.Rel("/admin/error-traces", "Error Traces"),
+    linkwell.Rel("/admin/sessions", "Sessions"),
 )
-hypermedia.Ring(
-    hypermedia.Rel("/admin/system", "System"),
-    hypermedia.Rel("/admin/health", "Health"),
-    hypermedia.Rel("/admin/error-traces", "Error Traces"),
+linkwell.Ring(
+    linkwell.Rel("/admin/system", "System"),
+    linkwell.Rel("/admin/health", "Health"),
+    linkwell.Rel("/admin/error-traces", "Error Traces"),
 )`
 }

--- a/web/views/hypermedia_links.templ
+++ b/web/views/hypermedia_links.templ
@@ -3,12 +3,12 @@ package views
 
 import (
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 )
 
 // LinksPageData holds all data needed to render the links page.
 type LinksPageData struct {
-	Links       map[string][]hypermedia.LinkRelation
+	Links       map[string][]linkwell.LinkRelation
 	StoredLinks []demo.StoredLinkRelation
 	Routes      []string
 }
@@ -77,7 +77,7 @@ templ HypermediaLinksPage(data LinksPageData) {
 		@linksSection("7. Live Registry") {
 			<p class="text-sm text-base-content/70 mb-3">
 				All link relations currently registered in this running application, via
-				<code class="text-xs bg-base-200 px-1 rounded">hypermedia.AllLinks()</code>.
+				<code class="text-xs bg-base-200 px-1 rounded">linkwell.AllLinks()</code>.
 			</p>
 			@LinksRegistryTable(data)
 		}
@@ -138,7 +138,7 @@ templ LinksRegistryTable(data LinksPageData) {
 					</tr>
 				</thead>
 				<tbody>
-					for _, src := range hypermedia.SortedPaths(data.Links) {
+					for _, src := range linkwell.SortedPaths(data.Links) {
 						for i, link := range data.Links[src] {
 							<tr class={ templ.KV("border-t border-base-300", i == 0) }>
 								if i == 0 {

--- a/web/views/hypermedia_links_templ.go
+++ b/web/views/hypermedia_links_templ.go
@@ -12,12 +12,12 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 )
 
 // LinksPageData holds all data needed to render the links page.
 type LinksPageData struct {
-	Links       map[string][]hypermedia.LinkRelation
+	Links       map[string][]linkwell.LinkRelation
 	StoredLinks []demo.StoredLinkRelation
 	Routes      []string
 }
@@ -260,7 +260,7 @@ func HypermediaLinksPage(data LinksPageData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<p class=\"text-sm text-base-content/70 mb-3\">All link relations currently registered in this running application, via <code class=\"text-xs bg-base-200 px-1 rounded\">hypermedia.AllLinks()</code>.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<p class=\"text-sm text-base-content/70 mb-3\">All link relations currently registered in this running application, via <code class=\"text-xs bg-base-200 px-1 rounded\">linkwell.AllLinks()</code>.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -359,7 +359,7 @@ func LinksRegistryTable(data LinksPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, src := range hypermedia.SortedPaths(data.Links) {
+		for _, src := range linkwell.SortedPaths(data.Links) {
 			for i, link := range data.Links[src] {
 				var templ_7745c5c3_Var17 = []any{templ.KV("border-t border-base-300", i == 0)}
 				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var17...)

--- a/web/views/hypermedia_lists.templ
+++ b/web/views/hypermedia_lists.templ
@@ -4,7 +4,7 @@ package views
 import (
 	"strconv"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -16,7 +16,7 @@ type ListsDemoItem struct {
 }
 
 // ListsPage is a static showcase of list/pagination/filter/sort patterns.
-templ ListsPage(items []ListsDemoItem, info hypermedia.PageInfo) {
+templ ListsPage(items []ListsDemoItem, info linkwell.PageInfo) {
 	<div class="p-4 space-y-6 max-w-4xl mx-auto">
 		<div class="flex items-center justify-between mb-4">
 			<h1 class="text-2xl font-bold">List Patterns</h1>
@@ -27,32 +27,32 @@ templ ListsPage(items []ListsDemoItem, info hypermedia.PageInfo) {
 		</div>
 		@listsSection("Search") {
 			<p class="text-sm text-base-content/70 mb-3">A search input with <code class="text-xs bg-base-200 px-1 rounded">hx-trigger="input changed delay:400ms"</code> debounces keystrokes and replaces the table fragment.</p>
-			@components.FilterBar(hypermedia.NewFilterBar("/demo/inventory/items", "#inventory-table-container",
-				hypermedia.SearchField("q", "Search items…", ""),
+			@components.FilterBar(linkwell.NewFilterBar("/demo/inventory/items", "#inventory-table-container",
+				linkwell.SearchField("q", "Search items…", ""),
 			))
 		}
 		@listsSection("Filter") {
 			<p class="text-sm text-base-content/70 mb-3">Dropdown + checkbox filters submit via <code class="text-xs bg-base-200 px-1 rounded">hx-get</code> on change, replacing only the table container.</p>
-			@components.FilterBar(hypermedia.NewFilterBar("/demo/inventory/items", "#inventory-table-container",
-				hypermedia.SelectField("category", "Category", "",
-					hypermedia.SelectOptions("",
+			@components.FilterBar(linkwell.NewFilterBar("/demo/inventory/items", "#inventory-table-container",
+				linkwell.SelectField("category", "Category", "",
+					linkwell.SelectOptions("",
 						"", "All",
 						"Electronics", "Electronics",
 						"Clothing", "Clothing",
 						"Food", "Food",
 					)),
-				hypermedia.CheckboxField("active", "Active only", ""),
-				hypermedia.RangeField("price", "Max Price", "500", "0", "1000", "10"),
+				linkwell.CheckboxField("active", "Active only", ""),
+				linkwell.RangeField("price", "Max Price", "500", "0", "1000", "10"),
 			))
 		}
 		@listsSection("Sort Columns") {
 			<p class="text-sm text-base-content/70 mb-3">Column headers are links that append <code class="text-xs bg-base-200 px-1 rounded">?sort=col&dir=asc/desc</code> and toggle direction on re-click.</p>
 			<div class="overflow-x-auto">
 				<table class="table table-sm">
-					@components.TableHeader([]hypermedia.TableCol{
-						hypermedia.SortableCol("name", "Name", "name", "asc", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
-						hypermedia.SortableCol("category", "Category", "name", "asc", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
-						hypermedia.SortableCol("price", "Price", "", "", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
+					@components.TableHeader([]linkwell.TableCol{
+						linkwell.SortableCol("name", "Name", "name", "asc", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
+						linkwell.SortableCol("category", "Category", "name", "asc", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
+						linkwell.SortableCol("price", "Price", "", "", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
 						{Label: "Actions"},
 					})
 					<tbody>
@@ -85,7 +85,7 @@ templ listsSection(title string) {
 
 // ListsDemoTable renders the pagination demo table body + pagination bar.
 // Returned as a fragment for HTMX partial replacement.
-templ ListsDemoTable(items []ListsDemoItem, info hypermedia.PageInfo) {
+templ ListsDemoTable(items []ListsDemoItem, info linkwell.PageInfo) {
 	<div id="lists-table-container">
 		<div class="overflow-x-auto">
 			<table class="table table-zebra table-sm w-full">

--- a/web/views/hypermedia_lists_templ.go
+++ b/web/views/hypermedia_lists_templ.go
@@ -13,7 +13,7 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	"strconv"
 
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -25,7 +25,7 @@ type ListsDemoItem struct {
 }
 
 // ListsPage is a static showcase of list/pagination/filter/sort patterns.
-func ListsPage(items []ListsDemoItem, info hypermedia.PageInfo) templ.Component {
+func ListsPage(items []ListsDemoItem, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -79,8 +79,8 @@ func ListsPage(items []ListsDemoItem, info hypermedia.PageInfo) templ.Component 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.FilterBar(hypermedia.NewFilterBar("/demo/inventory/items", "#inventory-table-container",
-				hypermedia.SearchField("q", "Search items…", ""),
+			templ_7745c5c3_Err = components.FilterBar(linkwell.NewFilterBar("/demo/inventory/items", "#inventory-table-container",
+				linkwell.SearchField("q", "Search items…", ""),
 			)).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -107,16 +107,16 @@ func ListsPage(items []ListsDemoItem, info hypermedia.PageInfo) templ.Component 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.FilterBar(hypermedia.NewFilterBar("/demo/inventory/items", "#inventory-table-container",
-				hypermedia.SelectField("category", "Category", "",
-					hypermedia.SelectOptions("",
+			templ_7745c5c3_Err = components.FilterBar(linkwell.NewFilterBar("/demo/inventory/items", "#inventory-table-container",
+				linkwell.SelectField("category", "Category", "",
+					linkwell.SelectOptions("",
 						"", "All",
 						"Electronics", "Electronics",
 						"Clothing", "Clothing",
 						"Food", "Food",
 					)),
-				hypermedia.CheckboxField("active", "Active only", ""),
-				hypermedia.RangeField("price", "Max Price", "500", "0", "1000", "10"),
+				linkwell.CheckboxField("active", "Active only", ""),
+				linkwell.RangeField("price", "Max Price", "500", "0", "1000", "10"),
 			)).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -143,10 +143,10 @@ func ListsPage(items []ListsDemoItem, info hypermedia.PageInfo) templ.Component 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = components.TableHeader([]hypermedia.TableCol{
-				hypermedia.SortableCol("name", "Name", "name", "asc", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
-				hypermedia.SortableCol("category", "Category", "name", "asc", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
-				hypermedia.SortableCol("price", "Price", "", "", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
+			templ_7745c5c3_Err = components.TableHeader([]linkwell.TableCol{
+				linkwell.SortableCol("name", "Name", "name", "asc", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
+				linkwell.SortableCol("category", "Category", "name", "asc", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
+				linkwell.SortableCol("price", "Price", "", "", "/demo/inventory/items", "#inventory-table-container", "#filter-form"),
 				{Label: "Actions"},
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
@@ -268,7 +268,7 @@ func listsSection(title string) templ.Component {
 
 // ListsDemoTable renders the pagination demo table body + pagination bar.
 // Returned as a fragment for HTMX partial replacement.
-func ListsDemoTable(items []ListsDemoItem, info hypermedia.PageInfo) templ.Component {
+func ListsDemoTable(items []ListsDemoItem, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/hypermedia_realtime.templ
+++ b/web/views/hypermedia_realtime.templ
@@ -2,12 +2,12 @@
 package views
 
 import (
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"fmt"
 )
 
 // RealtimePage is the full-page layout for /hypermedia/realtime.
-templ RealtimePage(initial ssebroker.SystemStats, snap MetricsSnapshot, services []ServiceStatus, svcLatencies []ServiceLatency) {
+templ RealtimePage(initial tavern.SystemStats, snap MetricsSnapshot, services []ServiceStatus, svcLatencies []ServiceLatency) {
 	<link rel="stylesheet" href="/public/css/charts.min.css"/>
 	<style>
 		/* Charts.css transition smoothing */
@@ -383,7 +383,7 @@ templ oobServicesChart(services []ServiceStatus) {
 
 // --- Dashboard System Stats (compact 6-card subset) ---
 
-templ dashboardSystemStats(s ssebroker.SystemStats) {
+templ dashboardSystemStats(s tavern.SystemStats) {
 	<div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
 		@statsCard("stat-uptime", "Uptime", s.Uptime)
 		@statsCard("stat-goroutines", "Goroutines", fmt.Sprintf("%d", s.Goroutines))
@@ -413,7 +413,7 @@ templ oobEventItem(evt DashboardEvent) {
 // --- OOB Composites (rendered server-side, sent via SSE) ---
 
 // MetricsOOB emits KPI cards + all metrics charts + dashboard system stats via OOB swaps.
-templ MetricsOOB(snap MetricsSnapshot, stats ssebroker.SystemStats) {
+templ MetricsOOB(snap MetricsSnapshot, stats tavern.SystemStats) {
 	@oobKpiCard("kpi-rps", "Requests/s", fmtRPS(snap.RPS), "text-primary")
 	@oobKpiCard("kpi-errors", "Error Rate", fmtPct(snap.ErrorPct), "text-error")
 	@oobKpiCard("kpi-latency", "P99 Latency", fmtMs(snap.P99Ms), "text-warning")
@@ -447,7 +447,7 @@ templ EventOOB(evt DashboardEvent) {
 
 // SystemStatsOOB renders all stat cards with hx-swap-oob for SSE per-card updates.
 // Also emits the goroutines KPI card for the dashboard.
-templ SystemStatsOOB(s ssebroker.SystemStats) {
+templ SystemStatsOOB(s tavern.SystemStats) {
 	for _, e := range statsEntries(s) {
 		@oobStatsCard(e.ID, e.Label, e.Value)
 	}

--- a/web/views/hypermedia_realtime_templ.go
+++ b/web/views/hypermedia_realtime_templ.go
@@ -11,12 +11,12 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 	"fmt"
 )
 
 // RealtimePage is the full-page layout for /hypermedia/realtime.
-func RealtimePage(initial ssebroker.SystemStats, snap MetricsSnapshot, services []ServiceStatus, svcLatencies []ServiceLatency) templ.Component {
+func RealtimePage(initial tavern.SystemStats, snap MetricsSnapshot, services []ServiceStatus, svcLatencies []ServiceLatency) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -1080,7 +1080,7 @@ func oobServicesChart(services []ServiceStatus) templ.Component {
 }
 
 // --- Dashboard System Stats (compact 6-card subset) ---
-func dashboardSystemStats(s ssebroker.SystemStats) templ.Component {
+func dashboardSystemStats(s tavern.SystemStats) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -1244,7 +1244,7 @@ func oobEventItem(evt DashboardEvent) templ.Component {
 // --- OOB Composites (rendered server-side, sent via SSE) ---
 
 // MetricsOOB emits KPI cards + all metrics charts + dashboard system stats via OOB swaps.
-func MetricsOOB(snap MetricsSnapshot, stats ssebroker.SystemStats) templ.Component {
+func MetricsOOB(snap MetricsSnapshot, stats tavern.SystemStats) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -1407,7 +1407,7 @@ func EventOOB(evt DashboardEvent) templ.Component {
 
 // SystemStatsOOB renders all stat cards with hx-swap-oob for SSE per-card updates.
 // Also emits the goroutines KPI card for the dashboard.
-func SystemStatsOOB(s ssebroker.SystemStats) templ.Component {
+func SystemStatsOOB(s tavern.SystemStats) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -1,12 +1,12 @@
 package views
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // Root template
-templ Index(layoutContent templ.Component, menuContent templ.Component, csrfToken string, devMode bool, theme string, crumbs []hypermedia.Breadcrumb, links []hypermedia.LinkRelation, currentPath string, version string, appName string, hubs []hypermedia.HubEntry) {
+templ Index(layoutContent templ.Component, menuContent templ.Component, csrfToken string, devMode bool, theme string, crumbs []linkwell.Breadcrumb, links []linkwell.LinkRelation, currentPath string, version string, appName string, hubs []linkwell.HubEntry) {
 	<!DOCTYPE html>
 	<html lang="en" data-theme={ theme }>
 		@header(csrfToken, devMode, appName, nil)

--- a/web/views/index_templ.go
+++ b/web/views/index_templ.go
@@ -9,12 +9,12 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // Root template
-func Index(layoutContent templ.Component, menuContent templ.Component, csrfToken string, devMode bool, theme string, crumbs []hypermedia.Breadcrumb, links []hypermedia.LinkRelation, currentPath string, version string, appName string, hubs []hypermedia.HubEntry) templ.Component {
+func Index(layoutContent templ.Component, menuContent templ.Component, csrfToken string, devMode bool, theme string, crumbs []linkwell.Breadcrumb, links []linkwell.LinkRelation, currentPath string, version string, appName string, hubs []linkwell.HubEntry) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/inventory.templ
+++ b/web/views/inventory.templ
@@ -6,24 +6,24 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // InventoryPage is the full page content for /demo/inventory.
 // The FilterBar lives outside the table container so it is never replaced by HTMX swaps.
-templ InventoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
+templ InventoryPage(bar linkwell.FilterBar, tableContainer templ.Component) {
 	<div class="p-4 space-y-4">
 		<div class="flex items-center justify-between">
 			<h1 class="text-2xl font-bold">📦 Items Inventory</h1>
 			<div class="flex items-center gap-2">
-				@components.Controls([]hypermedia.Control{
+				@components.Controls([]linkwell.Control{
 					{
-						Kind:    hypermedia.ControlKindHTMX,
+						Kind:    linkwell.ControlKindHTMX,
 						Label:   "+ Add Item",
-						Variant: hypermedia.VariantPrimary,
-						Swap:    hypermedia.SwapOuterHTML,
-						HxRequest: hypermedia.HxGet("/demo/inventory/items/new", "#new-item-row"),
+						Variant: linkwell.VariantPrimary,
+						Swap:    linkwell.SwapOuterHTML,
+						HxRequest: linkwell.HxGet("/demo/inventory/items/new", "#new-item-row"),
 					},
 				})
 				<a href="/hypermedia/controls" class="btn btn-sm btn-ghost">Hypermedia Controls →</a>
@@ -35,7 +35,7 @@ templ InventoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
 }
 
 // InventoryTableContainer is the replaceable fragment targeted by filter/sort/page HTMX requests.
-templ InventoryTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) {
+templ InventoryTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) {
 	<div id="inventory-table-container">
 		@components.Table(cols, body, info)
 	</div>
@@ -70,7 +70,7 @@ templ InventoryItemRow(item demo.Item) {
 			}
 		</td>
 		<td>
-			@components.Controls(hypermedia.TableRowActions(hypermedia.TableRowActionCfg{
+			@components.Controls(linkwell.TableRowActions(linkwell.TableRowActionCfg{
 				EditURL:     editURL,
 				DeleteURL:   deleteURL,
 				RowTarget:   rowTarget,
@@ -95,7 +95,7 @@ templ InventoryDetailPage(item demo.Item) {
 			<div class="card-body">
 				<div class="flex items-center justify-between">
 					<h2 class="card-title text-2xl">{ item.Name }</h2>
-					@components.Controls(hypermedia.ResourceActions(hypermedia.ResourceActionCfg{
+					@components.Controls(linkwell.ResourceActions(linkwell.ResourceActionCfg{
 						EditURL:    editURL,
 						DeleteURL:  deleteURL,
 						ConfirmMsg: "Delete this item?",
@@ -138,10 +138,10 @@ templ InventoryDetailPage(item demo.Item) {
 // saveURL and cancelURL are fully-built by the handler (may include filter query params).
 templ InventoryEditRow(item demo.Item, isNew bool, saveURL, cancelURL string) {
 	{{ var rowID string }}
-	{{ var controls []hypermedia.Control }}
+	{{ var controls []linkwell.Control }}
 	if isNew {
 		{{ rowID = "new-item-row" }}
-		{{ controls = hypermedia.NewRowFormActions(hypermedia.RowFormActionCfg{
+		{{ controls = linkwell.NewRowFormActions(linkwell.RowFormActionCfg{
 			SaveURL:      saveURL,
 			CancelURL:    cancelURL,
 			SaveTarget:   "#inventory-table-container",
@@ -149,7 +149,7 @@ templ InventoryEditRow(item demo.Item, isNew bool, saveURL, cancelURL string) {
 		}) }}
 	} else {
 		{{ rowID = fmt.Sprintf("item-row-%d", item.ID) }}
-		{{ controls = hypermedia.RowFormActions(hypermedia.RowFormActionCfg{
+		{{ controls = linkwell.RowFormActions(linkwell.RowFormActionCfg{
 			SaveURL:      saveURL,
 			CancelURL:    cancelURL,
 			SaveTarget:   "#inventory-table-container",

--- a/web/views/inventory_templ.go
+++ b/web/views/inventory_templ.go
@@ -15,13 +15,13 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // InventoryPage is the full page content for /demo/inventory.
 // The FilterBar lives outside the table container so it is never replaced by HTMX swaps.
-func InventoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ.Component {
+func InventoryPage(bar linkwell.FilterBar, tableContainer templ.Component) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -46,13 +46,13 @@ func InventoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) tem
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+		templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 			{
-				Kind:      hypermedia.ControlKindHTMX,
+				Kind:      linkwell.ControlKindHTMX,
 				Label:     "+ Add Item",
-				Variant:   hypermedia.VariantPrimary,
-				Swap:      hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxGet("/demo/inventory/items/new", "#new-item-row"),
+				Variant:   linkwell.VariantPrimary,
+				Swap:      linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxGet("/demo/inventory/items/new", "#new-item-row"),
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -79,7 +79,7 @@ func InventoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) tem
 }
 
 // InventoryTableContainer is the replaceable fragment targeted by filter/sort/page HTMX requests.
-func InventoryTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) templ.Component {
+func InventoryTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -279,7 +279,7 @@ func InventoryItemRow(item demo.Item) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls(hypermedia.TableRowActions(hypermedia.TableRowActionCfg{
+		templ_7745c5c3_Err = components.Controls(linkwell.TableRowActions(linkwell.TableRowActionCfg{
 			EditURL:     editURL,
 			DeleteURL:   deleteURL,
 			RowTarget:   rowTarget,
@@ -368,7 +368,7 @@ func InventoryDetailPage(item demo.Item) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls(hypermedia.ResourceActions(hypermedia.ResourceActionCfg{
+		templ_7745c5c3_Err = components.Controls(linkwell.ResourceActions(linkwell.ResourceActionCfg{
 			EditURL:    editURL,
 			DeleteURL:  deleteURL,
 			ConfirmMsg: "Delete this item?",
@@ -477,10 +477,10 @@ func InventoryEditRow(item demo.Item, isNew bool, saveURL, cancelURL string) tem
 		}
 		ctx = templ.ClearChildren(ctx)
 		var rowID string
-		var controls []hypermedia.Control
+		var controls []linkwell.Control
 		if isNew {
 			rowID = "new-item-row"
-			controls = hypermedia.NewRowFormActions(hypermedia.RowFormActionCfg{
+			controls = linkwell.NewRowFormActions(linkwell.RowFormActionCfg{
 				SaveURL:      saveURL,
 				CancelURL:    cancelURL,
 				SaveTarget:   "#inventory-table-container",
@@ -488,7 +488,7 @@ func InventoryEditRow(item demo.Item, isNew bool, saveURL, cancelURL string) tem
 			})
 		} else {
 			rowID = fmt.Sprintf("item-row-%d", item.ID)
-			controls = hypermedia.RowFormActions(hypermedia.RowFormActionCfg{
+			controls = linkwell.RowFormActions(linkwell.RowFormActionCfg{
 				SaveURL:      saveURL,
 				CancelURL:    cancelURL,
 				SaveTarget:   "#inventory-table-container",

--- a/web/views/kanban.templ
+++ b/web/views/kanban.templ
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -96,14 +96,14 @@ templ kanbanMoveButtons(t demo.KanbanTask) {
 	{{ taskURL := fmt.Sprintf("/demo/kanban/tasks/%d", t.ID) }}
 	if statusIdx > 0 {
 		{{ prevStatus := demo.KanbanStatuses[statusIdx-1] }}
-		@components.Controls([]hypermedia.Control{
+		@components.Controls([]linkwell.Control{
 			{
-				Kind:    hypermedia.ControlKindHTMX,
+				Kind:    linkwell.ControlKindHTMX,
 				Label:   "\u2190 " + kanbanStatusLabels[prevStatus],
-				Variant: hypermedia.VariantGhost,
-				Swap:    hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxRequestConfig{
-					Method: hypermedia.HxMethodPatch,
+				Variant: linkwell.VariantGhost,
+				Swap:    linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxRequestConfig{
+					Method: linkwell.HxMethodPatch,
 					URL:    taskURL,
 					Target: "#kanban-board",
 					Vals:   `{"status":"` + prevStatus + `"}`,
@@ -113,14 +113,14 @@ templ kanbanMoveButtons(t demo.KanbanTask) {
 	}
 	if statusIdx < len(demo.KanbanStatuses)-1 {
 		{{ nextStatus := demo.KanbanStatuses[statusIdx+1] }}
-		@components.Controls([]hypermedia.Control{
+		@components.Controls([]linkwell.Control{
 			{
-				Kind:    hypermedia.ControlKindHTMX,
+				Kind:    linkwell.ControlKindHTMX,
 				Label:   kanbanStatusLabels[nextStatus] + " \u2192",
-				Variant: hypermedia.VariantGhost,
-				Swap:    hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxRequestConfig{
-					Method: hypermedia.HxMethodPatch,
+				Variant: linkwell.VariantGhost,
+				Swap:    linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxRequestConfig{
+					Method: linkwell.HxMethodPatch,
 					URL:    taskURL,
 					Target: "#kanban-board",
 					Vals:   `{"status":"` + nextStatus + `"}`,

--- a/web/views/kanban_templ.go
+++ b/web/views/kanban_templ.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
@@ -334,14 +334,14 @@ func kanbanMoveButtons(t demo.KanbanTask) templ.Component {
 		taskURL := fmt.Sprintf("/demo/kanban/tasks/%d", t.ID)
 		if statusIdx > 0 {
 			prevStatus := demo.KanbanStatuses[statusIdx-1]
-			templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+			templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 				{
-					Kind:    hypermedia.ControlKindHTMX,
+					Kind:    linkwell.ControlKindHTMX,
 					Label:   "\u2190 " + kanbanStatusLabels[prevStatus],
-					Variant: hypermedia.VariantGhost,
-					Swap:    hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxRequestConfig{
-						Method: hypermedia.HxMethodPatch,
+					Variant: linkwell.VariantGhost,
+					Swap:    linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxRequestConfig{
+						Method: linkwell.HxMethodPatch,
 						URL:    taskURL,
 						Target: "#kanban-board",
 						Vals:   `{"status":"` + prevStatus + `"}`,
@@ -354,14 +354,14 @@ func kanbanMoveButtons(t demo.KanbanTask) templ.Component {
 		}
 		if statusIdx < len(demo.KanbanStatuses)-1 {
 			nextStatus := demo.KanbanStatuses[statusIdx+1]
-			templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+			templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 				{
-					Kind:    hypermedia.ControlKindHTMX,
+					Kind:    linkwell.ControlKindHTMX,
 					Label:   kanbanStatusLabels[nextStatus] + " \u2192",
-					Variant: hypermedia.VariantGhost,
-					Swap:    hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxRequestConfig{
-						Method: hypermedia.HxMethodPatch,
+					Variant: linkwell.VariantGhost,
+					Swap:    linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxRequestConfig{
+						Method: linkwell.HxMethodPatch,
 						URL:    taskURL,
 						Target: "#kanban-board",
 						Vals:   `{"status":"` + nextStatus + `"}`,

--- a/web/views/people.templ
+++ b/web/views/people.templ
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
-templ PeoplePage(people []demo.Person, total int, bar hypermedia.FilterBar, cols []hypermedia.TableCol, info hypermedia.PageInfo, from string) {
+templ PeoplePage(people []demo.Person, total int, bar linkwell.FilterBar, cols []linkwell.TableCol, info linkwell.PageInfo, from string) {
 	<div class="p-4 space-y-4">
 		<div class="flex items-center justify-between">
 			<h1 class="text-2xl font-bold">People Directory</h1>
@@ -21,7 +21,7 @@ templ PeoplePage(people []demo.Person, total int, bar hypermedia.FilterBar, cols
 	</div>
 }
 
-templ PeopleTableContainer(cols []hypermedia.TableCol, people []demo.Person, info hypermedia.PageInfo, from string) {
+templ PeopleTableContainer(cols []linkwell.TableCol, people []demo.Person, info linkwell.PageInfo, from string) {
 	<div id="people-table-container">
 		@components.Table(cols, PeopleTableBody(people, from), info)
 	</div>
@@ -36,7 +36,7 @@ templ PeopleTableBody(people []demo.Person, from string) {
 }
 
 templ PersonRow(p demo.Person, from string) {
-	{{ profileURL := hypermedia.FromNav(fmt.Sprintf("/demo/people/%d", p.ID), from) }}
+	{{ profileURL := linkwell.FromNav(fmt.Sprintf("/demo/people/%d", p.ID), from) }}
 	<tr class="hover:bg-base-200/50 cursor-pointer" hx-get={ profileURL } hx-target="body" hx-push-url="true">
 		<td class="font-medium">{ p.FullName() }</td>
 		<td>{ p.Department }</td>
@@ -61,14 +61,14 @@ templ PersonProfileCard(p demo.Person) {
 		<div class="card-body">
 			<div class="flex items-center justify-between">
 				<h2 class="card-title text-2xl">{ p.FullName() }</h2>
-				@components.Controls([]hypermedia.Control{
+				@components.Controls([]linkwell.Control{
 					{
-						Kind:    hypermedia.ControlKindHTMX,
+						Kind:    linkwell.ControlKindHTMX,
 						Label:   "Edit",
-						Variant: hypermedia.VariantSecondary,
-						Icon:    hypermedia.IconPencilSquare,
-						Swap:    hypermedia.SwapOuterHTML,
-						HxRequest: hypermedia.HxGet(editURL, "#person-profile-card"),
+						Variant: linkwell.VariantSecondary,
+						Icon:    linkwell.IconPencilSquare,
+						Swap:    linkwell.SwapOuterHTML,
+						HxRequest: linkwell.HxGet(editURL, "#person-profile-card"),
 					},
 				})
 			</div>
@@ -153,27 +153,27 @@ templ PersonEditForm(p demo.Person) {
 					<textarea name="bio" class="textarea w-full" rows="3">{ p.Bio }</textarea>
 				</div>
 				<div class="card-actions mt-4">
-					@components.Controls([]hypermedia.Control{
+					@components.Controls([]linkwell.Control{
 						{
-							Kind:    hypermedia.ControlKindHTMX,
+							Kind:    linkwell.ControlKindHTMX,
 							Label:   "Save",
-							Variant: hypermedia.VariantPrimary,
-							Icon:    hypermedia.IconCheck,
-							Swap:    hypermedia.SwapOuterHTML,
-							HxRequest: hypermedia.HxRequestConfig{
-								Method:  hypermedia.HxMethodPut,
+							Variant: linkwell.VariantPrimary,
+							Icon:    linkwell.IconCheck,
+							Swap:    linkwell.SwapOuterHTML,
+							HxRequest: linkwell.HxRequestConfig{
+								Method:  linkwell.HxMethodPut,
 								URL:     saveURL,
 								Target:  "#person-profile-card",
 								Include: "#person-profile-card",
 							},
 						},
 						{
-							Kind:    hypermedia.ControlKindHTMX,
+							Kind:    linkwell.ControlKindHTMX,
 							Label:   "Cancel",
-							Variant: hypermedia.VariantGhost,
-							Icon:    hypermedia.IconXMark,
-							Swap:    hypermedia.SwapOuterHTML,
-							HxRequest: hypermedia.HxGet(cancelURL, "#person-profile-card"),
+							Variant: linkwell.VariantGhost,
+							Icon:    linkwell.IconXMark,
+							Swap:    linkwell.SwapOuterHTML,
+							HxRequest: linkwell.HxGet(cancelURL, "#person-profile-card"),
 						},
 					})
 				</div>

--- a/web/views/people_templ.go
+++ b/web/views/people_templ.go
@@ -14,11 +14,11 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
-func PeoplePage(people []demo.Person, total int, bar hypermedia.FilterBar, cols []hypermedia.TableCol, info hypermedia.PageInfo, from string) templ.Component {
+func PeoplePage(people []demo.Person, total int, bar linkwell.FilterBar, cols []linkwell.TableCol, info linkwell.PageInfo, from string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -63,7 +63,7 @@ func PeoplePage(people []demo.Person, total int, bar hypermedia.FilterBar, cols 
 	})
 }
 
-func PeopleTableContainer(cols []hypermedia.TableCol, people []demo.Person, info hypermedia.PageInfo, from string) templ.Component {
+func PeopleTableContainer(cols []linkwell.TableCol, people []demo.Person, info linkwell.PageInfo, from string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -160,7 +160,7 @@ func PersonRow(p demo.Person, from string) templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		profileURL := hypermedia.FromNav(fmt.Sprintf("/demo/people/%d", p.ID), from)
+		profileURL := linkwell.FromNav(fmt.Sprintf("/demo/people/%d", p.ID), from)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<tr class=\"hover:bg-base-200/50 cursor-pointer\" hx-get=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -349,14 +349,14 @@ func PersonProfileCard(p demo.Person) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+		templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 			{
-				Kind:      hypermedia.ControlKindHTMX,
+				Kind:      linkwell.ControlKindHTMX,
 				Label:     "Edit",
-				Variant:   hypermedia.VariantSecondary,
-				Icon:      hypermedia.IconPencilSquare,
-				Swap:      hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxGet(editURL, "#person-profile-card"),
+				Variant:   linkwell.VariantSecondary,
+				Icon:      linkwell.IconPencilSquare,
+				Swap:      linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxGet(editURL, "#person-profile-card"),
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -661,27 +661,27 @@ func PersonEditForm(p demo.Person) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+		templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 			{
-				Kind:    hypermedia.ControlKindHTMX,
+				Kind:    linkwell.ControlKindHTMX,
 				Label:   "Save",
-				Variant: hypermedia.VariantPrimary,
-				Icon:    hypermedia.IconCheck,
-				Swap:    hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxRequestConfig{
-					Method:  hypermedia.HxMethodPut,
+				Variant: linkwell.VariantPrimary,
+				Icon:    linkwell.IconCheck,
+				Swap:    linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxRequestConfig{
+					Method:  linkwell.HxMethodPut,
 					URL:     saveURL,
 					Target:  "#person-profile-card",
 					Include: "#person-profile-card",
 				},
 			},
 			{
-				Kind:      hypermedia.ControlKindHTMX,
+				Kind:      linkwell.ControlKindHTMX,
 				Label:     "Cancel",
-				Variant:   hypermedia.VariantGhost,
-				Icon:      hypermedia.IconXMark,
-				Swap:      hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxGet(cancelURL, "#person-profile-card"),
+				Variant:   linkwell.VariantGhost,
+				Icon:      linkwell.IconXMark,
+				Swap:      linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxGet(cancelURL, "#person-profile-card"),
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {

--- a/web/views/realtime.go
+++ b/web/views/realtime.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"time"
 
-	ssebroker "github.com/catgoose/tavern"
+	"github.com/catgoose/tavern"
 )
 
 // --- Dashboard data types ---
@@ -233,7 +233,7 @@ type statsEntry struct {
 	Section string
 }
 
-func statsEntries(s ssebroker.SystemStats) []statsEntry {
+func statsEntries(s tavern.SystemStats) []statsEntry {
 	return []statsEntry{
 		// Runtime
 		{"stat-uptime", "Uptime", s.Uptime, "Runtime"},

--- a/web/views/repository.templ
+++ b/web/views/repository.templ
@@ -6,12 +6,12 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // RepositoryPage is the full page for /demo/repository.
-templ RepositoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
+templ RepositoryPage(bar linkwell.FilterBar, tableContainer templ.Component) {
 	<div class="p-4 space-y-4">
 		<div class="flex items-center justify-between">
 			<div>
@@ -21,13 +21,13 @@ templ RepositoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
 				</p>
 			</div>
 			<div class="flex items-center gap-2">
-				@components.Controls([]hypermedia.Control{
+				@components.Controls([]linkwell.Control{
 					{
-						Kind:    hypermedia.ControlKindHTMX,
+						Kind:    linkwell.ControlKindHTMX,
 						Label:   "+ New Task",
-						Variant: hypermedia.VariantPrimary,
-						Swap:    hypermedia.SwapOuterHTML,
-						HxRequest: hypermedia.HxGet("/demo/repository/tasks/new", "#new-task-row"),
+						Variant: linkwell.VariantPrimary,
+						Swap:    linkwell.SwapOuterHTML,
+						HxRequest: linkwell.HxGet("/demo/repository/tasks/new", "#new-task-row"),
 					},
 				})
 			</div>
@@ -56,7 +56,7 @@ templ RepositoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) {
 }
 
 // RepositoryTableContainer is the replaceable fragment targeted by HTMX.
-templ RepositoryTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) {
+templ RepositoryTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) {
 	<div id="repo-table-container">
 		@components.Table(cols, body, info)
 	</div>
@@ -118,46 +118,46 @@ templ RepositoryTaskRow(task demo.Task) {
 		<td>
 			<div class="flex gap-1">
 				if task.DeletedAt.Valid {
-					@components.Controls([]hypermedia.Control{
+					@components.Controls([]linkwell.Control{
 						{
-							Kind: hypermedia.ControlKindHTMX, Label: "Restore", Variant: hypermedia.VariantPrimary,
-							Swap: hypermedia.SwapOuterHTML,
-							HxRequest: hypermedia.HxRequestConfig{
-								Method: hypermedia.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
+							Kind: linkwell.ControlKindHTMX, Label: "Restore", Variant: linkwell.VariantPrimary,
+							Swap: linkwell.SwapOuterHTML,
+							HxRequest: linkwell.HxRequestConfig{
+								Method: linkwell.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
 								Vals: `{"action":"restore"}`,
 							},
 						},
 					})
 				} else if task.ArchivedAt.Valid {
-					@components.Controls([]hypermedia.Control{
+					@components.Controls([]linkwell.Control{
 						{
-							Kind: hypermedia.ControlKindHTMX, Label: "Unarchive", Variant: hypermedia.VariantSecondary,
-							Swap: hypermedia.SwapOuterHTML,
-							HxRequest: hypermedia.HxRequestConfig{
-								Method: hypermedia.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
+							Kind: linkwell.ControlKindHTMX, Label: "Unarchive", Variant: linkwell.VariantSecondary,
+							Swap: linkwell.SwapOuterHTML,
+							HxRequest: linkwell.HxRequestConfig{
+								Method: linkwell.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
 								Vals: `{"action":"unarchive"}`,
 							},
 						},
 					})
 				} else {
-					@components.Controls([]hypermedia.Control{
+					@components.Controls([]linkwell.Control{
 						{
-							Kind: hypermedia.ControlKindHTMX, Label: "Edit", Variant: hypermedia.VariantGhost,
-							Swap: hypermedia.SwapOuterHTML,
-							HxRequest: hypermedia.HxGet(editURL, rowTarget),
+							Kind: linkwell.ControlKindHTMX, Label: "Edit", Variant: linkwell.VariantGhost,
+							Swap: linkwell.SwapOuterHTML,
+							HxRequest: linkwell.HxGet(editURL, rowTarget),
 						},
 						{
-							Kind: hypermedia.ControlKindHTMX, Label: "Archive", Variant: hypermedia.VariantSecondary,
-							Swap: hypermedia.SwapOuterHTML,
-							HxRequest: hypermedia.HxRequestConfig{
-								Method: hypermedia.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
+							Kind: linkwell.ControlKindHTMX, Label: "Archive", Variant: linkwell.VariantSecondary,
+							Swap: linkwell.SwapOuterHTML,
+							HxRequest: linkwell.HxRequestConfig{
+								Method: linkwell.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
 								Vals: `{"action":"archive"}`,
 							},
 						},
 						{
-							Kind: hypermedia.ControlKindHTMX, Label: "Delete", Variant: hypermedia.VariantDanger,
-							Swap: hypermedia.SwapOuterHTML, Confirm: "Soft-delete this task?",
-							HxRequest: hypermedia.HxDelete(deleteURL, "#repo-table-container"),
+							Kind: linkwell.ControlKindHTMX, Label: "Delete", Variant: linkwell.VariantDanger,
+							Swap: linkwell.SwapOuterHTML, Confirm: "Soft-delete this task?",
+							HxRequest: linkwell.HxDelete(deleteURL, "#repo-table-container"),
 						},
 					})
 				}
@@ -174,10 +174,10 @@ templ NewTaskPlaceholder() {
 // RepositoryEditRow renders an inline edit form row.
 templ RepositoryEditRow(task demo.Task, isNew bool, saveURL, cancelURL string) {
 	{{ var rowID string }}
-	{{ var controls []hypermedia.Control }}
+	{{ var controls []linkwell.Control }}
 	if isNew {
 		{{ rowID = "new-task-row" }}
-		{{ controls = hypermedia.NewRowFormActions(hypermedia.RowFormActionCfg{
+		{{ controls = linkwell.NewRowFormActions(linkwell.RowFormActionCfg{
 			SaveURL:      saveURL,
 			CancelURL:    cancelURL,
 			SaveTarget:   "#repo-table-container",
@@ -185,7 +185,7 @@ templ RepositoryEditRow(task demo.Task, isNew bool, saveURL, cancelURL string) {
 		}) }}
 	} else {
 		{{ rowID = fmt.Sprintf("task-row-%d", task.ID) }}
-		{{ controls = hypermedia.RowFormActions(hypermedia.RowFormActionCfg{
+		{{ controls = linkwell.RowFormActions(linkwell.RowFormActionCfg{
 			SaveURL:      saveURL,
 			CancelURL:    cancelURL,
 			SaveTarget:   "#repo-table-container",

--- a/web/views/repository_templ.go
+++ b/web/views/repository_templ.go
@@ -15,12 +15,12 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
 // RepositoryPage is the full page for /demo/repository.
-func RepositoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) templ.Component {
+func RepositoryPage(bar linkwell.FilterBar, tableContainer templ.Component) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -45,13 +45,13 @@ func RepositoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) te
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+		templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 			{
-				Kind:      hypermedia.ControlKindHTMX,
+				Kind:      linkwell.ControlKindHTMX,
 				Label:     "+ New Task",
-				Variant:   hypermedia.VariantPrimary,
-				Swap:      hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxGet("/demo/repository/tasks/new", "#new-task-row"),
+				Variant:   linkwell.VariantPrimary,
+				Swap:      linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxGet("/demo/repository/tasks/new", "#new-task-row"),
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -78,7 +78,7 @@ func RepositoryPage(bar hypermedia.FilterBar, tableContainer templ.Component) te
 }
 
 // RepositoryTableContainer is the replaceable fragment targeted by HTMX.
-func RepositoryTableContainer(cols []hypermedia.TableCol, body templ.Component, info hypermedia.PageInfo) templ.Component {
+func RepositoryTableContainer(cols []linkwell.TableCol, body templ.Component, info linkwell.PageInfo) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -327,12 +327,12 @@ func RepositoryTaskRow(task demo.Task) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if task.DeletedAt.Valid {
-			templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+			templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 				{
-					Kind: hypermedia.ControlKindHTMX, Label: "Restore", Variant: hypermedia.VariantPrimary,
-					Swap: hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxRequestConfig{
-						Method: hypermedia.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
+					Kind: linkwell.ControlKindHTMX, Label: "Restore", Variant: linkwell.VariantPrimary,
+					Swap: linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxRequestConfig{
+						Method: linkwell.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
 						Vals: `{"action":"restore"}`,
 					},
 				},
@@ -341,12 +341,12 @@ func RepositoryTaskRow(task demo.Task) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else if task.ArchivedAt.Valid {
-			templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+			templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 				{
-					Kind: hypermedia.ControlKindHTMX, Label: "Unarchive", Variant: hypermedia.VariantSecondary,
-					Swap: hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxRequestConfig{
-						Method: hypermedia.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
+					Kind: linkwell.ControlKindHTMX, Label: "Unarchive", Variant: linkwell.VariantSecondary,
+					Swap: linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxRequestConfig{
+						Method: linkwell.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
 						Vals: `{"action":"unarchive"}`,
 					},
 				},
@@ -355,24 +355,24 @@ func RepositoryTaskRow(task demo.Task) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+			templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 				{
-					Kind: hypermedia.ControlKindHTMX, Label: "Edit", Variant: hypermedia.VariantGhost,
-					Swap:      hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxGet(editURL, rowTarget),
+					Kind: linkwell.ControlKindHTMX, Label: "Edit", Variant: linkwell.VariantGhost,
+					Swap:      linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxGet(editURL, rowTarget),
 				},
 				{
-					Kind: hypermedia.ControlKindHTMX, Label: "Archive", Variant: hypermedia.VariantSecondary,
-					Swap: hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxRequestConfig{
-						Method: hypermedia.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
+					Kind: linkwell.ControlKindHTMX, Label: "Archive", Variant: linkwell.VariantSecondary,
+					Swap: linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxRequestConfig{
+						Method: linkwell.HxMethodPatch, URL: patchURL, Target: "#repo-table-container",
 						Vals: `{"action":"archive"}`,
 					},
 				},
 				{
-					Kind: hypermedia.ControlKindHTMX, Label: "Delete", Variant: hypermedia.VariantDanger,
-					Swap: hypermedia.SwapOuterHTML, Confirm: "Soft-delete this task?",
-					HxRequest: hypermedia.HxDelete(deleteURL, "#repo-table-container"),
+					Kind: linkwell.ControlKindHTMX, Label: "Delete", Variant: linkwell.VariantDanger,
+					Swap: linkwell.SwapOuterHTML, Confirm: "Soft-delete this task?",
+					HxRequest: linkwell.HxDelete(deleteURL, "#repo-table-container"),
 				},
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
@@ -440,10 +440,10 @@ func RepositoryEditRow(task demo.Task, isNew bool, saveURL, cancelURL string) te
 		}
 		ctx = templ.ClearChildren(ctx)
 		var rowID string
-		var controls []hypermedia.Control
+		var controls []linkwell.Control
 		if isNew {
 			rowID = "new-task-row"
-			controls = hypermedia.NewRowFormActions(hypermedia.RowFormActionCfg{
+			controls = linkwell.NewRowFormActions(linkwell.RowFormActionCfg{
 				SaveURL:      saveURL,
 				CancelURL:    cancelURL,
 				SaveTarget:   "#repo-table-container",
@@ -451,7 +451,7 @@ func RepositoryEditRow(task demo.Task, isNew bool, saveURL, cancelURL string) te
 			})
 		} else {
 			rowID = fmt.Sprintf("task-row-%d", task.ID)
-			controls = hypermedia.RowFormActions(hypermedia.RowFormActionCfg{
+			controls = linkwell.RowFormActions(linkwell.RowFormActionCfg{
 				SaveURL:      saveURL,
 				CancelURL:    cancelURL,
 				SaveTarget:   "#repo-table-container",

--- a/web/views/vendors_contacts.templ
+++ b/web/views/vendors_contacts.templ
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
-templ VendorContactsPage(vendors []demo.Vendor, bar hypermedia.FilterBar) {
+templ VendorContactsPage(vendors []demo.Vendor, bar linkwell.FilterBar) {
 	<div class="p-4 space-y-4">
 		<div class="flex items-center justify-between">
 			<h1 class="text-2xl font-bold">Vendor Contacts</h1>
@@ -84,14 +84,14 @@ templ ContactCard(c demo.Contact) {
 				<div class="font-medium text-sm">{ c.Name }</div>
 				<div class="text-xs text-base-content/50">{ c.Role }</div>
 			</div>
-			@components.Controls([]hypermedia.Control{
+			@components.Controls([]linkwell.Control{
 				{
-					Kind:    hypermedia.ControlKindHTMX,
+					Kind:    linkwell.ControlKindHTMX,
 					Label:   "Edit",
-					Variant: hypermedia.VariantGhost,
-					Icon:    hypermedia.IconPencilSquare,
-					Swap:    hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxGet(editURL, "#" + cardID),
+					Variant: linkwell.VariantGhost,
+					Icon:    linkwell.IconPencilSquare,
+					Swap:    linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxGet(editURL, "#" + cardID),
 				},
 			})
 		</div>
@@ -128,27 +128,27 @@ templ ContactEditForm(c demo.Contact) {
 			</div>
 		</div>
 		<div class="flex gap-2 mt-2">
-			@components.Controls([]hypermedia.Control{
+			@components.Controls([]linkwell.Control{
 				{
-					Kind:    hypermedia.ControlKindHTMX,
+					Kind:    linkwell.ControlKindHTMX,
 					Label:   "Save",
-					Variant: hypermedia.VariantPrimary,
-					Icon:    hypermedia.IconCheck,
-					Swap:    hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxRequestConfig{
-						Method:  hypermedia.HxMethodPut,
+					Variant: linkwell.VariantPrimary,
+					Icon:    linkwell.IconCheck,
+					Swap:    linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxRequestConfig{
+						Method:  linkwell.HxMethodPut,
 						URL:     saveURL,
 						Target:  "#" + cardID,
 						Include: "#" + cardID,
 					},
 				},
 				{
-					Kind:    hypermedia.ControlKindHTMX,
+					Kind:    linkwell.ControlKindHTMX,
 					Label:   "Cancel",
-					Variant: hypermedia.VariantGhost,
-					Icon:    hypermedia.IconXMark,
-					Swap:    hypermedia.SwapOuterHTML,
-					HxRequest: hypermedia.HxGet(cancelURL, "#" + cardID),
+					Variant: linkwell.VariantGhost,
+					Icon:    linkwell.IconXMark,
+					Swap:    linkwell.SwapOuterHTML,
+					HxRequest: linkwell.HxGet(cancelURL, "#" + cardID),
 				},
 			})
 		</div>

--- a/web/views/vendors_contacts_templ.go
+++ b/web/views/vendors_contacts_templ.go
@@ -14,11 +14,11 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	hypermedia "github.com/catgoose/linkwell"
+	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
-func VendorContactsPage(vendors []demo.Vendor, bar hypermedia.FilterBar) templ.Component {
+func VendorContactsPage(vendors []demo.Vendor, bar linkwell.FilterBar) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -323,14 +323,14 @@ func ContactCard(c demo.Contact) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+		templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 			{
-				Kind:      hypermedia.ControlKindHTMX,
+				Kind:      linkwell.ControlKindHTMX,
 				Label:     "Edit",
-				Variant:   hypermedia.VariantGhost,
-				Icon:      hypermedia.IconPencilSquare,
-				Swap:      hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxGet(editURL, "#"+cardID),
+				Variant:   linkwell.VariantGhost,
+				Icon:      linkwell.IconPencilSquare,
+				Swap:      linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxGet(editURL, "#"+cardID),
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -473,27 +473,27 @@ func ContactEditForm(c demo.Contact) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.Controls([]hypermedia.Control{
+		templ_7745c5c3_Err = components.Controls([]linkwell.Control{
 			{
-				Kind:    hypermedia.ControlKindHTMX,
+				Kind:    linkwell.ControlKindHTMX,
 				Label:   "Save",
-				Variant: hypermedia.VariantPrimary,
-				Icon:    hypermedia.IconCheck,
-				Swap:    hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxRequestConfig{
-					Method:  hypermedia.HxMethodPut,
+				Variant: linkwell.VariantPrimary,
+				Icon:    linkwell.IconCheck,
+				Swap:    linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxRequestConfig{
+					Method:  linkwell.HxMethodPut,
 					URL:     saveURL,
 					Target:  "#" + cardID,
 					Include: "#" + cardID,
 				},
 			},
 			{
-				Kind:      hypermedia.ControlKindHTMX,
+				Kind:      linkwell.ControlKindHTMX,
 				Label:     "Cancel",
-				Variant:   hypermedia.VariantGhost,
-				Icon:      hypermedia.IconXMark,
-				Swap:      hypermedia.SwapOuterHTML,
-				HxRequest: hypermedia.HxGet(cancelURL, "#"+cardID),
+				Variant:   linkwell.VariantGhost,
+				Icon:      linkwell.IconXMark,
+				Swap:      linkwell.SwapOuterHTML,
+				HxRequest: linkwell.HxGet(cancelURL, "#"+cardID),
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Removed all import aliases that hid extracted library names behind old package names (`ssebroker`, `hypermedia`, `response`, `hx`, `htmxpkg`). All 102 affected files now use direct imports: `tavern`, `linkwell`, `flighty`, `cheddar`.
- Pinned `porter` from pseudo-version `v0.0.0-20260331...` to tagged `v0.2.1`.
- Added missing `setup:feature:demo` guard on `linkwell` import in `routes.go` — this caused build failures when the demo feature was stripped (the import was unguarded but all call sites were inside demo guards).

## What changed

| Old alias | Library | Package name |
|---|---|---|
| `ssebroker` | github.com/catgoose/tavern | `tavern` |
| `hypermedia` | github.com/catgoose/linkwell | `linkwell` |
| `response` | github.com/catgoose/flighty | `flighty` |
| `hx` / `htmxpkg` | github.com/catgoose/cheddar | `cheddar` |

Both `.go` source files and `.templ` / `_templ.go` generated files were updated.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (including setup feature-stripping tests that were previously broken)
- [x] No stale internal imports remain
- [x] No backwards-compat shims, re-exports, or type aliases remain
- [x] All library deps on tagged versions