### PR TITLE
fix: exclude unnecessary files and directories from mage setup output

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -335,7 +335,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		_ = os.Remove(filepath.Join(dir, "config", "Caddyfile"))
 	}
 
-	// Compose .env.dev and .env.development from the tracked .env.development.
+	// Compose .env.development from the tracked .env.development.
 	// Lines tagged with "# setup:env " are activated (prefix stripped, literal
 	// default removed) and template placeholders are resolved to real ports.
 	envDevPath := filepath.Join(dir, ".env.development")
@@ -348,10 +348,8 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		if !strings.Contains(content, "APP_NAME=") {
 			content += "\n# Application\nAPP_NAME=" + opts.AppName + "\n"
 		}
-		for _, envTarget := range []string{".env.dev", ".env.development"} {
-			if err := os.WriteFile(filepath.Join(dir, envTarget), []byte(content), 0644); err != nil {
-				return err
-			}
+		if err := os.WriteFile(envDevPath, []byte(content), 0644); err != nil {
+			return err
 		}
 	}
 
@@ -538,7 +536,9 @@ func removeOptionalContent(dir string, opts Options) error {
 	_ = os.Remove(filepath.Join(dir, "AGENTS.md"))
 	_ = os.Remove(filepath.Join(dir, "README.harmony.md"))
 
-	// Remove dothog-specific scripts (doc generation, screenshot automation).
+	// Remove dothog-specific development tooling.
+	_ = os.RemoveAll(filepath.Join(dir, "cmd", "testwatcher"))
+	stripTestWatchTarget(filepath.Join(dir, "magefile.go"))
 	_ = os.RemoveAll(filepath.Join(dir, "scripts"))
 	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "screenshots.yml"))
 	_ = os.Remove(filepath.Join(dir, ".github", "workflows", "docs.yml"))
@@ -800,6 +800,19 @@ func parseFeatureBlockEnd(trimmed string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// stripTestWatchTarget removes the TestWatch mage target from the generated
+// magefile. The function and its doc comment reference cmd/testwatcher which
+// is only present in the dothog development tree.
+func stripTestWatchTarget(magePath string) {
+	data, err := os.ReadFile(magePath)
+	if err != nil {
+		return
+	}
+	re := regexp.MustCompile(`(?ms)^// TestWatch runs tests.*?^}\n`)
+	cleaned := re.ReplaceAllString(string(data), "")
+	_ = os.WriteFile(magePath, []byte(cleaned), 0644)
 }
 
 // collapseBlankLines collapses runs of 3+ blank lines down to 2.

--- a/mage_setup.go
+++ b/mage_setup.go
@@ -161,13 +161,7 @@ func Setup() error {
 		if err := os.MkdirAll(filepath.Dir(absTarget), 0755); err != nil {
 			return err
 		}
-		// Ensure node_modules are present before copying
-		if _, err := os.Stat("package-lock.json"); err == nil {
-			if err := sh.Run("npm", "ci"); err != nil {
-				return fmt.Errorf("npm ci: %w", err)
-			}
-		}
-		if err := setup.CopyRepoTo(".", absTarget, []string{".git", "bin", "build", "tmp"}); err != nil {
+		if err := setup.CopyRepoTo(".", absTarget, []string{".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp"}); err != nil {
 			return fmt.Errorf("copying template: %w", err)
 		}
 		gitInit, _ := huhConfirm("Run git init in the new directory?")

--- a/magefile.go
+++ b/magefile.go
@@ -666,15 +666,8 @@ func SetupTo(dest, appName string) error {
 		}
 	}
 
-	// Ensure node_modules are present before copying
-	if _, err := os.Stat(filepath.Join(src, "package-lock.json")); err == nil {
-		if err := sh.Run("npm", "ci"); err != nil {
-			return fmt.Errorf("npm ci: %w", err)
-		}
-	}
-
 	fmt.Printf("Copying template to %s...\n", absDest)
-	if err := setup.CopyRepoTo(src, absDest, []string{".git", "bin", "build", "tmp"}); err != nil {
+	if err := setup.CopyRepoTo(src, absDest, []string{".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp"}); err != nil {
 		return fmt.Errorf("copy: %w", err)
 	}
 

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -24,7 +24,7 @@ func TestSetupReplacesAppNameAndModule(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -130,7 +130,7 @@ func TestSetupUsesRandomPortWhenPOmitted(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -324,7 +324,7 @@ func TestSetup_NoBareBinaryInGitignore(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -363,7 +363,7 @@ func TestSetup_MageSetupAndInternalSetupRemovable(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	// Remove setup-only files before running setup (mimics the copy flow in mage_setup.go)
@@ -398,7 +398,7 @@ func TestSetup_FeaturesAll(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	features := make([]string, len(setup.AllFeatures))
@@ -443,7 +443,7 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -545,7 +545,7 @@ func TestSetup_FeaturesAuthOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -582,7 +582,7 @@ func TestSetup_FeaturesDatabaseOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	// database is implicit — no need to pass it explicitly; MSSQL not selected
@@ -611,7 +611,7 @@ func TestSetup_FeaturesMSSQL(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	// database is implicit; explicitly selecting mssql adds MSSQL support
@@ -637,7 +637,7 @@ func TestSetup_FeaturesSSECaddy(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -666,7 +666,7 @@ func TestSetup_FeaturesDemo(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -695,7 +695,7 @@ func TestSetup_PWAWithoutCapacitor(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	err = setup.Run(context.Background(), dest, setup.Options{
@@ -729,7 +729,7 @@ func TestSetup_NoDothogReferences(t *testing.T) {
 	require.NoError(t, err)
 
 	dest := setupTempDir(t)
-	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", "bin", "build", "log", "tmp", "node_modules")
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
 	require.NoError(t, err)
 
 	// Remove setup-only files (mimics the copy flow in mage_setup.go).


### PR DESCRIPTION
## Summary

- Add `.claude`, `.cursor`, `node_modules`, `log`, `build`, `test-results` to the `CopyRepoTo` exclusion list so these directories are not copied to generated projects
- Remove `cmd/testwatcher` directory and strip the `TestWatch` mage target during setup (dothog-only development tooling)
- Stop generating `.env.dev` during setup -- only `.env.development` is written since dio normalizes "dev" to "development", making `.env.dev` unused
- Remove pre-copy `npm ci` calls that were populating `node_modules` for copying; `setup.Run` already has a failsafe that runs `npm ci` when `node_modules` is missing in the target directory
- Update test helper exclusion lists to match

Fixes #387, Fixes #388, Fixes #389, Fixes #390, Fixes #392, Fixes #393, Fixes #394