### PR TITLE
fix: correct generated-from link in derived app README

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -329,26 +329,6 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		}
 	}
 
-	templateReadme := filepath.Join(dir, TemplateSetupDir, "README.template.md")
-	if data, err := os.ReadFile(templateReadme); err == nil {
-		content := string(data)
-		content = strings.ReplaceAll(content, "{{APP_TLS_PORT}}", appTLSPort)
-		content = strings.ReplaceAll(content, "{{TEMPL_HTTP_PORT}}", templHTTPPort)
-		content = strings.ReplaceAll(content, "{{CADDY_TLS_PORT}}", caddyTLSPort)
-		content = strings.ReplaceAll(content, "{{APP_NAME}}", opts.AppName)
-		content = strings.ReplaceAll(content, "{{BINARY_NAME}}", binaryName)
-		content = strings.ReplaceAll(content, "{{MODULE_PATH}}", modulePath)
-		content = strings.ReplaceAll(content, "{{TEMPLATE_REF}}", "the template")
-		content = strings.ReplaceAll(content, "{{FEATURE_TABLE}}", buildFeatureTable(opts.Features))
-		content = strings.ReplaceAll(content, "{{FEATURE_SECTIONS}}", buildFeatureSections(opts.Features))
-		content = strings.ReplaceAll(content, "{{TECH_STACK}}", buildTechStack(opts.Features))
-		content = strings.ReplaceAll(content, "{{QUICK_START}}", buildQuickStart(binaryName, appTLSPort))
-		content = strings.ReplaceAll(content, "{{ENV_TABLE}}", buildEnvTable(opts.Features, opts.AppName, appTLSPort))
-		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content), 0644); err != nil {
-			return err
-		}
-	}
-
 	// Legacy --no-caddy flag: remove Caddyfile if requested.
 	// The new Features mechanism handles this too (see removeOptionalContent).
 	if opts.NoCaddy {
@@ -435,6 +415,29 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	// titles, test assertions, doc references, CI workflows, etc.).
 	if err := replaceTemplateNames(dir, binaryName, opts.AppName); err != nil {
 		return fmt.Errorf("replacing template names: %w", err)
+	}
+
+	// Generate the derived app's README from the template.  This runs after
+	// replaceTemplateNames so that the intentional "generated from
+	// catgoose/dothog" reference is not rewritten to the derived app's name.
+	templateReadme := filepath.Join(dir, TemplateSetupDir, "README.template.md")
+	if data, err := os.ReadFile(templateReadme); err == nil {
+		content := string(data)
+		content = strings.ReplaceAll(content, "{{APP_TLS_PORT}}", appTLSPort)
+		content = strings.ReplaceAll(content, "{{TEMPL_HTTP_PORT}}", templHTTPPort)
+		content = strings.ReplaceAll(content, "{{CADDY_TLS_PORT}}", caddyTLSPort)
+		content = strings.ReplaceAll(content, "{{APP_NAME}}", opts.AppName)
+		content = strings.ReplaceAll(content, "{{BINARY_NAME}}", binaryName)
+		content = strings.ReplaceAll(content, "{{MODULE_PATH}}", modulePath)
+		content = strings.ReplaceAll(content, "{{TEMPLATE_REF}}", "["+TemplateModule+"](https://github.com/"+TemplateModule+")")
+		content = strings.ReplaceAll(content, "{{FEATURE_TABLE}}", buildFeatureTable(opts.Features))
+		content = strings.ReplaceAll(content, "{{FEATURE_SECTIONS}}", buildFeatureSections(opts.Features))
+		content = strings.ReplaceAll(content, "{{TECH_STACK}}", buildTechStack(opts.Features))
+		content = strings.ReplaceAll(content, "{{QUICK_START}}", buildQuickStart(binaryName, appTLSPort))
+		content = strings.ReplaceAll(content, "{{ENV_TABLE}}", buildEnvTable(opts.Features, opts.AppName, appTLSPort))
+		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content), 0644); err != nil {
+			return err
+		}
 	}
 
 	if err := removeOptionalContent(dir, opts); err != nil {

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -66,8 +66,11 @@ func TestSetupReplacesAppNameAndModule(t *testing.T) {
 	readmeContent := string(readmeBytes)
 	require.Contains(t, readmeContent, "Test App")
 	require.Contains(t, readmeContent, "12345")
+	require.Contains(t, readmeContent, "catgoose/dothog",
+		"README should reference the source template (catgoose/dothog)")
 	require.NotContains(t, readmeContent, "{{APP_NAME}}")
 	require.NotContains(t, readmeContent, "{{APP_PORT}}")
+	require.NotContains(t, readmeContent, "{{TEMPLATE_REF}}")
 
 	envPath := filepath.Join(dest, ".env.development")
 	envBytes, err := os.ReadFile(envPath)
@@ -103,6 +106,10 @@ func TestSetupReplacesAppNameAndModule(t *testing.T) {
 		}
 		rel, _ := filepath.Rel(dest, path)
 		if strings.HasPrefix(rel, "_template_setup"+string(filepath.Separator)) {
+			return nil
+		}
+		// README.md intentionally references catgoose/dothog as the source template.
+		if rel == "README.md" {
 			return nil
 		}
 		data, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary

- Moved README template generation after `replaceTemplateNames` so the intentional `catgoose/dothog` source reference is not rewritten to the derived app's module path
- Replaced the `{{TEMPLATE_REF}}` placeholder with a proper markdown link to `catgoose/dothog` instead of the vague "the template"
- Updated tests to verify the generated README contains the correct source template reference

## Test plan

- [x] `go test ./tests/ -run TestSetup -v -count=1` — all pass