### PR TITLE
fix: remove dothog-specific CI files from derived apps during setup

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -529,6 +529,8 @@ func removeOptionalContent(dir string, opts Options) error {
 	_ = os.RemoveAll(filepath.Join(dir, "scripts"))
 	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "screenshots.yml"))
 	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "docs.yml"))
+	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "pipeline.yml"))
+	_ = os.RemoveAll(filepath.Join(dir, ".github", "harmony"))
 
 	// Create docs/screenshots/ for derived app documentation assets (#355).
 	screenshotsDir := filepath.Join(dir, "docs", "screenshots")

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -475,6 +475,9 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	assertDirRemoved(t, filepath.Join(dest, "scripts"))
 	_, err = os.Stat(filepath.Join(dest, ".github", "workflows", "screenshots.yml"))
 	require.True(t, os.IsNotExist(err), "screenshots.yml should be removed during setup")
+	_, err = os.Stat(filepath.Join(dest, ".github", "workflows", "pipeline.yml"))
+	require.True(t, os.IsNotExist(err), "pipeline.yml should be removed during setup (#367)")
+	assertDirRemoved(t, filepath.Join(dest, ".github", "harmony"))
 
 	// db/gen_seed should be removed when demo not selected (#358)
 	assertDirRemoved(t, filepath.Join(dest, "db", "gen_seed"))


### PR DESCRIPTION
Removes pipeline.yml, docs.yml, and .github/harmony/ during setup. Derived apps should configure their own CI. release.yml is kept as it's generic enough.

Closes #367