### PR TITLE
Replace local status helpers with flighty v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/catgoose/cheddar v0.2.1
 	github.com/catgoose/crooner v1.4.2
 	github.com/catgoose/dio v1.0.26
-	github.com/catgoose/flighty v0.1.1
+	github.com/catgoose/flighty v0.2.0
 	github.com/catgoose/fraggle v0.1.12
 	github.com/catgoose/linkwell v0.1.0
 	github.com/catgoose/porter v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/catgoose/crooner v1.4.2 h1:U8efhD24MkYaXR+ZPf+pK4QbKL/WmP4PaghfIFdSIu
 github.com/catgoose/crooner v1.4.2/go.mod h1:XG7CntqYjfjWqLDwNUoLugoxbxmZlwiqkUxj5FV0r7U=
 github.com/catgoose/dio v1.0.26 h1:Yy5N9tjZMS3BIWgLZTuf354pyZ5ZtFWNkPngzx9uW0M=
 github.com/catgoose/dio v1.0.26/go.mod h1:+9RVLE5n6ku7n74XffvwoS9m0XQ6nmKoiPrlgBpzMsM=
-github.com/catgoose/flighty v0.1.1 h1:2oY3EgR8ntPb6rwOyKIkvNXd4lbDFG1FHVg4IHaQUac=
-github.com/catgoose/flighty v0.1.1/go.mod h1:dgyt0TUDjFGnctMuHOUU/FXbYO49NJ4T60rKiCqgXuU=
+github.com/catgoose/flighty v0.2.0 h1:3cWM4XflKGitdgvEdbCvMKUv699tA1gD27x4hINZtkk=
+github.com/catgoose/flighty v0.2.0/go.mod h1:Uqt8qbVh7hFHuMJ5wElUp0ziX0mNxKyVMWsr379t6Tg=
 github.com/catgoose/fraggle v0.1.12 h1:0yL8VmOWBcQKJL5RFt19Natgb9RUMIF4AC9WGS9NxvU=
 github.com/catgoose/fraggle v0.1.12/go.mod h1:cH5k1/se9azQqMj6aBgjR0iu5knl52ZxVu6wlPer+6s=
 github.com/catgoose/linkwell v0.1.0 h1:aCZogCAQD8fZ5pzx+LMRbyRHY0g3iu24PVmPTL18pOs=

--- a/internal/routes/middleware/helpers_test.go
+++ b/internal/routes/middleware/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/catgoose/flighty"
 	"github.com/catgoose/linkwell"
 
 	"github.com/a-h/templ"
@@ -157,7 +158,7 @@ func TestCreated(t *testing.T) {
 	c, rec := newTestContext(http.MethodPost, "/items")
 	cmp := dummyComponent("<div>created</div>")
 
-	err := Created(c, cmp).Send()
+	err := flighty.Created(c, cmp).Send()
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, rec.Code)
@@ -168,7 +169,7 @@ func TestAccepted(t *testing.T) {
 	c, rec := newTestContext(http.MethodPost, "/jobs")
 	cmp := dummyComponent("<span>accepted</span>")
 
-	err := Accepted(c, cmp).Send()
+	err := flighty.Accepted(c, cmp).Send()
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusAccepted, rec.Code)
@@ -178,7 +179,7 @@ func TestAccepted(t *testing.T) {
 func TestNoContent(t *testing.T) {
 	c, rec := newTestContext(http.MethodDelete, "/items/1")
 
-	err := NoContent(c)
+	err := flighty.NoContent(c)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, rec.Code)
@@ -188,7 +189,7 @@ func TestNoContent(t *testing.T) {
 func TestSeeOther(t *testing.T) {
 	c, rec := newTestContext(http.MethodPost, "/login")
 
-	err := SeeOther(c, "/dashboard")
+	err := flighty.SeeOther(c, "/dashboard")
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusSeeOther, rec.Code)
@@ -203,7 +204,7 @@ func TestCreated_WithPushURL(t *testing.T) {
 	c, rec := newTestContext(http.MethodPost, "/items")
 	cmp := dummyComponent("<tr>new row</tr>")
 
-	err := Created(c, cmp).PushURL("/items/99").Send()
+	err := flighty.Created(c, cmp).PushURL("/items/99").Send()
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, rec.Code)
@@ -215,7 +216,7 @@ func TestCreated_WithTriggerEvent(t *testing.T) {
 	c, rec := newTestContext(http.MethodPost, "/items")
 	cmp := dummyComponent("<tr>row</tr>")
 
-	err := Created(c, cmp).TriggerEvent("item-created", map[string]string{"id": "42"}).Send()
+	err := flighty.Created(c, cmp).TriggerEvent("item-created", map[string]string{"id": "42"}).Send()
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, rec.Code)
@@ -226,7 +227,7 @@ func TestAccepted_WithTriggerEvent(t *testing.T) {
 	c, rec := newTestContext(http.MethodPost, "/jobs")
 	cmp := dummyComponent("<div>queued</div>")
 
-	err := Accepted(c, cmp).TriggerEvent("job-queued", nil).Send()
+	err := flighty.Accepted(c, cmp).TriggerEvent("job-queued", nil).Send()
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusAccepted, rec.Code)
@@ -246,7 +247,7 @@ func TestSeeOther_DifferentPaths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c, rec := newTestContext(http.MethodPost, "/form")
 
-			err := SeeOther(c, tt.url)
+			err := flighty.SeeOther(c, tt.url)
 
 			require.NoError(t, err)
 			require.Equal(t, http.StatusSeeOther, rec.Code)
@@ -258,7 +259,7 @@ func TestSeeOther_DifferentPaths(t *testing.T) {
 func TestNoContent_EmptyBody(t *testing.T) {
 	c, rec := newTestContext(http.MethodDelete, "/items/1")
 
-	err := NoContent(c)
+	err := flighty.NoContent(c)
 
 	require.NoError(t, err)
 	require.Empty(t, rec.Body.String())

--- a/internal/routes/middleware/status.go
+++ b/internal/routes/middleware/status.go
@@ -3,38 +3,12 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/catgoose/cheddar"
-	"github.com/catgoose/linkwell"
 	"github.com/catgoose/flighty"
+	"github.com/catgoose/linkwell"
 	corecomponents "catgoose/dothog/web/components/core"
 
-	"github.com/a-h/templ"
 	"github.com/labstack/echo/v4"
 )
-
-// Created returns a 201 builder. Chain PushURL, TriggerEvent, etc. as needed.
-func Created(c echo.Context, cmp templ.Component) *flighty.Builder {
-	return flighty.New(c).Status(http.StatusCreated).Component(cmp)
-}
-
-// Accepted returns a 202 builder.
-func Accepted(c echo.Context, cmp templ.Component) *flighty.Builder {
-	return flighty.New(c).Status(http.StatusAccepted).Component(cmp)
-}
-
-// NoContent sends a 204 response with HX-Reswap: none so HTMX performs no swap.
-func NoContent(c echo.Context) error {
-	c.Response().Header().Set(cheddar.HeaderReswap, string(cheddar.SwapNone))
-	c.Response().WriteHeader(http.StatusNoContent)
-	return nil
-}
-
-// SeeOther sends a 303 redirect via HX-Redirect for HTMX requests.
-func SeeOther(c echo.Context, url string) error {
-	c.Response().Header().Set(cheddar.HeaderRedirect, url)
-	c.Response().WriteHeader(http.StatusSeeOther)
-	return nil
-}
 
 // UnprocessableEntity returns a 422 builder pre-loaded with an error panel component.
 // Append additional OOB swaps or triggers via the returned builder before calling Send().


### PR DESCRIPTION
## Summary

- Upgrade `github.com/catgoose/flighty` from v0.1.1 to v0.2.0
- Remove `Created`, `Accepted`, `NoContent`, and `SeeOther` from `internal/routes/middleware/status.go` — these now live in flighty as `flighty.Created`, `flighty.Accepted`, `flighty.NoContent`, `flighty.SeeOther`
- Keep `UnprocessableEntity` locally since it references app-specific components
- Update tests to call the flighty versions directly

Closes #351