### PR TITLE
Don't create docs/screenshots/ in derived apps

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -538,11 +538,6 @@ func removeOptionalContent(dir string, opts Options) error {
 	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "pipeline.yml"))
 	_ = os.RemoveAll(filepath.Join(dir, ".github", "harmony"))
 
-	// Create docs/screenshots/ for derived app documentation assets (#355).
-	screenshotsDir := filepath.Join(dir, "docs", "screenshots")
-	_ = os.MkdirAll(screenshotsDir, 0755)
-	_ = os.WriteFile(filepath.Join(screenshotsDir, ".gitkeep"), []byte(""), 0644)
-
 	// Remove dothog-specific docs that are not relevant to derived apps (#355).
 	// Keep SETUP.md (universal); remove docs that describe dothog's demo architecture.
 	_ = os.Remove(filepath.Join(dir, "docs", "HAL.md"))

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -413,9 +413,6 @@ func TestSetup_FeaturesAll(t *testing.T) {
 	assertDirExists(t, filepath.Join(dest, "internal", "service", "graph"))
 	assertDirExists(t, filepath.Join(dest, "internal", "demo"))
 
-	// docs/screenshots/ should exist (#355)
-	assertDirExists(t, filepath.Join(dest, "docs", "screenshots"))
-
 	// e2e smoke test should exist (#356)
 	_, err = os.Stat(filepath.Join(dest, "e2e", "smoke.spec.ts"))
 	require.NoError(t, err, "smoke.spec.ts should exist after setup")


### PR DESCRIPTION
Closes #374. The screenshots workflow and script are already removed during setup, so the empty directory serves no purpose. Derived apps can add it themselves if needed.