### PR TITLE
fix: replace .env.dev references with .env.development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ go.work.sum
 
 # env files (.env.sample is tracked)
 .env
-.env.dev
+.env.development
 .env.local
 
 # Editor/IDE

--- a/README.harmony.md
+++ b/README.harmony.md
@@ -100,7 +100,7 @@ Harmony is designed to be used as a project template. After cloning:
 
    Supports flags for non-interactive use: `go tool mage setup -n "My App" -m "github.com/you/my-app" -p 5124`
 
-2. Review `.env.dev` (generated from `.env.sample`) and adjust as needed.
+2. Review `.env.development` (generated from `.env.sample`) and adjust as needed.
 
 4. Start development:
 


### PR DESCRIPTION
## Summary

- Replace `.env.dev` with `.env.development` in `.gitignore` (line 30)
- Replace `.env.dev` with `.env.development` in `README.harmony.md` (line 103)

dio normalizes "dev" to "development", making `.env.dev` redundant. Setup already stopped generating `.env.dev` -- this cleans up the remaining stale references in tracked files.

## Test plan

- [x] `go test ./...` passes
- [x] Grep confirms no remaining `.env.dev` references in tracked files