### PR TITLE
fix: exclude dothog-specific files from derived apps during setup

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -57,11 +57,10 @@ var AllFeatures = []string{FeatureAuth, FeatureGraph, FeatureDatabase, FeatureMS
 var ImplicitFeatures = []string{FeatureDatabase, FeatureAlpine}
 
 // featureDeps maps a feature to the features it implies.
-// sync -> offline -> capacitor.
+// pwa -> sync -> offline.  capacitor is a separate opt-in for native wrapping.
 var featureDeps = map[string][]string{
 	FeatureSync:           {FeatureOffline},
-	FeatureOffline:        {FeatureCapacitor},
-	FeaturePWA:            {FeatureOffline, FeatureSync, FeatureCapacitor},
+	FeaturePWA:            {FeatureOffline, FeatureSync},
 	FeatureDemo:            {FeatureSessionSettings},
 	FeatureCSRF:           {FeatureSessionSettings},
 	FeatureLinkRelations:  {FeatureSessionSettings},
@@ -519,14 +518,29 @@ func removeOptionalContent(dir string, opts Options) error {
 		removeTags[FeatureDemo] = true
 	}
 
+	// Remove dothog-specific documentation that is not relevant to derived apps.
+	_ = os.Remove(filepath.Join(dir, "MANIFESTO.md"))
+	_ = os.Remove(filepath.Join(dir, "AGENTS.md"))
+	_ = os.Remove(filepath.Join(dir, "README.harmony.md"))
+
+	// Remove dothog-specific scripts (doc generation, screenshot automation).
+	_ = os.RemoveAll(filepath.Join(dir, "scripts"))
+	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "screenshots.yml"))
+	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "docs.yml"))
+
 	// Remove all .db files (and WAL/SHM) so derived apps start clean.
 	// The app auto-creates databases on first start via os.MkdirAll + EnsureSchema.
-	// seed.db and demo.db are tracked in git but not needed in derived apps.
 	if matches, err := filepath.Glob(filepath.Join(dir, "db", "*.db*")); err == nil {
 		for _, m := range matches {
 			_ = os.Remove(m)
 		}
 	}
+
+	// Seed data generation is only relevant when the demo feature is selected.
+	if removeTags[FeatureDemo] {
+		_ = os.RemoveAll(filepath.Join(dir, "db", "gen_seed"))
+	}
+
 	if removeTags[FeatureSSE] {
 		_ = os.Remove(filepath.Join(dir, "web", "assets", "public", "js", "htmx.ext.sse.js"))
 	}
@@ -537,6 +551,8 @@ func removeOptionalContent(dir string, opts Options) error {
 		_ = os.Remove(filepath.Join(dir, "capacitor.config.ts"))
 		_ = os.Remove(filepath.Join(dir, "tsconfig.json"))
 		_ = os.RemoveAll(filepath.Join(dir, "fastlane"))
+		_ = os.Remove(filepath.Join(dir, "Gemfile"))
+		_ = os.Remove(filepath.Join(dir, ".github", "workflows", "ios.yml"))
 	}
 	// Alpine.js is always included (implicit feature); no removal needed.
 

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -440,12 +440,32 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	assertDirRemoved(t, filepath.Join(dest, "internal", "domain"))
 	assertDirRemoved(t, filepath.Join(dest, "internal", "demo"))
 
-
 	_, err = os.Stat(filepath.Join(dest, "config", "Caddyfile"))
 	require.True(t, os.IsNotExist(err), "Caddyfile should be removed when no features selected")
 
 	_, err = os.Stat(filepath.Join(dest, "web", "assets", "public", "js", "htmx.ext.sse.js"))
 	require.True(t, os.IsNotExist(err), "htmx.ext.sse.js should be removed when sse not selected")
+
+	// Dothog-specific docs should be removed (#354)
+	for _, f := range []string{"MANIFESTO.md", "AGENTS.md", "README.harmony.md"} {
+		_, err = os.Stat(filepath.Join(dest, f))
+		require.True(t, os.IsNotExist(err), "%s should be removed during setup", f)
+	}
+
+	// scripts/ directory should be removed (#361)
+	assertDirRemoved(t, filepath.Join(dest, "scripts"))
+	_, err = os.Stat(filepath.Join(dest, ".github", "workflows", "screenshots.yml"))
+	require.True(t, os.IsNotExist(err), "screenshots.yml should be removed during setup")
+
+	// db/gen_seed should be removed when demo not selected (#358)
+	assertDirRemoved(t, filepath.Join(dest, "db", "gen_seed"))
+
+	// Capacitor files should be removed when capacitor not selected (#353)
+	for _, f := range []string{"capacitor.config.ts", "tsconfig.json", "Gemfile"} {
+		_, err = os.Stat(filepath.Join(dest, f))
+		require.True(t, os.IsNotExist(err), "%s should be removed when capacitor not selected", f)
+	}
+	assertDirRemoved(t, filepath.Join(dest, "fastlane"))
 }
 
 func TestSetup_FeaturesAuthOnly(t *testing.T) {
@@ -591,6 +611,42 @@ func TestSetup_FeaturesDemo(t *testing.T) {
 	assertNoSetupMarkers(t, dest)
 	assertBuildSucceeds(t, dest)
 	assertDirExists(t, filepath.Join(dest, "internal", "demo"))
+
+	// db/gen_seed should be kept when demo is selected (#358)
+	assertDirExists(t, filepath.Join(dest, "db", "gen_seed"))
+}
+
+// TestSetup_PWAWithoutCapacitor verifies that selecting PWA does not pull in
+// Capacitor files (#353). PWA is a web feature; Capacitor is a separate opt-in.
+func TestSetup_PWAWithoutCapacitor(t *testing.T) {
+	t.Parallel()
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+
+	dest := setupTempDir(t)
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	require.NoError(t, err)
+
+	err = setup.Run(context.Background(), dest, setup.Options{
+		AppName:    "PWA Only App",
+		ModulePath: "github.com/test/pwa-only-app",
+		BasePort:   "20900",
+		Force:      true,
+		Features:   []string{"pwa"},
+	})
+	require.NoError(t, err)
+
+	assertNoSetupMarkers(t, dest)
+	assertBuildSucceeds(t, dest)
+
+	// Capacitor files should NOT be present when only PWA is selected
+	for _, f := range []string{"capacitor.config.ts", "tsconfig.json", "Gemfile"} {
+		_, err = os.Stat(filepath.Join(dest, f))
+		require.True(t, os.IsNotExist(err), "%s should not exist with PWA-only setup", f)
+	}
+	assertDirRemoved(t, filepath.Join(dest, "fastlane"))
+	_, err = os.Stat(filepath.Join(dest, ".github", "workflows", "ios.yml"))
+	require.True(t, os.IsNotExist(err), "ios.yml should not exist with PWA-only setup")
 }
 
 // TestSetup_NoDothogReferences runs setup with all features enabled and verifies


### PR DESCRIPTION
## Summary

- Remove `MANIFESTO.md`, `AGENTS.md`, `README.harmony.md` during setup -- these are dothog-specific docs not relevant to derived apps (#354)
- Gate `db/gen_seed/` directory behind demo feature so it is only included when demo content is selected (#358)
- Exclude `scripts/` directory and its associated workflows (`screenshots.yml`, `docs.yml`) from derived apps (#361)
- Decouple PWA from Capacitor feature dependency -- PWA now depends on `sync -> offline` only, Capacitor is a separate opt-in for native wrapping (#353)
- Add `Gemfile` and `.github/workflows/ios.yml` to Capacitor cleanup list

## Test plan

- [x] All 13 existing setup tests pass
- [x] New `TestSetup_PWAWithoutCapacitor` verifies Capacitor files are absent with PWA-only setup
- [x] `TestSetup_FeaturesNone` now asserts removal of dothog docs, scripts, gen_seed, and Capacitor files
- [x] `TestSetup_FeaturesDemo` now asserts `db/gen_seed` is preserved when demo is selected
- [x] `go build ./...` succeeds

Closes #353, #354, #358, #361