### PR TITLE
fix: update test assertions to match restructured README template

### DIFF
--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -426,7 +426,7 @@ func TestSetup_FeaturesAll(t *testing.T) {
 	readmeContent := string(readmeBytes)
 	require.Contains(t, readmeContent, "Auth (Crooner)")
 	require.Contains(t, readmeContent, "SSE")
-	require.Contains(t, readmeContent, "## Features")
+	require.Contains(t, readmeContent, "## Setup Configuration")
 	require.Contains(t, readmeContent, "## Architecture")
 }
 
@@ -527,7 +527,7 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	require.NoError(t, err)
 	readmeContent := string(readmeBytes)
 	require.Contains(t, readmeContent, "No Features App")
-	require.Contains(t, readmeContent, "## Features")
+	require.Contains(t, readmeContent, "## Setup Configuration")
 	// Minimal config should still have implicit features (database, alpine)
 	require.Contains(t, readmeContent, "Database (fraggle)")
 }


### PR DESCRIPTION
## Summary

- Update two test assertions in `tests/setup_test.go` that expected `## Features` heading to expect `## Setup Configuration`, matching the restructured README template from #380

## Test plan

- All `TestSetup_*` tests pass locally (`go test ./tests/ -run TestSetup -v -count=1`)