### PR TITLE
fix: replace capitalized Dothog/DOTHOG references in harmony sync

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -342,6 +342,8 @@ jobs:
 
           # Scrub binary name references (workflows, Dockerfile, and files with literal "dothog")
           sed -i 's/dothog/harmony/g' .github/workflows/*.yml Dockerfile magefile.go internal/logger/logger.go
+          find . -not -name '*.go' -not -name '*.templ' -type f -exec grep -l 'Dothog' {} + | xargs -r sed -i 's/Dothog/Harmony/g'
+          find . -not -name '*.go' -not -name '*.templ' -type f -exec grep -l 'DOTHOG' {} + | xargs -r sed -i 's/DOTHOG/HARMONY/g'
 
       - name: Push to harmony
         run: |


### PR DESCRIPTION
## Summary

- The harmony CI test `TestSetup_NoDothogReferences` fails because `web/assets/public/index.html` still contains "Dothog" after the sync step
- The existing `sed` on line 344 only replaces lowercase `dothog` in specific files
- Adds `find`+`sed` steps to replace `Dothog` → `Harmony` and `DOTHOG` → `HARMONY` in all non-`.go`/`.templ` files (those are already handled by the module path replacement)

## Test plan

- [ ] Verify harmony sync CI job passes
- [ ] Verify `TestSetup_NoDothogReferences` passes in harmony's CI after sync