### PR TITLE
fix: remove stale docs and setup artifacts from derived apps

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -548,6 +548,15 @@ func removeOptionalContent(dir string, opts Options) error {
 	_ = os.Remove(filepath.Join(dir, "docs", "mkdocs.yml"))
 	_ = os.RemoveAll(filepath.Join(dir, "docs", "audit"))
 
+	// Remove auto-generated package docs and demo screenshots (#377).
+	// Derived apps can regenerate their own if needed.
+	_ = os.RemoveAll(filepath.Join(dir, "docs", "packages"))
+	_ = os.RemoveAll(filepath.Join(dir, "docs", "screenshots"))
+
+	// Remove the setup package itself — it only exists for template setup (#377).
+	_ = os.RemoveAll(filepath.Join(dir, "internal", "setup"))
+	_ = os.Remove(filepath.Join(dir, "tests", "setup_test.go"))
+
 	// Replace demo-specific e2e tests with a minimal smoke suite (#356).
 	// Keep helpers.ts and playwright.config.ts (they contain general utilities
 	// and the binary-name aware config). Remove all demo page spec files and

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -494,6 +494,15 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	}
 	assertDirRemoved(t, filepath.Join(dest, "docs", "audit"))
 
+	// Auto-generated package docs and screenshots should be removed (#377)
+	assertDirRemoved(t, filepath.Join(dest, "docs", "packages"))
+	assertDirRemoved(t, filepath.Join(dest, "docs", "screenshots"))
+
+	// Setup package and setup tests should be removed (#377)
+	assertDirRemoved(t, filepath.Join(dest, "internal", "setup"))
+	_, err = os.Stat(filepath.Join(dest, "tests", "setup_test.go"))
+	require.True(t, os.IsNotExist(err), "tests/setup_test.go should be removed during setup")
+
 	// e2e should contain only smoke test, helpers, and config (#356)
 	e2eEntries, err := os.ReadDir(filepath.Join(dest, "e2e"))
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #377

Adds removal of four stale artifact paths in `removeOptionalContent()`:

- `docs/packages/` -- auto-generated gomarkdoc output from dothog
- `docs/screenshots/` -- demo screenshots that get copied but never cleaned
- `internal/setup/` -- the setup package itself, only needed during template setup
- `tests/setup_test.go` -- setup integration tests not relevant to derived apps

Test assertions added to `TestSetup_FeaturesNone`.