### PR TITLE
fix: remove docs/ directory from derived apps during setup

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -545,20 +545,10 @@ func removeOptionalContent(dir string, opts Options) error {
 	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "pipeline.yml"))
 	_ = os.RemoveAll(filepath.Join(dir, ".github", "harmony"))
 
-	// Remove dothog-specific docs that are not relevant to derived apps (#355).
-	// Keep SETUP.md (universal); remove docs that describe dothog's demo architecture.
-	_ = os.Remove(filepath.Join(dir, "docs", "HAL.md"))
-	_ = os.Remove(filepath.Join(dir, "docs", "COMPONENTS.md"))
-	_ = os.Remove(filepath.Join(dir, "docs", "LINK_RELATIONS.md"))
-	_ = os.Remove(filepath.Join(dir, "docs", "ARCHITECTURE.md"))
-	_ = os.Remove(filepath.Join(dir, "docs", "index.md"))
-	_ = os.Remove(filepath.Join(dir, "docs", "mkdocs.yml"))
-	_ = os.RemoveAll(filepath.Join(dir, "docs", "audit"))
-
-	// Remove auto-generated package docs and demo screenshots (#377).
-	// Derived apps can regenerate their own if needed.
-	_ = os.RemoveAll(filepath.Join(dir, "docs", "packages"))
-	_ = os.RemoveAll(filepath.Join(dir, "docs", "screenshots"))
+	// Remove the entire docs/ directory — it contains only dothog-specific
+	// documentation (ARCHITECTURE.md, HAL.md, etc.) that isn't useful in
+	// derived apps.  The generated README is sufficient.
+	_ = os.RemoveAll(filepath.Join(dir, "docs"))
 
 	// Remove the setup package itself — it only exists for template setup (#377).
 	_ = os.RemoveAll(filepath.Join(dir, "internal", "setup"))

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -494,16 +494,8 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	}
 	assertDirRemoved(t, filepath.Join(dest, "fastlane"))
 
-	// Dothog-specific docs should be removed (#355)
-	for _, f := range []string{"HAL.md", "COMPONENTS.md", "LINK_RELATIONS.md", "ARCHITECTURE.md", "index.md", "mkdocs.yml"} {
-		_, err = os.Stat(filepath.Join(dest, "docs", f))
-		require.True(t, os.IsNotExist(err), "docs/%s should be removed during setup", f)
-	}
-	assertDirRemoved(t, filepath.Join(dest, "docs", "audit"))
-
-	// Auto-generated package docs and screenshots should be removed (#377)
-	assertDirRemoved(t, filepath.Join(dest, "docs", "packages"))
-	assertDirRemoved(t, filepath.Join(dest, "docs", "screenshots"))
+	// Entire docs/ directory should be removed — it's all dothog-specific.
+	assertDirRemoved(t, filepath.Join(dest, "docs"))
 
 	// Setup package and setup tests should be removed (#377)
 	assertDirRemoved(t, filepath.Join(dest, "internal", "setup"))


### PR DESCRIPTION
The docs/ directory contains dothog-specific documentation (SETUP.md, ARCHITECTURE.md, HAL.md, COMPONENTS.md, LINK_RELATIONS.md, index.md, mkdocs.yml, audit/, packages/, screenshots/) that isn't useful in derived apps.

Replace individual file/directory removals with a single `os.RemoveAll` for the entire `docs/` directory. The generated README is sufficient documentation for derived apps.