### PR TITLE
feat: enhance README template with new sections

### DIFF
--- a/_template_setup/README.template.md
+++ b/_template_setup/README.template.md
@@ -1,127 +1,83 @@
 # {{APP_NAME}}
 
-{{APP_NAME}} is a Go + HTMX application built on the reach-up architecture pattern.
+A server-driven hypermedia web application built with Go, HTMX, and templ. Generated from [dothog](https://github.com/catgoose/dothog) using `mage setup`.
 
-It uses:
+{{APP_NAME}} runs as a single binary with all assets embedded. No external runtime dependencies are required, though environment files (`.env.development`, `.env.sample`) are used to configure the application.
 
-- Go + Echo (web framework)
-- HTMX + templ (type-safe HTML templating)
-- Tailwind CSS + DaisyUI (styling, 30+ themes)
-- Air (live reload)
-- Mage (build automation)
-- Playwright (E2E testing)
+See [PHILOSOPHY.md](PHILOSOPHY.md) for the architectural principles behind the project.
 
-## Features
+## Setup Configuration
+
+This project was generated with the following features enabled:
 
 {{FEATURE_TABLE}}
 
-## Getting Started
+For documentation on each configuration option, see [docs/SETUP.md](docs/SETUP.md).
 
-### Prerequisites
+## Tech Stack
 
-- Go 1.24+
-- Node.js 18+ (for Tailwind, Playwright)
+{{TECH_STACK}}
 
-### Setup
+## Quick Start
 
-```bash
-# Install dependencies
-npm ci
-
-# Start development (live reload)
-go tool mage watch
-```
-
-This will:
-
-- Start templ in watch mode, proxying to `https://localhost:{{APP_TLS_PORT}}` with a local HTTP proxy on `{{TEMPL_HTTP_PORT}}`
-- Run Air to rebuild and restart the Go app
-- Run Tailwind in watch mode
-
-Access {{APP_NAME}} at: `https://localhost:{{APP_TLS_PORT}}`
-
-### Ports
-
-| Service | Port | URL |
-| --- | --- | --- |
-| Echo app (TLS) | {{APP_TLS_PORT}} | `https://localhost:{{APP_TLS_PORT}}` |
-| templ HTTP proxy | {{TEMPL_HTTP_PORT}} | `http://localhost:{{TEMPL_HTTP_PORT}}` |
-| Caddy TLS front | {{CADDY_TLS_PORT}} | `https://localhost:{{CADDY_TLS_PORT}}` |
-
-### Environment Variables
-
-Copy `.env.development` and adjust as needed. Key variables:
-
-| Variable | Description | Default |
-| --- | --- | --- |
-| `SERVER_LISTEN_PORT` | Echo server port | {{APP_TLS_PORT}} |
-| `LOG_LEVEL` | DEBUG, INFO, WARN, ERROR | INFO |
-| `ENABLE_DATABASE` | Enable SQL backend | false |
-| `APP_NAME` | Application display name | {{APP_NAME}} |
+{{QUICK_START}}
 
 ## Architecture
 
-{{APP_NAME}} follows the **reach-up model** -- each layer reaches up to the layer above it rather than importing downward:
+{{APP_NAME}} follows a **reach-up model**: start at HTML and only reach for higher-abstraction tools when the current layer cannot express the intent.
 
 ```
-Behavior    (Alpine.js, Hyperscript)     -- client-side interactivity
-    ^
-Presentation (templ + DaisyUI)            -- type-safe HTML rendering
-    ^
-HTTP        (Echo + HTMX)                 -- routing, hypermedia exchanges
-    ^
-Data        (Go + SQL)                    -- repositories, schema DSL
+                  State               Behavior              Presentation
+           +------------------+----------------------+----------------------+
+  Server   |  Go + SQL        |  HTTP + HTMX         |  templ + DaisyUI     |
+           |  source of truth |  hypermedia controls |  semantic components |
+           +------------------+----------------------+----------------------+
+  Client   |  Alpine.js       |  _hyperscript        |  Tailwind + CSS      |
+           |  view state      |  DOM interactions    |  layout, spacing     |
+           +------------------+----------------------+----------------------+
 ```
 
-Key patterns:
+## Project Structure
 
-- **HATEOAS** -- hypermedia as the engine of application state; navigation and actions are link-driven
-- **Server-rendered** -- templ components produce HTML; HTMX handles partial page updates
-- **Feature-gated** -- code is organized by feature with clean separation for easy extension
-
-{{FEATURE_SECTIONS}}
+```
+.
+├── cmd/                    # CLI entry points
+├── internal/
+│   ├── config/             # Application configuration
+│   ├── database/           # Database connections, schema, repository
+│   ├── domain/             # Domain models
+│   ├── routes/
+│   │   ├── handler/        # Render helpers, error handling
+│   │   ├── middleware/     # Correlation IDs, error handler
+│   │   └── *.go            # Route handlers
+│   └── service/            # Business logic, Graph client
+├── web/
+│   ├── assets/public/      # Static assets (CSS, JS, images)
+│   ├── components/core/    # Reusable templ components
+│   └── views/              # Page-level templ templates
+├── e2e/                    # Playwright E2E tests
+├── docs/                   # Documentation and MkDocs config
+└── .github/workflows/      # CI/CD workflows
+```
 
 ## Development
 
-### Testing
+### Prerequisites
+
+- Go 1.26+ (latest)
+- Node.js 22+ (for Playwright E2E tests)
+
+### Running the Dev Server
 
 ```bash
-go tool mage test             # Run all Go tests
-go tool mage teste2e          # Run Playwright E2E tests
-go tool mage testcoverage     # Coverage report
+go tool mage watch
 ```
 
-### Linting
+This starts templ in watch mode, Air for live reload, and Tailwind in watch mode.
 
-```bash
-go tool mage lint              # Run golangci-lint
-go tool mage fixfieldalignment # Auto-fix struct field alignment
-```
+Access the application at: `https://localhost:{{APP_TLS_PORT}}`
 
-### Building
-
-```bash
-go tool mage build    # Full production build
-go tool mage compile  # Compile Go binary only
-```
-
-### Mage Targets
-
-All targets are run with `go tool mage <target>`:
-
-| Target | Description |
-| --- | --- |
-| `watch` | Start dev mode with live reload |
-| `build` | Full production build |
-| `compile` | Compile Go binary |
-| `test` / `testverbose` / `testcoverage` | Go tests |
-| `teste2e` / `teste2eheaded` / `teste2eui` | Playwright E2E tests |
-| `lint` / `lintwatch` | Lint |
-| `updateassets` | Update frontend assets |
-| `clean` | Remove build artifacts |
-| `setup` | Run the template setup wizard |
-
-## HTTPS Development Setup
+### HTTPS Development Setup
 
 When Caddy is configured, the app uses self-signed certificates for local HTTPS.
 
@@ -142,6 +98,54 @@ sudo update-ca-certificates
 
 1. Right-click `localhost.crt` > Install Certificate
 2. Choose Local Machine > Trusted Root Certification Authorities
+
+## Testing
+
+```bash
+# Go tests
+go tool mage test              # Run all tests
+go tool mage testverbose       # Verbose output
+go tool mage testcoverage      # Coverage report
+go tool mage testrace          # Race condition detection
+go tool mage testwatch         # Auto-run on file changes
+
+# E2E tests (Playwright)
+npm ci                          # Install dependencies
+npx playwright install chromium # Install browser
+go tool mage teste2e            # Run headless
+go tool mage teste2eheaded      # Run with visible browser
+go tool mage teste2eui          # Run with Playwright UI
+
+# Linting
+go tool mage lint              # Run golangci-lint
+go tool mage lintwatch         # Lint on file changes
+```
+
+## Mage Targets
+
+All targets are run with `go tool mage <target>`:
+
+| Target | Description |
+| --- | --- |
+| `watch` | Start dev mode with live reload (Tailwind, templ, Air) |
+| `build` | Full production build |
+| `compile` | Compile Go binary |
+| `templ` / `templwatch` | Run templ / templ in watch mode |
+| `tailwind` / `tailwindwatch` | Build / watch Tailwind CSS |
+| `air` | Start Air live reload |
+| `test*` | Test targets (see Testing section) |
+| `teste2e` / `teste2eheaded` / `teste2eui` | Playwright E2E tests |
+| `lint` / `lintwatch` | Lint / lint on file changes |
+| `updateassets` | Update all frontend assets |
+| `envcheck` | Validate required environment variables |
+
+## Environment Variables
+
+See `.env.sample` for the full list. Key variables:
+
+{{ENV_TABLE}}
+
+{{FEATURE_SECTIONS}}
 
 ## Module
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -336,10 +336,14 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		content = strings.ReplaceAll(content, "{{TEMPL_HTTP_PORT}}", templHTTPPort)
 		content = strings.ReplaceAll(content, "{{CADDY_TLS_PORT}}", caddyTLSPort)
 		content = strings.ReplaceAll(content, "{{APP_NAME}}", opts.AppName)
+		content = strings.ReplaceAll(content, "{{BINARY_NAME}}", binaryName)
 		content = strings.ReplaceAll(content, "{{MODULE_PATH}}", modulePath)
 		content = strings.ReplaceAll(content, "{{TEMPLATE_REF}}", "the template")
 		content = strings.ReplaceAll(content, "{{FEATURE_TABLE}}", buildFeatureTable(opts.Features))
 		content = strings.ReplaceAll(content, "{{FEATURE_SECTIONS}}", buildFeatureSections(opts.Features))
+		content = strings.ReplaceAll(content, "{{TECH_STACK}}", buildTechStack(opts.Features))
+		content = strings.ReplaceAll(content, "{{QUICK_START}}", buildQuickStart(binaryName, appTLSPort))
+		content = strings.ReplaceAll(content, "{{ENV_TABLE}}", buildEnvTable(opts.Features, opts.AppName, appTLSPort))
 		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content), 0644); err != nil {
 			return err
 		}
@@ -1233,6 +1237,131 @@ Capacitor wraps the web app for native iOS/Android deployment. Configuration is 
 		} else {
 			sb.WriteString("Offline mode is enabled with service worker caching and a write queue.\n\n")
 		}
+	}
+
+	return sb.String()
+}
+
+// buildTechStack generates a markdown table of technologies used by the app.
+// Core entries are always included; conditional entries depend on selected features.
+func buildTechStack(features []string) string {
+	expanded := ExpandFeatureDeps(features)
+	keep := make(map[string]bool)
+	for _, f := range expanded {
+		keep[f] = true
+	}
+	for _, f := range ImplicitFeatures {
+		keep[f] = true
+	}
+
+	var sb strings.Builder
+	sb.WriteString("| Component | Purpose |\n")
+	sb.WriteString("| --- | --- |\n")
+
+	// Core (always included)
+	sb.WriteString("| [Go](https://go.dev/) | Application server, single binary output |\n")
+	sb.WriteString("| [Echo](https://echo.labstack.com/) | HTTP routing and middleware |\n")
+	sb.WriteString("| [HTMX](https://htmx.org/) | Hypermedia interactions |\n")
+	sb.WriteString("| [templ](https://templ.guide/) | Type-safe HTML templating |\n")
+	sb.WriteString("| [Tailwind CSS](https://tailwindcss.com/) | Utility-first styling |\n")
+	sb.WriteString("| [DaisyUI](https://daisyui.com/) | Semantic component classes with 30+ themes |\n")
+	sb.WriteString("| [Hyperscript](https://hyperscript.org/) | Client-side DOM interactions |\n")
+	sb.WriteString("| [SQLite](https://www.sqlite.org/) | Embedded database (dev), session storage |\n")
+
+	// Conditional
+	if keep[FeatureMSSQL] {
+		sb.WriteString("| [SQL Server](https://www.microsoft.com/sql-server) | Production database |\n")
+	}
+	if keep[FeaturePostgres] {
+		sb.WriteString("| [PostgreSQL](https://www.postgresql.org/) | Production database |\n")
+	}
+	if keep[FeatureCaddy] {
+		sb.WriteString("| [Caddy](https://caddyserver.com/) | HTTPS reverse proxy |\n")
+	}
+	if keep[FeatureAlpine] {
+		sb.WriteString("| [Alpine.js](https://alpinejs.dev/) | Client-side state management |\n")
+	}
+
+	// Always included (dev tools)
+	sb.WriteString("| [Air](https://github.com/air-verse/air) | Live reload for development |\n")
+	sb.WriteString("| [Mage](https://magefile.org/) | Build automation (Go-based) |\n")
+
+	return sb.String()
+}
+
+// buildQuickStart generates the Quick Start section with binary name and port.
+func buildQuickStart(binaryName, appTLSPort string) string {
+	var sb strings.Builder
+
+	sb.WriteString("### From Source\n\n")
+	sb.WriteString("```bash\n")
+	sb.WriteString("go build -o " + binaryName + " .\n")
+	sb.WriteString("./" + binaryName + "\n")
+	sb.WriteString("```\n\n")
+
+	sb.WriteString("### From Docker\n\n")
+	sb.WriteString("```bash\n")
+	sb.WriteString("docker build -t " + binaryName + " .\n")
+	sb.WriteString("docker run -p " + appTLSPort + ":" + appTLSPort + " " + binaryName + "\n")
+	sb.WriteString("```\n\n")
+
+	sb.WriteString("### From Release Binary\n\n")
+	sb.WriteString("Download the latest release for your platform from the [Releases](../../releases) page:\n\n")
+	sb.WriteString("```bash\n")
+	sb.WriteString("# Linux\n")
+	sb.WriteString("chmod +x " + binaryName + "-linux-amd64\n")
+	sb.WriteString("./" + binaryName + "-linux-amd64\n")
+	sb.WriteString("\n")
+	sb.WriteString("# Windows\n")
+	sb.WriteString(binaryName + "-windows-amd64.exe\n")
+	sb.WriteString("```\n\n")
+
+	sb.WriteString("Override the default port:\n\n")
+	sb.WriteString("```bash\n")
+	sb.WriteString("SERVER_LISTEN_PORT=8080 ./" + binaryName + "-linux-amd64\n")
+	sb.WriteString("```")
+
+	return sb.String()
+}
+
+// buildEnvTable generates a markdown table of environment variables based on features.
+func buildEnvTable(features []string, appName, appTLSPort string) string {
+	expanded := ExpandFeatureDeps(features)
+	keep := make(map[string]bool)
+	for _, f := range expanded {
+		keep[f] = true
+	}
+	for _, f := range ImplicitFeatures {
+		keep[f] = true
+	}
+
+	var sb strings.Builder
+	sb.WriteString("| Variable | Description | Default |\n")
+	sb.WriteString("| --- | --- | --- |\n")
+
+	// Always included
+	sb.WriteString("| `SERVER_LISTEN_PORT` | Echo server port | " + appTLSPort + " |\n")
+	sb.WriteString("| `APP_NAME` | Application name | " + appName + " |\n")
+	sb.WriteString("| `LOG_LEVEL` | DEBUG, INFO, WARN, ERROR | INFO |\n")
+	sb.WriteString("| `ENABLE_DATABASE` | Enable SQL backend | false |\n")
+	sb.WriteString("| `DATABASE_URL` | Database connection string | sqlite:///db/app.db |\n")
+
+	// Auth
+	if keep[FeatureAuth] {
+		sb.WriteString("| `SESSION_SECRET` | Session encryption key | (required with auth) |\n")
+		sb.WriteString("| `OIDC_ISSUER_URL` | OIDC provider issuer URL | -- |\n")
+		sb.WriteString("| `OIDC_CLIENT_ID` | OIDC client ID | -- |\n")
+		sb.WriteString("| `OIDC_CLIENT_SECRET` | OIDC client secret | -- |\n")
+	}
+
+	// CSRF
+	if keep[FeatureCSRF] {
+		sb.WriteString("| `CSRF_ROTATE_PER_REQUEST` | Rotate CSRF token per request | false |\n")
+	}
+
+	// Graph
+	if keep[FeatureGraph] {
+		sb.WriteString("| `ENABLE_PHOTO_DOWNLOAD` | Download user photos from Graph | false |\n")
 	}
 
 	return sb.String()


### PR DESCRIPTION
## Summary

Closes #379

- Rewrites `_template_setup/README.template.md` to match the capstone reference README structure
- Adds `buildTechStack()`, `buildQuickStart()`, and `buildEnvTable()` builder functions in `internal/setup/setup.go`
- New template placeholders: `{{TECH_STACK}}`, `{{QUICK_START}}`, `{{ENV_TABLE}}`, `{{BINARY_NAME}}`
- Tech Stack table includes core entries (Go, Echo, HTMX, templ, etc.) plus conditional entries for MSSQL, PostgreSQL, Caddy, and Alpine.js based on selected features
- Quick Start section uses the binary name and TLS port for source, Docker, and release binary instructions
- Environment Variables table adapts to selected features (auth adds OIDC vars, CSRF adds rotation var, Graph adds photo download var)
- Updated architecture diagram from vertical reach-up to server/client matrix format
- Added static Project Structure tree
- Expanded intro with single-binary note and PHILOSOPHY.md link

## Test plan

- [ ] Run `go test ./internal/setup/` -- all existing tests pass
- [ ] Run `mage setup` with various feature combinations and verify the generated README contains correct Tech Stack, Quick Start, and Environment Variables sections
- [ ] Verify conditional entries appear/disappear correctly (e.g., MSSQL row only when mssql feature selected)
- [ ] Verify `{{BINARY_NAME}}` resolves to lowercase-hyphenated app name in Quick Start section