### PR TITLE
feat: setup enhancements for derived app scaffolding

### DIFF
--- a/_template_setup/README.template.md
+++ b/_template_setup/README.template.md
@@ -1,30 +1,6 @@
 # {{APP_NAME}}
 
-<!--toc:start-->
-
-- [{{APP_NAME}}](#appname)
-  - [Template Setup](#template-setup)
-  - [Running the App](#running-the-app)
-  - [Local HTTPS & Ports](#local-https-ports)
-  - [HTTPS Development Setup](#https-development-setup)
-  - [Middleware](#middleware)
-  - [Database](#database)
-  - [Server-Sent Events (SSE)](#server-sent-events-sse)
-  - [Observability](#observability)
-  - [Enabling Crooner (Auth)](#enabling-crooner-auth)
-  - [Enabling Microsoft Graph](#enabling-microsoft-graph)
-  - [Avatar Photos](#avatar-photos)
-  - [Testing](#testing)
-    - [Go Tests](#go-tests)
-    - [E2E Tests (Playwright)](#e2e-tests-playwright)
-    - [Linting](#linting)
-  - [Updating Frontend Assets](#updating-frontend-assets)
-  - [CI/CD Workflows](#cicd-workflows)
-  - [Mage Targets](#mage-targets)
-  - [Environment Variables](#environment-variables)
-  <!--toc:end-->
-
-{{APP_NAME}} is a Go + HTMX application generated from {{TEMPLATE_REF}}.
+{{APP_NAME}} is a Go + HTMX application built on the reach-up architecture pattern.
 
 It uses:
 
@@ -34,70 +10,120 @@ It uses:
 - Air (live reload)
 - Mage (build automation)
 - Playwright (E2E testing)
-- Caddy (optional HTTPS dev proxy)
 
-## Template Setup
+## Features
 
-This project was bootstrapped from {{TEMPLATE_REF}}. If you are starting from the template:
+{{FEATURE_TABLE}}
 
-1. Run the setup wizard to stamp your app name, module path, and dev ports:
+## Getting Started
 
-   ```bash
-   go tool mage setup
-   ```
+### Prerequisites
 
-   The wizard lets you optionally copy the template to a new directory (no `.git` is copied), run `git init` there, then complete app name, module path, and ports in that directory. With flags (e.g. `go tool mage setup -n "My App" -m "github.com/you/my-app" -p 5124`) setup runs non-interactively. After setup you can run cleanup (when prompted) to remove the `_template_setup` folder and `mage_setup.go`.
+- Go 1.24+
+- Node.js 18+ (for Tailwind, Playwright)
 
-3. Review `.env.dev` (generated from `.env.sample`) and adjust as needed.
-4. Start development:
-
-   ```bash
-   go tool mage watch
-   ```
-
-   If you used the copy-and-git-init flow, add a remote when ready: `git remote add origin <url>`.
-
-## Running the App
-
-With `.env.dev` in place (or equivalent env vars set):
+### Setup
 
 ```bash
+# Install dependencies
+npm ci
+
+# Start development (live reload)
 go tool mage watch
 ```
 
 This will:
 
-- Start templ in watch mode, proxying to `https://localhost:{{APP_TLS_PORT}}` with a local HTTP proxy on `{{TEMPL_HTTP_PORT}}`.
-- Run Air to rebuild and restart the Go app.
-- Run Tailwind in watch mode.
-- Optionally start Caddy (via `go tool mage caddystart`) using the templated `Caddyfile`.
+- Start templ in watch mode, proxying to `https://localhost:{{APP_TLS_PORT}}` with a local HTTP proxy on `{{TEMPL_HTTP_PORT}}`
+- Run Air to rebuild and restart the Go app
+- Run Tailwind in watch mode
 
-Access {{APP_NAME}} at:
+Access {{APP_NAME}} at: `https://localhost:{{APP_TLS_PORT}}`
 
-- Direct TLS: `https://localhost:{{APP_TLS_PORT}}`
-- Via Caddy: `https://localhost:{{CADDY_TLS_PORT}}`
+### Ports
 
-## Local HTTPS & Ports
+| Service | Port | URL |
+| --- | --- | --- |
+| Echo app (TLS) | {{APP_TLS_PORT}} | `https://localhost:{{APP_TLS_PORT}}` |
+| templ HTTP proxy | {{TEMPL_HTTP_PORT}} | `http://localhost:{{TEMPL_HTTP_PORT}}` |
+| Caddy TLS front | {{CADDY_TLS_PORT}} | `https://localhost:{{CADDY_TLS_PORT}}` |
 
-The dev HTTPS stack for {{APP_NAME}}:
+### Environment Variables
 
-- Echo app (TLS): `https://localhost:{{APP_TLS_PORT}}`
-- templ HTTP proxy (internal): `http://localhost:{{TEMPL_HTTP_PORT}}`
-- Caddy TLS front: `https://localhost:{{CADDY_TLS_PORT}}`
+Copy `.env.development` and adjust as needed. Key variables:
 
-Request flow:
+| Variable | Description | Default |
+| --- | --- | --- |
+| `SERVER_LISTEN_PORT` | Echo server port | {{APP_TLS_PORT}} |
+| `LOG_LEVEL` | DEBUG, INFO, WARN, ERROR | INFO |
+| `ENABLE_DATABASE` | Enable SQL backend | false |
+| `APP_NAME` | Application display name | {{APP_NAME}} |
 
-- Browser → Caddy (`https://localhost:{{CADDY_TLS_PORT}}`)
-- Caddy (TLS termination) → templ HTTP proxy (`http://localhost:{{TEMPL_HTTP_PORT}}`)
-- templ HTTP proxy → Echo over TLS (`https://localhost:{{APP_TLS_PORT}}`)
+## Architecture
+
+{{APP_NAME}} follows the **reach-up model** -- each layer reaches up to the layer above it rather than importing downward:
+
+```
+Behavior    (Alpine.js, Hyperscript)     -- client-side interactivity
+    ^
+Presentation (templ + DaisyUI)            -- type-safe HTML rendering
+    ^
+HTTP        (Echo + HTMX)                 -- routing, hypermedia exchanges
+    ^
+Data        (Go + SQL)                    -- repositories, schema DSL
+```
+
+Key patterns:
+
+- **HATEOAS** -- hypermedia as the engine of application state; navigation and actions are link-driven
+- **Server-rendered** -- templ components produce HTML; HTMX handles partial page updates
+- **Feature-gated** -- code is organized by feature with clean separation for easy extension
+
+{{FEATURE_SECTIONS}}
+
+## Development
+
+### Testing
+
+```bash
+go tool mage test             # Run all Go tests
+go tool mage teste2e          # Run Playwright E2E tests
+go tool mage testcoverage     # Coverage report
+```
+
+### Linting
+
+```bash
+go tool mage lint              # Run golangci-lint
+go tool mage fixfieldalignment # Auto-fix struct field alignment
+```
+
+### Building
+
+```bash
+go tool mage build    # Full production build
+go tool mage compile  # Compile Go binary only
+```
+
+### Mage Targets
+
+All targets are run with `go tool mage <target>`:
+
+| Target | Description |
+| --- | --- |
+| `watch` | Start dev mode with live reload |
+| `build` | Full production build |
+| `compile` | Compile Go binary |
+| `test` / `testverbose` / `testcoverage` | Go tests |
+| `teste2e` / `teste2eheaded` / `teste2eui` | Playwright E2E tests |
+| `lint` / `lintwatch` | Lint |
+| `updateassets` | Update frontend assets |
+| `clean` | Remove build artifacts |
+| `setup` | Run the template setup wizard |
 
 ## HTTPS Development Setup
 
-When the Caddy feature is selected, `mage setup` checks for existing `localhost.crt` and
-`localhost.key` in the project root. If they exist (e.g. already trusted by your OS), they
-are used as-is. If missing, setup asks whether to generate new self-signed certificates.
-
-Generated certificates need to be installed in your system trust store:
+When Caddy is configured, the app uses self-signed certificates for local HTTPS.
 
 **Linux (Ubuntu/Debian):**
 
@@ -109,203 +135,15 @@ sudo update-ca-certificates
 **macOS:**
 
 1. Open Keychain Access
-2. Drag `localhost.crt` to Keychain Access → System
-3. Double-click the certificate and set 'Trust' to 'Always Trust'
+2. Drag `localhost.crt` to System keychain
+3. Set Trust to Always Trust
 
 **Windows:**
 
-1. Right-click `localhost.crt`
-2. Select 'Install Certificate'
-3. Choose 'Local Machine' and 'Trusted Root Certification Authorities'
+1. Right-click `localhost.crt` > Install Certificate
+2. Choose Local Machine > Trusted Root Certification Authorities
 
-To regenerate certificates manually:
+## Module
 
-```bash
-openssl req -x509 -newkey rsa:2048 -keyout localhost.key -out localhost.crt \
-	-days 365 -nodes -subj "/CN=localhost" \
-	-addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
-```
-
-## Middleware
-
-The app includes several middleware components:
-
-- **Correlation IDs** — Each request gets a unique ID for tracing through logs
-- **CSRF protection** — Token-based CSRF with optional per-request rotation (`CSRF_ROTATE_PER_REQUEST`, `CSRF_PER_REQUEST_PATHS`)
-- **Error handling** — Centralized error display
-- **Form validation** — Request validation helpers
-- **Session settings** — Per-user session preferences
-
-## Database
-
-Database support is **disabled by default** (`ENABLE_DATABASE=false` in `.env`). When enabled, the app supports SQLite and MS SQL Server.
-
-Features include:
-
-- Schema builder with traits (timestamps, soft delete, audit trails)
-- Repository pattern with query builder (where/select)
-- Health checks and validation
-- Multi-dialect support (SQLite/MSSQL)
-
-Configure via environment variables:
-
-```bash
-ENABLE_DATABASE=true
-DB_ENGINE=sqlite # or sqlserver
-DB_HOST=...
-DB_DATABASE=...
-DB_USER=...
-DB_PASSWORD=...
-```
-
-## Server-Sent Events (SSE)
-
-When the SSE feature is selected, the app includes a real-time event broker:
-
-- Topic-based publish/subscribe
-- HTMX SSE extension integration
-- Automatic Caddy configuration for streaming
-
-## Observability
-
-- **Structured logging** — slog-based with configurable log level (`LOG_LEVEL`: DEBUG, INFO, WARN, ERROR)
-- **Request log capture** — In-memory ring buffer (512 entries) for recent request inspection
-- **Issue reporting** — `GET /report-issue/:requestID` endpoint with full request context
-- **File logging** — Rotation via lumberjack
-
-## Enabling Crooner (Auth)
-
-Crooner (Azure AD / Entra ID auth) is **disabled by default** via the config variable `CroonerDisabled = true` in `internal/config/config.go`. To enable Crooner:
-
-1. Set `CroonerDisabled = false` in config (or refactor to read from an env var).
-2. Set the required env vars: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_REDIRECT_URL`, `AZURE_LOGIN_REDIRECT_URL`, `AZURE_LOGOUT_REDIRECT_URL`, `SESSION_SECRET`. Optional: `APP_NAME` (defaults to `"app"`).
-
-3. Protect routes using Crooner's session/claims helpers.
-
-When Crooner is enabled, the app errors on startup if any of the required env vars are not set. When disabled, those vars are not required.
-
-## Enabling Microsoft Graph
-
-The template includes a Microsoft Graph client (using the [Microsoft Graph SDK for Go](https://github.com/microsoftgraph/msgraph-sdk-go)) and user cache under `internal/service/graph`. Graph is **off by default** until you:
-
-1. Set Azure app-only credentials (same env vars as Crooner; used for Graph client credentials):
-
-   ```bash
-   AZURE_CLIENT_ID=...
-   AZURE_CLIENT_SECRET=...
-   AZURE_TENANT_ID=...
-   AZURE_USER_REFRESH_HOUR=5
-   ```
-
-2. Wire the Graph client and user cache (e.g. `graph.NewGraphClient`, `InitAndSyncUserCache`) into your `main.go` or services.
-3. Optionally enable photo download: `ENABLE_PHOTO_DOWNLOAD=true`.
-
-See `.env.sample` for all optional env vars. If Azure/Graph vars are unset, Graph features stay inactive.
-
-## Avatar Photos
-
-When the `avatar` setup feature is selected, the app downloads user profile photos from Microsoft Graph and caches them on the filesystem.
-
-- **Cache directory**: `web/assets/public/images` (override in `main.go` if needed)
-- **Endpoint**: `GET /api/avatar/:azureID` — serves the cached photo, or 404
-- **Schedule**: photos sync on the same schedule as the user cache refresh (`AZURE_USER_REFRESH_HOUR`). An initial sync runs on startup, then daily at the configured hour (production) or once (development).
-- Photos are stored in a two-level directory (`images/ab/abc-123.jpg`) to avoid flat directory issues
-
-## Testing
-
-### Go Tests
-
-```bash
-go tool mage test             # Run all tests
-go tool mage testverbose      # Verbose output
-go tool mage testcoverage     # Coverage report
-go tool mage testcoveragehtml # HTML coverage report
-go tool mage testbenchmark    # Benchmarks
-go tool mage testrace         # Race condition detection
-go tool mage testwatch        # Auto-run tests on file changes
-```
-
-### E2E Tests (Playwright)
-
-End-to-end tests live in `e2e/` and run against a live instance of the app using Playwright and Chromium.
-
-```bash
-npm ci                          # Install dependencies (first time)
-npx playwright install chromium # Install browser (first time)
-go tool mage teste2e            # Run E2E tests headless
-go tool mage teste2eheaded      # Run with visible browser
-go tool mage teste2eui          # Run with Playwright UI
-```
-
-### Linting
-
-```bash
-go tool mage lint              # Run golangci-lint, golint, fieldalignment
-go tool mage fixfieldalignment # Auto-fix struct field alignment
-go tool mage lintwatch         # Lint on file changes
-```
-
-## Updating Frontend Assets
-
-Mage targets to pull the latest versions of frontend dependencies:
-
-```bash
-go tool mage updateassets      # Update all assets
-go tool mage tailwindupdate    # Tailwind CLI binary
-go tool mage htmxupdate        # HTMX + extensions (response-targets, SSE)
-go tool mage hyperscriptupdate # Hyperscript
-go tool mage daisyupdate       # DaisyUI CSS (includes 30+ themes)
-```
-
-## CI/CD Workflows
-
-The template includes GitHub Actions workflows:
-
-- **CI** (`ci.yml`) — Build, vet, and race-condition tests on push/PR
-- **E2E** (`e2e.yml`) — Playwright end-to-end tests on push/PR
-- **Docs** (`docs.yml`) — Generate gomarkdoc API docs and publish to GitHub Pages
-- **Dependency Updates** (`main.yml`) — Weekly `go get -u`, verify build/tests, auto-commit
-- **Release** (`release.yml`) — Semantic versioning with cross-compiled binaries (Linux/Windows)
-- **Screenshots** (`screenshots.yml`) — Automated Playwright screenshot capture
-
-## Mage Targets
-
-All targets are run with `go tool mage <target>`:
-
-| Target                                    | Description                                                       |
-| ----------------------------------------- | ----------------------------------------------------------------- |
-| `watch`                                   | Start dev mode with live reload (Tailwind, templ, Air)            |
-| `build`                                   | Full production build (clean, tailwind, compile, copy files)      |
-| `compile`                                 | Compile Go binary                                                 |
-| `templ` / `templwatch`                    | Run templ / templ in watch mode                                   |
-| `tailwind` / `tailwindwatch`              | Build / watch Tailwind CSS                                        |
-| `air`                                     | Start Air live reload                                             |
-| `test*`                                   | Test targets (see Testing section)                                |
-| `teste2e` / `teste2eheaded` / `teste2eui` | Playwright E2E tests                                              |
-| `lint` / `lintwatch`                      | Lint / lint on file changes                                       |
-| `fixfieldalignment`                       | Auto-fix struct field alignment                                   |
-| `updateassets`                            | Update all frontend assets (Tailwind, HTMX, DaisyUI, Hyperscript) |
-| `caddyinstall`                            | Install Caddy for local HTTPS                                     |
-| `caddystart`                              | Start Caddy with TLS termination                                  |
-| `clean` / `cleanbuild` / `cleandebug`     | Remove build artifacts                                            |
-| `setup`                                   | Run the template setup wizard                                     |
-| `envcheck`                                | Validate required environment variables                           |
-
-## Environment Variables
-
-See `.env.sample` for the full list. Key variables:
-
-| Variable                  | Description                                | Default    |
-| ------------------------- | ------------------------------------------ | ---------- |
-| `SERVER_LISTEN_PORT`      | Echo server port                           | (required) |
-| `LOG_LEVEL`               | DEBUG, INFO, WARN, ERROR                   | INFO       |
-| `ENABLE_DATABASE`         | Enable SQL backend                         | false      |
-| `DB_ENGINE`               | sqlite or sqlserver                        | —          |
-| `AZURE_CLIENT_ID`         | Azure AD app client ID                     | —          |
-| `AZURE_CLIENT_SECRET`     | Azure AD app client secret                 | —          |
-| `AZURE_TENANT_ID`         | Azure AD tenant ID                         | —          |
-| `SESSION_SECRET`          | Session encryption key                     | —          |
-| `CSRF_ROTATE_PER_REQUEST` | Rotate CSRF token per request              | false      |
-| `CSRF_PER_REQUEST_PATHS`  | Comma-separated paths for per-request CSRF | —          |
-| `AZURE_USER_REFRESH_HOUR` | Hour (0-23) for Graph user cache sync      | 5          |
-| `ENABLE_PHOTO_DOWNLOAD`   | Download user photos from Graph            | false      |
+- **Module path**: `{{MODULE_PATH}}`
+- **Generated from**: {{TEMPLATE_REF}}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -332,6 +332,8 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		content = strings.ReplaceAll(content, "{{APP_NAME}}", opts.AppName)
 		content = strings.ReplaceAll(content, "{{MODULE_PATH}}", modulePath)
 		content = strings.ReplaceAll(content, "{{TEMPLATE_REF}}", "the template")
+		content = strings.ReplaceAll(content, "{{FEATURE_TABLE}}", buildFeatureTable(opts.Features))
+		content = strings.ReplaceAll(content, "{{FEATURE_SECTIONS}}", buildFeatureSections(opts.Features))
 		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content), 0644); err != nil {
 			return err
 		}
@@ -527,6 +529,27 @@ func removeOptionalContent(dir string, opts Options) error {
 	_ = os.RemoveAll(filepath.Join(dir, "scripts"))
 	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "screenshots.yml"))
 	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "docs.yml"))
+
+	// Create docs/screenshots/ for derived app documentation assets (#355).
+	screenshotsDir := filepath.Join(dir, "docs", "screenshots")
+	_ = os.MkdirAll(screenshotsDir, 0755)
+	_ = os.WriteFile(filepath.Join(screenshotsDir, ".gitkeep"), []byte(""), 0644)
+
+	// Remove dothog-specific docs that are not relevant to derived apps (#355).
+	// Keep SETUP.md (universal); remove docs that describe dothog's demo architecture.
+	_ = os.Remove(filepath.Join(dir, "docs", "HAL.md"))
+	_ = os.Remove(filepath.Join(dir, "docs", "COMPONENTS.md"))
+	_ = os.Remove(filepath.Join(dir, "docs", "LINK_RELATIONS.md"))
+	_ = os.Remove(filepath.Join(dir, "docs", "ARCHITECTURE.md"))
+	_ = os.Remove(filepath.Join(dir, "docs", "index.md"))
+	_ = os.Remove(filepath.Join(dir, "docs", "mkdocs.yml"))
+	_ = os.RemoveAll(filepath.Join(dir, "docs", "audit"))
+
+	// Replace demo-specific e2e tests with a minimal smoke suite (#356).
+	// Keep helpers.ts and playwright.config.ts (they contain general utilities
+	// and the binary-name aware config). Remove all demo page spec files and
+	// generate a smoke test that verifies the app loads.
+	replaceE2EWithSmoke(dir, opts.AppName)
 
 	// Remove all .db files (and WAL/SHM) so derived apps start clean.
 	// The app auto-creates databases on first start via os.MkdirAll + EnsureSchema.
@@ -1052,6 +1075,158 @@ func goPkgName(importPath string) string {
 }
 
 // ---------------------------------------------------------------------------
+// README feature generation (#360)
+// ---------------------------------------------------------------------------
+
+// featureDescriptions maps feature tags to human-readable descriptions
+// for the generated README.
+var featureDescriptions = map[string]struct{ label, desc string }{
+	FeatureAuth:            {"Auth (Crooner)", "Azure AD / OIDC authentication via crooner"},
+	FeatureGraph:           {"Graph API", "Microsoft Graph API integration for user data"},
+	FeatureAvatar:          {"Avatar Photos", "User profile photo download and caching from Graph"},
+	FeatureDatabase:        {"Database (fraggle)", "Repository layer with schema DSL (SQLite base)"},
+	FeatureMSSQL:           {"MSSQL", "Microsoft SQL Server dialect support"},
+	FeaturePostgres:        {"PostgreSQL", "PostgreSQL dialect support"},
+	FeatureSSE:             {"SSE", "Server-Sent Events with HTMX integration"},
+	FeatureCaddy:           {"Caddy (HTTPS)", "Caddy reverse proxy with TLS termination"},
+	FeatureDemo:            {"Demo Content", "Demo pages, seed data, and example routes"},
+	FeatureSessionSettings: {"Session Settings", "Per-session theme and layout preferences"},
+	FeatureAlpine:          {"Alpine.js", "Client-side state management"},
+	FeatureCapacitor:       {"Capacitor", "Native mobile wrapper (iOS/Android)"},
+	FeatureOffline:         {"Offline Mode", "Service worker and write queue for offline use"},
+	FeatureSync:            {"Sync", "SQLite data synchronization between client and server"},
+	FeatureCSRF:            {"CSRF Protection", "Token-based CSRF with optional per-request rotation"},
+	FeatureLinkRelations:   {"Link Relations", "Context bars, breadcrumbs, and site map"},
+	FeatureWebStandards:    {"Web Standards", "Server-Timing, Vary, Permissions-Policy, Early Hints"},
+	FeatureBrowserAPIs:     {"Browser APIs", "sendBeacon, BroadcastChannel integration"},
+	FeaturePWA:             {"PWA", "Progressive Web App with offline + sync support"},
+}
+
+// buildFeatureTable generates a markdown table of enabled features for the README.
+func buildFeatureTable(features []string) string {
+	if features == nil {
+		return "_No feature configuration provided._"
+	}
+
+	expanded := ExpandFeatureDeps(features)
+	keep := make(map[string]bool)
+	for _, f := range expanded {
+		keep[f] = true
+	}
+	for _, f := range ImplicitFeatures {
+		keep[f] = true
+	}
+
+	var sb strings.Builder
+	sb.WriteString("| Feature | Description |\n")
+	sb.WriteString("| --- | --- |\n")
+
+	count := 0
+	for _, tag := range AllFeatures {
+		if !keep[tag] {
+			continue
+		}
+		info, ok := featureDescriptions[tag]
+		if !ok {
+			continue
+		}
+		sb.WriteString("| ")
+		sb.WriteString(info.label)
+		sb.WriteString(" | ")
+		sb.WriteString(info.desc)
+		sb.WriteString(" |\n")
+		count++
+	}
+
+	if count == 0 {
+		return "_Minimal configuration (no optional features)._"
+	}
+	return sb.String()
+}
+
+// buildFeatureSections generates per-feature documentation sections for the README.
+func buildFeatureSections(features []string) string {
+	if features == nil {
+		return ""
+	}
+
+	expanded := ExpandFeatureDeps(features)
+	keep := make(map[string]bool)
+	for _, f := range expanded {
+		keep[f] = true
+	}
+	for _, f := range ImplicitFeatures {
+		keep[f] = true
+	}
+
+	var sb strings.Builder
+
+	if keep[FeatureAuth] {
+		sb.WriteString(`### Authentication (Crooner)
+
+This app uses [crooner](https://github.com/catgoose/crooner) for Azure AD / Entra ID authentication. Configure via environment variables:
+
+- ` + "`AZURE_CLIENT_ID`" + `, ` + "`AZURE_CLIENT_SECRET`" + `, ` + "`AZURE_TENANT_ID`" + ` -- Azure app registration
+- ` + "`AZURE_REDIRECT_URL`" + `, ` + "`AZURE_LOGIN_REDIRECT_URL`" + `, ` + "`AZURE_LOGOUT_REDIRECT_URL`" + ` -- OAuth flow URLs
+- ` + "`SESSION_SECRET`" + ` -- session encryption key
+
+Auth is disabled by default (` + "`CroonerDisabled = true`" + ` in config). Set it to ` + "`false`" + ` to enable.
+
+`)
+	}
+
+	if keep[FeatureGraph] {
+		sb.WriteString(`### Microsoft Graph API
+
+Graph API integration is included for user data queries. Set the same Azure credentials as auth, plus:
+
+- ` + "`AZURE_USER_REFRESH_HOUR`" + ` -- hour (0-23) for daily user cache sync
+- ` + "`ENABLE_PHOTO_DOWNLOAD`" + ` -- download user photos from Graph
+
+`)
+	}
+
+	if keep[FeatureSSE] {
+		sb.WriteString(`### Server-Sent Events (SSE)
+
+Real-time event broker with topic-based publish/subscribe. HTMX SSE extension is included for declarative event binding. Caddy is configured for SSE streaming support.
+
+`)
+	}
+
+	if keep[FeatureCaddy] {
+		sb.WriteString(`### Caddy (HTTPS)
+
+Caddy provides TLS termination for local development. Certificates are generated during setup or can be provided manually. See the HTTPS Development Setup section for trust store installation.
+
+`)
+	}
+
+	if keep[FeatureCapacitor] {
+		sb.WriteString(`### Capacitor (Mobile)
+
+Capacitor wraps the web app for native iOS/Android deployment. Configuration is in ` + "`capacitor.config.ts`" + `.
+
+`)
+	}
+
+	if keep[FeatureOffline] || keep[FeatureSync] || keep[FeaturePWA] {
+		sb.WriteString(`### Offline & Sync
+
+`)
+		if keep[FeaturePWA] {
+			sb.WriteString("This app is configured as a **Progressive Web App** with offline support and data synchronization.\n\n")
+		} else if keep[FeatureSync] {
+			sb.WriteString("Data synchronization is enabled between client SQLite and server.\n\n")
+		} else {
+			sb.WriteString("Offline mode is enabled with service worker caching and a write queue.\n\n")
+		}
+	}
+
+	return sb.String()
+}
+
+// ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
 
@@ -1075,6 +1250,75 @@ func composeSetupEnv(content string) string {
 		out = append(out, line)
 	}
 	return strings.Join(out, "\n")
+}
+
+// replaceE2EWithSmoke removes all demo-specific e2e spec files and generates a
+// minimal smoke test that verifies the home page loads and the health endpoint
+// returns the configured app name (#356).
+func replaceE2EWithSmoke(dir, appName string) {
+	e2eDir := filepath.Join(dir, "e2e")
+	entries, err := os.ReadDir(e2eDir)
+	if err != nil {
+		return // no e2e directory — nothing to do
+	}
+
+	// Remove all *.spec.ts files (demo-specific tests).
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".spec.ts") {
+			_ = os.Remove(filepath.Join(e2eDir, e.Name()))
+		}
+	}
+
+	binaryName := binaryNameFromApp(appName)
+
+	// Generate a minimal smoke test.
+	smoke := `import { test, expect } from "@playwright/test";
+import { navigateTo } from "./helpers";
+
+test.describe("` + appName + ` Smoke Tests", () => {
+  test("home page loads", async ({ page }) => {
+    await navigateTo(page, "/");
+    await expect(page).toHaveTitle(/.+/);
+  });
+
+  test("health endpoint returns OK with correct app name", async ({ request }) => {
+    const resp = await request.get("/health");
+    expect(resp.ok()).toBe(true);
+    const body = await resp.json();
+    expect(body.status).toBe("healthy");
+    expect(body.name).toBe("` + binaryName + `");
+  });
+
+  test("navbar is present", async ({ page }) => {
+    await navigateTo(page, "/");
+    await expect(page.locator("nav")).toBeVisible();
+  });
+});
+`
+	_ = os.WriteFile(filepath.Join(e2eDir, "smoke.spec.ts"), []byte(smoke), 0644)
+
+	// Rewrite helpers.ts to remove demo-specific resetDB helper.
+	helpers := `import { type Page, expect } from "@playwright/test";
+
+/** Wait for HTMX to finish all pending requests. */
+export async function waitForHtmx(page: Page) {
+  await page.waitForFunction(
+    () =>
+      typeof (window as any).htmx !== "undefined" &&
+      (document.querySelectorAll(".htmx-request").length === 0),
+    { timeout: 10_000 },
+  );
+}
+
+/** Navigate to a page and assert it loaded (no server error). */
+export async function navigateTo(page: Page, path: string) {
+  const resp = await page.goto(path);
+  expect(resp?.ok(), ` + "`" + `Expected 2xx for ${path}, got ${resp?.status()}` + "`" + `).toBe(
+    true,
+  );
+}
+`
+	_ = os.WriteFile(filepath.Join(e2eDir, "helpers.ts"), []byte(helpers), 0644)
 }
 
 // replaceDefaultFavicons copies the generic favicons from images/default/ over

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -411,6 +411,25 @@ func TestSetup_FeaturesAll(t *testing.T) {
 	assertDirExists(t, filepath.Join(dest, "internal", "database"))
 	assertDirExists(t, filepath.Join(dest, "internal", "service", "graph"))
 	assertDirExists(t, filepath.Join(dest, "internal", "demo"))
+
+	// docs/screenshots/ should exist (#355)
+	assertDirExists(t, filepath.Join(dest, "docs", "screenshots"))
+
+	// e2e smoke test should exist (#356)
+	_, err = os.Stat(filepath.Join(dest, "e2e", "smoke.spec.ts"))
+	require.NoError(t, err, "smoke.spec.ts should exist after setup")
+	// Demo spec files should be removed
+	_, err = os.Stat(filepath.Join(dest, "e2e", "dashboard.spec.ts"))
+	require.True(t, os.IsNotExist(err), "demo e2e tests should be removed after setup")
+
+	// README should list all features (#360)
+	readmeBytes, err := os.ReadFile(filepath.Join(dest, "README.md"))
+	require.NoError(t, err)
+	readmeContent := string(readmeBytes)
+	require.Contains(t, readmeContent, "Auth (Crooner)")
+	require.Contains(t, readmeContent, "SSE")
+	require.Contains(t, readmeContent, "## Features")
+	require.Contains(t, readmeContent, "## Architecture")
 }
 
 func TestSetup_FeaturesNone(t *testing.T) {
@@ -466,6 +485,46 @@ func TestSetup_FeaturesNone(t *testing.T) {
 		require.True(t, os.IsNotExist(err), "%s should be removed when capacitor not selected", f)
 	}
 	assertDirRemoved(t, filepath.Join(dest, "fastlane"))
+
+	// docs/screenshots/ should be created with .gitkeep (#355)
+	assertDirExists(t, filepath.Join(dest, "docs", "screenshots"))
+	_, err = os.Stat(filepath.Join(dest, "docs", "screenshots", ".gitkeep"))
+	require.NoError(t, err, "docs/screenshots/.gitkeep should exist")
+
+	// Dothog-specific docs should be removed (#355)
+	for _, f := range []string{"HAL.md", "COMPONENTS.md", "LINK_RELATIONS.md", "ARCHITECTURE.md", "index.md", "mkdocs.yml"} {
+		_, err = os.Stat(filepath.Join(dest, "docs", f))
+		require.True(t, os.IsNotExist(err), "docs/%s should be removed during setup", f)
+	}
+	assertDirRemoved(t, filepath.Join(dest, "docs", "audit"))
+
+	// e2e should contain only smoke test, helpers, and config (#356)
+	e2eEntries, err := os.ReadDir(filepath.Join(dest, "e2e"))
+	require.NoError(t, err)
+	var e2eNames []string
+	for _, e := range e2eEntries {
+		e2eNames = append(e2eNames, e.Name())
+	}
+	require.Contains(t, e2eNames, "smoke.spec.ts", "e2e should have smoke.spec.ts")
+	require.Contains(t, e2eNames, "helpers.ts", "e2e should have helpers.ts")
+	require.Contains(t, e2eNames, "playwright.config.ts", "e2e should have playwright.config.ts")
+	require.NotContains(t, e2eNames, "dashboard.spec.ts", "demo e2e tests should be removed")
+	require.NotContains(t, e2eNames, "inventory.spec.ts", "demo e2e tests should be removed")
+	require.NotContains(t, e2eNames, "home.spec.ts", "demo e2e tests should be removed")
+
+	// Smoke test should reference the app's binary name (#356)
+	smokeBytes, err := os.ReadFile(filepath.Join(dest, "e2e", "smoke.spec.ts"))
+	require.NoError(t, err)
+	require.Contains(t, string(smokeBytes), "no-features-app", "smoke test should use the app binary name")
+
+	// README should contain a feature table (#360)
+	readmeBytes, err := os.ReadFile(filepath.Join(dest, "README.md"))
+	require.NoError(t, err)
+	readmeContent := string(readmeBytes)
+	require.Contains(t, readmeContent, "No Features App")
+	require.Contains(t, readmeContent, "## Features")
+	// Minimal config should still have implicit features (database, alpine)
+	require.Contains(t, readmeContent, "Database (fraggle)")
 }
 
 func TestSetup_FeaturesAuthOnly(t *testing.T) {


### PR DESCRIPTION
## Summary

- **#355 -- docs/screenshots/**: Create `docs/screenshots/` with `.gitkeep` in generated projects. Remove dothog-specific docs (HAL, COMPONENTS, LINK_RELATIONS, ARCHITECTURE, audit, mkdocs) that are irrelevant to derived apps. Keep SETUP.md which is universal.

- **#356 -- e2e smoke tests**: Replace all 18 demo-specific Playwright spec files with a single `smoke.spec.ts` that verifies the home page loads, the health endpoint returns the correct binary name, and the navbar is present. Rewrite `helpers.ts` to drop the demo-specific `resetDB` helper. Keep `playwright.config.ts` which already has binary-name templating.

- **#360 -- per-configuration README**: Rewrite the README template to include a feature configuration table (generated from selected features), per-feature documentation sections (auth, Graph, SSE, Caddy, Capacitor, offline/sync), and an architecture overview describing the reach-up model.

## Test plan

- [x] `go build ./...` passes
- [x] All 13 `TestSetup_*` tests pass with new assertions for:
  - `docs/screenshots/.gitkeep` exists after setup
  - Dothog-specific docs removed from `docs/`
  - Only `smoke.spec.ts`, `helpers.ts`, `playwright.config.ts` remain in `e2e/`
  - Smoke test references the app's binary name
  - README contains feature table with enabled features
  - README contains architecture section

Closes #355, #356, #360