### PR TITLE
fix: derive porter session cookie name from app name

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -323,7 +323,11 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 
 	// setup:feature:session_settings:start
 	if settingsRepo != nil {
-		e.Use(porter.SessionSettingsMiddleware(settingsRepo, nil))
+		var sessCfg porter.SessionConfig
+		if cfg != nil && cfg.AppName != "" {
+			sessCfg.CookieName = cfg.AppName + "_session_id"
+		}
+		e.Use(porter.SessionSettingsMiddleware(settingsRepo, nil, sessCfg))
 	}
 	// setup:feature:session_settings:end
 


### PR DESCRIPTION
## Summary

- Passes a `porter.SessionConfig` with `CookieName` derived from `cfg.AppName` to `SessionSettingsMiddleware`, so each dothog-generated app gets a unique session cookie (e.g. `myapp_session_id`) instead of the hardcoded `porter_session_id`
- Adds nil/empty guards for `cfg` and `cfg.AppName`, falling back to porter's default cookie name when the app name is unavailable

Fixes #385