### PR TITLE
fix: demo feature gating for broker/theme routes and demo.db

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -164,13 +164,14 @@ func (ar *appRoutes) InitRoutes() error {
 	ar.initComponents3Routes()
 	// setup:feature:demo:end
 
-	// setup:feature:demo:start
 	// setup:feature:sse:start
 	ar.broker = tavern.NewSSEBroker()
 	// setup:feature:sse:end
 	// setup:feature:session_settings:start
 	ar.initThemeRoutes(ar.broker)
 	// setup:feature:session_settings:end
+
+	// setup:feature:demo:start
 	ar.initHypermediaRoutes()
 	ar.initHALRoutes()
 	ar.initErrorsRoutes()

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -577,6 +577,14 @@ func removeOptionalContent(dir string, opts Options) error {
 			_ = os.Remove(m)
 		}
 	}
+	// Remove root-level demo.db (and WAL/SHM) when demo feature is not selected.
+	if removeTags[FeatureDemo] {
+		if matches, err := filepath.Glob(filepath.Join(dir, "demo.db*")); err == nil {
+			for _, m := range matches {
+				_ = os.Remove(m)
+			}
+		}
+	}
 
 	// Seed data generation is only relevant when the demo feature is selected.
 	if removeTags[FeatureDemo] {


### PR DESCRIPTION
## Summary
- Move SSE broker initialization and `initThemeRoutes()` outside the `demo` feature block in `internal/routes/routes.go`, gating them on their own features (`sse` and `session_settings` respectively). Previously these were stripped when generating a project without the `demo` feature.
- Add removal of root-level `demo.db` (and WAL/SHM) when the `demo` feature is not selected. The existing glob only covered `db/*.db*` files.

Fixes #384, Fixes #386

## Test plan
- [x] `go test ./...` passes
- [ ] Generate a project without `demo` but with `session_settings` and `sse` -- verify broker init and theme routes are present
- [ ] Generate a project without `demo` -- verify no `demo.db` at root level