### PR TITLE
fix: define app-specific SSE topic constants locally

### DIFF
--- a/internal/routes/routes_canvas.go
+++ b/internal/routes/routes_canvas.go
@@ -16,6 +16,7 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
+	"catgoose/dothog/internal/ssetopics"
 	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
@@ -82,9 +83,9 @@ func (cr *canvasRoutes) handlePlace(c echo.Context) error {
 
 func (cr *canvasRoutes) handleReset(c echo.Context) error {
 	cr.canvas.Reset()
-	if cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
+	if cr.broker.HasSubscribers(ssetopics.TopicCanvasUpdate) {
 		msg := tavern.NewSSEMessage("canvas-reset", "").String()
-		cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
+		cr.broker.Publish(ssetopics.TopicCanvasUpdate, msg)
 	}
 	return c.NoContent(http.StatusOK)
 }
@@ -107,7 +108,7 @@ func (cr *canvasRoutes) handleCanvasSSE(c echo.Context) error {
 		return fmt.Errorf("streaming unsupported")
 	}
 
-	ch, unsub := cr.broker.Subscribe(tavern.TopicCanvasUpdate)
+	ch, unsub := cr.broker.Subscribe(ssetopics.TopicCanvasUpdate)
 	defer unsub()
 
 	heartbeat := time.NewTicker(10 * time.Second)
@@ -146,7 +147,7 @@ func (cr *canvasRoutes) runTicker() {
 }
 
 func (cr *canvasRoutes) broadcastPixel(x, y int, color string) {
-	if !cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
+	if !cr.broker.HasSubscribers(ssetopics.TopicCanvasUpdate) {
 		return
 	}
 	data, err := json.Marshal(map[string]any{"x": x, "y": y, "color": color})
@@ -155,11 +156,11 @@ func (cr *canvasRoutes) broadcastPixel(x, y int, color string) {
 		return
 	}
 	msg := tavern.NewSSEMessage("pixel-update", string(data)).String()
-	cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
+	cr.broker.Publish(ssetopics.TopicCanvasUpdate, msg)
 }
 
 func (cr *canvasRoutes) broadcastClients() {
-	if !cr.broker.HasSubscribers(tavern.TopicCanvasUpdate) {
+	if !cr.broker.HasSubscribers(ssetopics.TopicCanvasUpdate) {
 		return
 	}
 	clients := cr.canvas.ActiveClients()
@@ -169,7 +170,7 @@ func (cr *canvasRoutes) broadcastClients() {
 		return
 	}
 	msg := tavern.NewSSEMessage("clients-update", string(data)).String()
-	cr.broker.Publish(tavern.TopicCanvasUpdate, msg)
+	cr.broker.Publish(ssetopics.TopicCanvasUpdate, msg)
 }
 
 func getOrCreateClientID(c echo.Context) string {

--- a/internal/routes/routes_feed.go
+++ b/internal/routes/routes_feed.go
@@ -14,6 +14,7 @@ import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/shared"
+	"catgoose/dothog/internal/ssetopics"
 	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
@@ -79,7 +80,7 @@ func (f *feedRoutes) handleActivitySSE(c echo.Context) error {
 		return fmt.Errorf("streaming unsupported")
 	}
 
-	ch, unsub := f.broker.Subscribe(tavern.TopicActivityFeed)
+	ch, unsub := f.broker.Subscribe(ssetopics.TopicActivityFeed)
 	defer unsub()
 
 	ctx := c.Request().Context()
@@ -99,7 +100,7 @@ func (f *feedRoutes) handleActivitySSE(c echo.Context) error {
 
 // BroadcastActivity publishes an activity event to the SSE feed.
 func BroadcastActivity(broker *tavern.SSEBroker, e demo.ActivityEvent) {
-	if !broker.HasSubscribers(tavern.TopicActivityFeed) {
+	if !broker.HasSubscribers(ssetopics.TopicActivityFeed) {
 		return
 	}
 	buf := statsBufPool.Get().(*bytes.Buffer)
@@ -110,7 +111,7 @@ func BroadcastActivity(broker *tavern.SSEBroker, e demo.ActivityEvent) {
 	}
 	msg := tavern.NewSSEMessage("activity-event", buf.String()).String()
 	statsBufPool.Put(buf)
-	broker.Publish(tavern.TopicActivityFeed, msg)
+	broker.Publish(ssetopics.TopicActivityFeed, msg)
 }
 
 // --- Simulated activity ---
@@ -148,7 +149,7 @@ func (ar *appRoutes) publishActivityEvents(actLog *demo.ActivityLog, broker *tav
 		case <-ar.ctx.Done():
 			return
 		case <-time.After(delay):
-			if !broker.HasSubscribers(tavern.TopicActivityFeed) {
+			if !broker.HasSubscribers(ssetopics.TopicActivityFeed) {
 				continue
 			}
 			tmpl := activityTemplates[rand.IntN(len(activityTemplates))]

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -14,6 +14,7 @@ import (
 	"github.com/catgoose/promolog"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/shared"
+	"catgoose/dothog/internal/ssetopics"
 	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
@@ -166,7 +167,7 @@ func handleErrorTracesSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
 		c.Response().WriteHeader(http.StatusOK)
 
 		flusher := c.Response().Writer.(http.Flusher)
-		ch, unsub := broker.Subscribe(tavern.TopicErrorTraces)
+		ch, unsub := broker.Subscribe(ssetopics.TopicErrorTraces)
 		defer unsub()
 
 		ctx := c.Request().Context()
@@ -186,7 +187,7 @@ func handleErrorTracesSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
 }
 
 func broadcastErrorTrace(broker *tavern.SSEBroker, summary promolog.TraceSummary) {
-	if !broker.HasSubscribers(tavern.TopicErrorTraces) {
+	if !broker.HasSubscribers(ssetopics.TopicErrorTraces) {
 		return
 	}
 	buf := new(bytes.Buffer)
@@ -195,7 +196,7 @@ func broadcastErrorTrace(broker *tavern.SSEBroker, summary promolog.TraceSummary
 		return
 	}
 	msg := tavern.NewSSEMessage("error-trace", buf.String()).String()
-	broker.Publish(tavern.TopicErrorTraces, msg)
+	broker.Publish(ssetopics.TopicErrorTraces, msg)
 }
 
 // setup:feature:sse:end

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -14,6 +14,7 @@ import (
 	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/internal/shared"
+	"catgoose/dothog/internal/ssetopics"
 	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
@@ -132,7 +133,7 @@ func (p *peopleRoutes) handlePersonUpdate(c echo.Context) error {
 }
 
 func (p *peopleRoutes) broadcastPersonUpdate(person demo.Person) {
-	topic := fmt.Sprintf("%s-%d", tavern.TopicPeopleUpdate, person.ID)
+	topic := fmt.Sprintf("%s-%d", ssetopics.TopicPeopleUpdate, person.ID)
 	if !p.broker.HasSubscribers(topic) {
 		return
 	}
@@ -152,7 +153,7 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 400, "Invalid person ID", err)
 	}
-	topic := fmt.Sprintf("%s-%d", tavern.TopicPeopleUpdate, id)
+	topic := fmt.Sprintf("%s-%d", ssetopics.TopicPeopleUpdate, id)
 
 	c.Response().Header().Set("Content-Type", "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "no-cache")

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -15,6 +15,7 @@ import (
 
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/shared"
+	"catgoose/dothog/internal/ssetopics"
 	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
@@ -72,7 +73,7 @@ func handleSSESystem(broker *tavern.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		ch, unsub := broker.Subscribe(tavern.TopicSystemStats)
+		ch, unsub := broker.Subscribe(ssetopics.TopicSystemStats)
 		defer unsub()
 
 		ctx := c.Request().Context()
@@ -115,11 +116,11 @@ func handleSSEDashboard(broker *tavern.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		chMetrics, unsubMetrics := broker.Subscribe(tavern.TopicDashMetrics)
+		chMetrics, unsubMetrics := broker.Subscribe(ssetopics.TopicDashMetrics)
 		defer unsubMetrics()
-		chServices, unsubServices := broker.Subscribe(tavern.TopicDashServices)
+		chServices, unsubServices := broker.Subscribe(ssetopics.TopicDashServices)
 		defer unsubServices()
-		chEvents, unsubEvents := broker.Subscribe(tavern.TopicDashEvents)
+		chEvents, unsubEvents := broker.Subscribe(ssetopics.TopicDashEvents)
 		defer unsubEvents()
 
 		lastSent := make(map[string]time.Time)
@@ -169,7 +170,7 @@ func (ar *appRoutes) publishSystemStats(broker *tavern.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(tavern.TopicSystemStats) {
+			if !broker.HasSubscribers(ssetopics.TopicSystemStats) {
 				continue
 			}
 			stats := tavern.CollectRuntimeStats(start)
@@ -181,7 +182,7 @@ func (ar *appRoutes) publishSystemStats(broker *tavern.SSEBroker) {
 			}
 			msg := tavern.NewSSEMessage("system-stats", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(tavern.TopicSystemStats, msg)
+			broker.Publish(ssetopics.TopicSystemStats, msg)
 		}
 	}
 }
@@ -240,7 +241,7 @@ func (ar *appRoutes) publishMetrics(broker *tavern.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(tavern.TopicDashMetrics) {
+			if !broker.HasSubscribers(ssetopics.TopicDashMetrics) {
 				continue
 			}
 
@@ -395,7 +396,7 @@ func (ar *appRoutes) publishMetrics(broker *tavern.SSEBroker) {
 			}
 			msg := tavern.NewSSEMessage("dashboard-metrics", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(tavern.TopicDashMetrics, msg)
+			broker.Publish(ssetopics.TopicDashMetrics, msg)
 		}
 	}
 }
@@ -451,7 +452,7 @@ func (ar *appRoutes) publishServices(broker *tavern.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-ticker.C:
-			if !broker.HasSubscribers(tavern.TopicDashServices) {
+			if !broker.HasSubscribers(ssetopics.TopicDashServices) {
 				continue
 			}
 
@@ -486,7 +487,7 @@ func (ar *appRoutes) publishServices(broker *tavern.SSEBroker) {
 			}
 			msg := tavern.NewSSEMessage("dashboard-services", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(tavern.TopicDashServices, msg)
+			broker.Publish(ssetopics.TopicDashServices, msg)
 		}
 	}
 }
@@ -534,7 +535,7 @@ func (ar *appRoutes) publishEvents(broker *tavern.SSEBroker) {
 		case <-ar.ctx.Done():
 			return
 		case <-time.After(delay):
-			if !broker.HasSubscribers(tavern.TopicDashEvents) {
+			if !broker.HasSubscribers(ssetopics.TopicDashEvents) {
 				continue
 			}
 
@@ -553,7 +554,7 @@ func (ar *appRoutes) publishEvents(broker *tavern.SSEBroker) {
 			}
 			msg := tavern.NewSSEMessage("dashboard-events", buf.String()).String()
 			statsBufPool.Put(buf)
-			broker.Publish(tavern.TopicDashEvents, msg)
+			broker.Publish(ssetopics.TopicDashEvents, msg)
 		}
 	}
 }

--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -11,6 +11,7 @@ import (
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/web/views"
 	// setup:feature:session_settings:end
+	"catgoose/dothog/internal/ssetopics"
 	"github.com/catgoose/tavern"
 
 	// setup:feature:session_settings:start
@@ -50,9 +51,9 @@ func (ar *appRoutes) handleTheme(broker *tavern.SSEBroker) echo.HandlerFunc {
 		}
 
 		// Broadcast theme change to all connected browsers.
-		if broker.HasSubscribers(tavern.TopicThemeChange) {
+		if broker.HasSubscribers(ssetopics.TopicThemeChange) {
 			msg := tavern.NewSSEMessage("theme-change", theme).String()
-			broker.Publish(tavern.TopicThemeChange, msg)
+			broker.Publish(ssetopics.TopicThemeChange, msg)
 		}
 
 		return handler.RenderComponent(c, views.ThemeChanged(theme))
@@ -97,7 +98,7 @@ func handleSSETheme(broker *tavern.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		ch, unsub := broker.Subscribe(tavern.TopicThemeChange)
+		ch, unsub := broker.Subscribe(ssetopics.TopicThemeChange)
 		defer unsub()
 
 		ctx := c.Request().Context()

--- a/internal/ssetopics/topics.go
+++ b/internal/ssetopics/topics.go
@@ -1,0 +1,15 @@
+// setup:feature:sse
+
+package ssetopics
+
+const (
+	TopicSystemStats  = "system-stats"
+	TopicDashMetrics  = "dashboard-metrics"
+	TopicDashServices = "dashboard-services"
+	TopicDashEvents   = "dashboard-events"
+	TopicPeopleUpdate = "people-update"
+	TopicActivityFeed = "activity-feed"
+	TopicErrorTraces  = "error-traces"
+	TopicThemeChange  = "theme-change"
+	TopicCanvasUpdate = "canvas-update"
+)


### PR DESCRIPTION
Tavern v0.3.0 moved topic constants out of the library into example_test.go.
This defines dothog-specific SSE topic constants in internal/ssetopics where
they belong, and updates all route files to use them.