### PR TITLE
Define app-specific SSE topic constants after tavern v0.3.0

### DIFF
--- a/internal/routes/routes_canvas.go
+++ b/internal/routes/routes_canvas.go
@@ -82,9 +82,9 @@ func (cr *canvasRoutes) handlePlace(c echo.Context) error {
 
 func (cr *canvasRoutes) handleReset(c echo.Context) error {
 	cr.canvas.Reset()
-	if cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
+	if cr.broker.HasSubscribers(TopicCanvasUpdate) {
 		msg := tavern.NewSSEMessage("canvas-reset", "").String()
-		cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
+		cr.broker.Publish(TopicCanvasUpdate, msg)
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -107,7 +107,7 @@ func (cr *canvasRoutes) handleCanvasSSE(c echo.Context) error {
 		return fmt.Errorf("streaming unsupported")
 	}
 
-	ch, unsub := cr.broker.Subscribe(tavern.TopicCanvasUpdate)
+	ch, unsub := cr.broker.Subscribe(TopicCanvasUpdate)
 	defer unsub()
 
 	heartbeat := time.NewTicker(10 * time.Second)
@@ -146,7 +146,7 @@ func (cr *canvasRoutes) runTicker() {
 }
 
 func (cr *canvasRoutes) broadcastPixel(x, y int, color string) {
-	if !cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
+	if !cr.broker.HasSubscribers(TopicCanvasUpdate) {
 		return
 	}
 	data, err := json.Marshal(map[string]any{"x": x, "y": y, "color": color})
@@ -155,11 +155,11 @@ func (cr *canvasRoutes) broadcastPixel(x, y int, color string) {
 		return
 	}
 	msg := tavern.NewSSEMessage("pixel-update", string(data)).String()
-	cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
+	cr.broker.Publish(TopicCanvasUpdate, msg)
 }
 
 func (cr *canvasRoutes) broadcastClients() {
-	if !cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
+	if !cr.broker.HasSubscribers(TopicCanvasUpdate) {
 		return
 	}
 	clients := cr.canvas.ActiveClients()
@@ -169,7 +169,7 @@ func (cr *canvasRoutes) broadcastClients() {
 		return
 	}
 	msg := tavern.NewSSEMessage("clients-update", string(data)).String()
-	cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
+	cr.broker.Publish(TopicCanvasUpdate, msg)
 }
 
 func getOrCreateClientID(c echo.Context) string {

--- a/internal/routes/routes_feed.go
+++ b/internal/routes/routes_feed.go
@@ -79,7 +79,7 @@ func (f *feedRoutes) handleActivitySSE(c echo.Context) error {
 		return fmt.Errorf("streaming unsupported")
 	}
 
-	ch, unsub := f.broker.Subscribe(tavern.TopicActivityFeed)
+	ch, unsub := f.broker.Subscribe(TopicActivityFeed)
 	defer unsub()
 
 	ctx := c.Request().Context()
@@ -99,7 +99,7 @@ func (f *feedRoutes) handleActivitySSE(c echo.Context) error {
 
 // BroadcastActivity publishes an activity event to the SSE feed.
 func BroadcastActivity(broker *tavern.SSEBroker, e demo.ActivityEvent) {
-	if !broker.HasSubscribers(tavern.TopicActivityFeed) {
+	if !broker.HasSubscribers(TopicActivityFeed) {
 		return
 	}
 	buf := statsBufPool.Get().(*bytes.Buffer)
@@ -110,7 +110,7 @@ func BroadcastActivity(broker *tavern.SSEBroker, e demo.ActivityEvent) {
 	}
 	msg := tavern.NewSSEMessage("activity-event", buf.String()).String()
 	statsBufPool.Put(buf)
-	broker.Publish(tavern.TopicActivityFeed, msg)
+	broker.Publish(TopicActivityFeed, msg)
 }
 
 // --- Simulated activity ---
@@ -148,7 +148,7 @@ func (ar *appRoutes) publishActivityEvents(actLog *demo.ActivityLog, broker *tav
 		case <-ar.ctx.Done():
 			return
 		case <-time.After(delay):
-			if !broker.HasSubscribers(tavern.TopicActivityFeed) {
+			if !broker.HasSubscribers(TopicActivityFeed) {
 				continue
 			}
 			tmpl := activityTemplates[rand.IntN(len(activityTemplates))]

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -166,7 +166,7 @@ func handleErrorTracesSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
 		c.Response().WriteHeader(http.StatusOK)
 
 		flusher := c.Response().Writer.(http.Flusher)
-		ch, unsub := broker.Subscribe(tavern.TopicErrorTraces)
+		ch, unsub := broker.Subscribe(TopicErrorTraces)
 		defer unsub()
 
 		ctx := c.Request().Context()
@@ -186,7 +186,7 @@ func handleErrorTracesSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
 }
 
 func broadcastErrorTrace(broker *tavern.SSEBroker, summary promolog.TraceSummary) {
-	if !broker.HasSubscribers(tavern.TopicErrorTraces) {
+	if !broker.HasSubscribers(TopicErrorTraces) {
 		return
 	}
 	buf := new(bytes.Buffer)
@@ -195,7 +195,7 @@ func broadcastErrorTrace(broker *tavern.SSEBroker, summary promolog.TraceSummary
 		return
 	}
 	msg := tavern.NewSSEMessage("error-trace", buf.String()).String()
-	broker.Publish(tavern.TopicErrorTraces, msg)
+	broker.Publish(TopicErrorTraces, msg)
 }
 
 // setup:feature:sse:end

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -132,7 +132,7 @@ func (p *peopleRoutes) handlePersonUpdate(c echo.Context) error {
 }
 
 func (p *peopleRoutes) broadcastPersonUpdate(person demo.Person) {
-	topic := fmt.Sprintf("%s-%d", tavern.TopicPeopleUpdate, person.ID)
+	topic := fmt.Sprintf("%s-%d", TopicPeopleUpdate, person.ID)
 	if !p.broker.HasSubscribers(topic) {
 		return
 	}
@@ -152,7 +152,7 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 400, "Invalid person ID", err)
 	}
-	topic := fmt.Sprintf("%s-%d", tavern.TopicPeopleUpdate, id)
+	topic := fmt.Sprintf("%s-%d", TopicPeopleUpdate, id)
 
 	c.Response().Header().Set("Content-Type", "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "no-cache")

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -72,7 +72,7 @@ func handleSSESystem(broker *tavern.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		ch, unsub := broker.Subscribe(tavern.TopicSystemStats)
+		ch, unsub := broker.Subscribe(TopicSystemStats)
 		defer unsub()
 
 		ctx := c.Request().Context()
@@ -115,11 +115,11 @@ func handleSSEDashboard(broker *tavern.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		chMetrics, unsubMetrics := broker.Subscribe(tavern.TopicDashMetrics)
+		chMetrics, unsubMetrics := broker.Subscribe(TopicDashMetrics)
 		defer unsubMetrics()
-		chServices, unsubServices := broker.Subscribe(tavern.TopicDashServices)
+		chServices, unsubServices := broker.Subscribe(TopicDashServices)
 		defer unsubServices()
-		chEvents, unsubEvents := broker.Subscribe(tavern.TopicDashEvents)
+		chEvents, unsubEvents := broker.Subscribe(TopicDashEvents)
 		defer unsubEvents()
 
 		lastSent := make(map[string]time.Time)
@@ -169,7 +169,7 @@ func (ar *appRoutes) publishSystemStats(broker *tavern.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(tavern.TopicSystemStats) {
+			if !broker.HasSubscribers(TopicSystemStats) {
 				continue
 			}
 			stats := tavern.CollectRuntimeStats(start)
@@ -181,7 +181,7 @@ func (ar *appRoutes) publishSystemStats(broker *tavern.SSEBroker) {
 			}
 			msg := tavern.NewSSEMessage("system-stats", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(tavern.TopicSystemStats, msg)
+			broker.Publish(TopicSystemStats, msg)
 		}
 	}
 }
@@ -240,7 +240,7 @@ func (ar *appRoutes) publishMetrics(broker *tavern.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(tavern.TopicDashMetrics) {
+			if !broker.HasSubscribers(TopicDashMetrics) {
 				continue
 			}
 
@@ -395,7 +395,7 @@ func (ar *appRoutes) publishMetrics(broker *tavern.SSEBroker) {
 			}
 			msg := tavern.NewSSEMessage("dashboard-metrics", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(tavern.TopicDashMetrics, msg)
+			broker.Publish(TopicDashMetrics, msg)
 		}
 	}
 }
@@ -451,7 +451,7 @@ func (ar *appRoutes) publishServices(broker *tavern.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(tavern.TopicDashServices) {
+			if !broker.HasSubscribers(TopicDashServices) {
 				continue
 			}
 
@@ -486,7 +486,7 @@ func (ar *appRoutes) publishServices(broker *tavern.SSEBroker) {
 			}
 			msg := tavern.NewSSEMessage("dashboard-services", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(tavern.TopicDashServices, msg)
+			broker.Publish(TopicDashServices, msg)
 		}
 	}
 }
@@ -534,7 +534,7 @@ func (ar *appRoutes) publishEvents(broker *tavern.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-time.After(delay):
-			if !broker.HasSubscribers(tavern.TopicDashEvents) {
+			if !broker.HasSubscribers(TopicDashEvents) {
 				continue
 			}
 
@@ -553,7 +553,7 @@ func (ar *appRoutes) publishEvents(broker *tavern.SSEBroker) {
 			}
 			msg := tavern.NewSSEMessage("dashboard-events", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(tavern.TopicDashEvents, msg)
+			broker.Publish(TopicDashEvents, msg)
 		}
 	}
 }

--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -50,9 +50,9 @@ func (ar *appRoutes) handleTheme(broker *tavern.SSEBroker) echo.HandlerFunc {
 		}
 
 		// Broadcast theme change to all connected browsers.
-		if broker.HasSubscribers(tavern.TopicThemeChange) {
+		if broker.HasSubscribers(TopicThemeChange) {
 			msg := tavern.NewSSEMessage("theme-change", theme).String()
-			broker.Publish(tavern.TopicThemeChange, msg)
+			broker.Publish(TopicThemeChange, msg)
 		}
 
 		return handler.RenderComponent(c, views.ThemeChanged(theme))
@@ -97,7 +97,7 @@ func handleSSETheme(broker *tavern.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		ch, unsub := broker.Subscribe(tavern.TopicThemeChange)
+		ch, unsub := broker.Subscribe(TopicThemeChange)
 		defer unsub()
 
 		ctx := c.Request().Context()

--- a/internal/routes/topics.go
+++ b/internal/routes/topics.go
@@ -1,0 +1,15 @@
+package routes
+
+// SSE topic constants for the broker. These are app-specific channel names
+// used by the real-time features (dashboard, canvas, feed, etc.).
+const (
+	TopicSystemStats  = "system-stats"
+	TopicDashMetrics  = "dashboard-metrics"
+	TopicDashServices = "dashboard-services"
+	TopicDashEvents   = "dashboard-events"
+	TopicPeopleUpdate = "people-update"
+	TopicActivityFeed = "activity-feed"
+	TopicErrorTraces  = "error-traces"
+	TopicThemeChange  = "theme-change"
+	TopicCanvasUpdate = "canvas-update"
+)


### PR DESCRIPTION
## Summary

Closes #207.

tavern v0.3.0 moved topic constants to examples since they're app-specific. This defines them locally in dothog's routes package.

- Added `internal/routes/topics.go` with all 9 SSE topic constants
- Replaced `tavern.Topic*` references with local `Topic*` constants in 6 route files