### PR TITLE
fix: call nodeModulesCheck in Watch before starting tasks

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -458,6 +458,10 @@ func EnvCheck() error {
 
 // Watch runs Tailwind, Templ, Air, and Caddy in watch mode
 func Watch() error {
+	if err := nodeModulesCheck(); err != nil {
+		return err
+	}
+
 	type task struct {
 		name string
 		fn   func() error


### PR DESCRIPTION
Watch() launches TailwindWatch which requires node_modules, but never checks if they're installed. Adds the same nodeModulesCheck() call that Build() already has.

Closes #347