### PR TITLE
fix(e2e): update navbar selector to match app-nav layout

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -35,7 +35,7 @@ test.describe("Home Page", () => {
 
   test("navbar is present", async ({ page }) => {
     await navigateTo(page, "/");
-    await expect(page.locator("nav.navbar")).toBeVisible();
+    await expect(page.locator("nav.app-nav")).toBeVisible();
   });
 
   test("health endpoint returns OK", async ({ request }) => {


### PR DESCRIPTION
## Summary
- The e2e "navbar is present" test looked for `nav.navbar` but `AppNavLayout` renders `<nav class="app-nav">`, causing consistent pipeline failures
- Updated the selector from `nav.navbar` to `nav.app-nav`

Closes #207

## Test plan
- [ ] Pipeline e2e tests pass (the `navbar is present` test should now find the correct element)