### PR TITLE
fix: remove unused mage/sh import from mage_setup.go

### DIFF
--- a/mage_setup.go
+++ b/mage_setup.go
@@ -16,7 +16,6 @@ import (
 	"catgoose/dothog/internal/setup"
 
 	"github.com/charmbracelet/huh"
-	"github.com/magefile/mage/sh"
 )
 
 const templateModulePath = "catgoose/dothog"


### PR DESCRIPTION
## Summary

- Remove unused `github.com/magefile/mage/sh` import from `mage_setup.go` that was left behind after the `sh.Run("npm", "ci")` call was removed in a prior commit
- Fixes the CI pipeline failure in the mage compile step

## Test plan

- [ ] CI pipeline passes (mage compile step no longer fails)
- [ ] `go build -tags mage ./...` succeeds
- [ ] `go vet -tags mage ./...` succeeds