### PR TITLE
fix: update linkwell to v0.2.0 and remove SortedPaths usage

### DIFF
--- a/web/views/hypermedia_links.go
+++ b/web/views/hypermedia_links.go
@@ -3,6 +3,7 @@ package views
 
 import (
 	"fmt"
+	"sort"
 
 	"catgoose/dothog/internal/demo"
 	"github.com/catgoose/linkwell"
@@ -38,6 +39,16 @@ func storedLinkID(stored []demo.StoredLinkRelation, source, rel, target string) 
 // linkDeleteURL returns the HTMX delete endpoint for a stored link.
 func linkDeleteURL(id int) string {
 	return fmt.Sprintf("/hypermedia/links/%d", id)
+}
+
+// sortedLinkPaths returns the keys of a link map in alphabetical order.
+func sortedLinkPaths(links map[string][]linkwell.LinkRelation) []string {
+	paths := make([]string, 0, len(links))
+	for k := range links {
+		paths = append(paths, k)
+	}
+	sort.Strings(paths)
+	return paths
 }
 
 func codeLinkExample() string {

--- a/web/views/hypermedia_links.templ
+++ b/web/views/hypermedia_links.templ
@@ -138,7 +138,7 @@ templ LinksRegistryTable(data LinksPageData) {
 					</tr>
 				</thead>
 				<tbody>
-					for _, src := range linkwell.SortedPaths(data.Links) {
+					for _, src := range sortedLinkPaths(data.Links) {
 						for i, link := range data.Links[src] {
 							<tr class={ templ.KV("border-t border-base-300", i == 0) }>
 								if i == 0 {

--- a/web/views/hypermedia_links_templ.go
+++ b/web/views/hypermedia_links_templ.go
@@ -359,7 +359,7 @@ func LinksRegistryTable(data LinksPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, src := range linkwell.SortedPaths(data.Links) {
+		for _, src := range sortedLinkPaths(data.Links) {
 			for i, link := range data.Links[src] {
 				var templ_7745c5c3_Var17 = []any{templ.KV("border-t border-base-300", i == 0)}
 				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var17...)


### PR DESCRIPTION
## Summary

- linkwell v0.2.0 unexported `SortedPaths` to `sortedPaths`
- Inlines the trivial sort-map-keys logic as `sortedLinkPaths` in `web/views/hypermedia_links.go`
- Updates `.templ` and regenerated `_templ.go` to use the local helper

## Test plan

- [x] `go build ./web/views/` passes (was failing on main with `undefined: linkwell.SortedPaths`)
- [ ] Verify links registry table still renders sorted source paths