### PR TITLE
Remove unused admininfo package

### DIFF
--- a/internal/routes/routes_admin_core.go
+++ b/internal/routes/routes_admin_core.go
@@ -26,7 +26,6 @@ func (ar *appRoutes) initAdminCoreRoutes() {
 	ar.e.GET("/admin/debug", handler.HandleComponent(views.AdminDebugPage()))
 	// setup:feature:demo:start
 	ar.e.GET("/admin/system", ar.handleSystemInfo)
-	ar.e.GET("/admin/system/check-update", ar.handleCheckUpdate)
 	ar.e.GET("/admin/config", ar.handleConfigInfo)
 	// setup:feature:demo:end
 	// setup:feature:session_settings:start
@@ -71,16 +70,6 @@ func (ar *appRoutes) handleSystemInfo(c echo.Context) error {
 	}
 
 	return handler.RenderBaseLayout(c, views.AdminSystemPage(info))
-}
-
-func (ar *appRoutes) handleCheckUpdate(c echo.Context) error {
-	info, err := version.CheckLatest(c.Request().Context())
-	if err != nil {
-		return handler.RenderComponent(c, views.UpdateCheckResult(version.UpdateInfo{
-			Current: version.Version,
-		}, err))
-	}
-	return handler.RenderComponent(c, views.UpdateCheckResult(info, nil))
 }
 
 func (ar *appRoutes) handleConfigInfo(c echo.Context) error {

--- a/internal/routes/routes_user_settings.go
+++ b/internal/routes/routes_user_settings.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"sync"
 
-	"catgoose/dothog/internal/admininfo"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/web/views"
 
@@ -18,8 +17,8 @@ import (
 // Applications should replace this with their own persistence.
 var prefsStore = struct {
 	sync.RWMutex
-	m map[string]admininfo.UserPreferences
-}{m: make(map[string]admininfo.UserPreferences)}
+	m map[string]views.UserPreferences
+}{m: make(map[string]views.UserPreferences)}
 
 func (ar *appRoutes) initUserSettingsRoutes() {
 	ar.e.GET("/user/settings", ar.handleUserSettings)
@@ -37,7 +36,7 @@ func (ar *appRoutes) handleUserSettingsSave(c echo.Context) error {
 		pageSize = 20
 	}
 
-	prefs := admininfo.UserPreferences{
+	prefs := views.UserPreferences{
 		PageSize:             pageSize,
 		DateFormat:           c.FormValue("date_format"),
 		CompactTables:        c.FormValue("compact_tables") == "true",
@@ -58,13 +57,13 @@ func (ar *appRoutes) handleUserSettingsSave(c echo.Context) error {
 	return handler.RenderComponent(c, views.UserSettingsSaved())
 }
 
-func getUserPrefs(c echo.Context) admininfo.UserPreferences {
+func getUserPrefs(c echo.Context) views.UserPreferences {
 	sessionID := porter.GetSessionSettings(c).SessionUUID
 	prefsStore.RLock()
 	prefs, ok := prefsStore.m[sessionID]
 	prefsStore.RUnlock()
 	if !ok {
-		return admininfo.DefaultUserPreferences()
+		return views.DefaultUserPreferences()
 	}
 	return prefs
 }

--- a/web/views/admin_core.templ
+++ b/web/views/admin_core.templ
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/admininfo"
-	"catgoose/dothog/internal/version"
 	// setup:feature:demo:end
 )
 
@@ -21,21 +20,7 @@ templ AdminSystemPage(info admininfo.SystemInfo) {
 		<div class="card bg-base-100 shadow border border-base-300">
 			<div class="card-body p-4">
 				<h2 class="card-title text-base">Version</h2>
-				<div class="flex items-center gap-4">
-					@systemStat("Current", info.Version)
-					<div id="update-check-result">
-						<button
-							class="btn btn-sm btn-outline"
-							hx-get="/admin/system/check-update"
-							hx-target="#update-check-result"
-							hx-swap="innerHTML"
-							hx-indicator="this"
-						>
-							<span class="htmx-indicator loading loading-spinner loading-xs"></span>
-							Check for Updates
-						</button>
-					</div>
-				</div>
+				@systemStat("Current", info.Version)
 			</div>
 		</div>
 
@@ -74,7 +59,7 @@ templ AdminSystemPage(info admininfo.SystemInfo) {
 				<h2 class="card-title text-base">GC & Allocator</h2>
 				<div class="grid grid-cols-2 md:grid-cols-4 gap-4">
 					@systemStat("GC Cycles", fmt.Sprintf("%d", info.GCCycles))
-					@systemStat("Last Pause", fmt.Sprintf("%d \u00b5s", info.LastPauseMicros))
+					@systemStat("Last Pause", fmt.Sprintf("%d µs", info.LastPauseMicros))
 					@systemStat("Next GC At", info.NextGCMB)
 					@systemStat("Heap Objects", fmt.Sprintf("%d", info.HeapObjects))
 					@systemStat("Live Objects", fmt.Sprintf("%d", info.LiveObjects))
@@ -89,34 +74,6 @@ templ systemStat(label, value string) {
 		<div class="stat-title text-xs">{ label }</div>
 		<div class="stat-value text-sm font-mono">{ value }</div>
 	</div>
-}
-
-// UpdateCheckResult renders the HTMX fragment returned by the update check endpoint.
-templ UpdateCheckResult(info version.UpdateInfo, err error) {
-	if err != nil {
-		<div class="alert alert-warning text-sm py-2">
-			<span>Failed to check for updates: { err.Error() }</span>
-		</div>
-	} else if info.NewerAvail {
-		<div class="alert alert-info text-sm py-2">
-			<div class="flex flex-col gap-1">
-				<span>
-					Update available: <strong>{ info.Latest }</strong> (current: { info.Current })
-				</span>
-				<a href={ templ.SafeURL(info.ReleaseURL) } target="_blank" rel="noopener" class="link link-primary text-xs">
-					View release notes
-				</a>
-				<div class="mockup-code text-xs mt-1">
-					<pre><code>docker pull ghcr.io/catgoose/dothog:latest
-docker compose up -d</code></pre>
-				</div>
-			</div>
-		</div>
-	} else {
-		<div class="alert alert-success text-sm py-2">
-			<span>You're running the latest version ({ info.Current }).</span>
-		</div>
-	}
 }
 
 // AdminConfigPage displays application configuration with secrets masked.

--- a/web/views/admin_core_templ.go
+++ b/web/views/admin_core_templ.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/admininfo"
-	"catgoose/dothog/internal/version"
 	// setup:feature:demo:end
 )
 
@@ -42,7 +41,7 @@ func AdminSystemPage(info admininfo.SystemInfo) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><h1 class=\"text-2xl font-bold\">System Information</h1><!-- Version --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Version</h2><div class=\"flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><h1 class=\"text-2xl font-bold\">System Information</h1><!-- Version --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Version</h2>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -50,7 +49,7 @@ func AdminSystemPage(info admininfo.SystemInfo) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div id=\"update-check-result\"><button class=\"btn btn-sm btn-outline\" hx-get=\"/admin/system/check-update\" hx-target=\"#update-check-result\" hx-swap=\"innerHTML\" hx-indicator=\"this\"><span class=\"htmx-indicator loading loading-spinner loading-xs\"></span> Check for Updates</button></div></div></div></div><!-- Runtime --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Runtime</h2><div class=\"grid grid-cols-2 md:grid-cols-4 gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><!-- Runtime --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Runtime</h2><div class=\"grid grid-cols-2 md:grid-cols-4 gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -110,7 +109,7 @@ func AdminSystemPage(info admininfo.SystemInfo) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = systemStat("Last Pause", fmt.Sprintf("%d \u00b5s", info.LastPauseMicros)).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = systemStat("Last Pause", fmt.Sprintf("%d µs", info.LastPauseMicros)).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -162,7 +161,7 @@ func systemStat(label, value string) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 89, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 74, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -175,7 +174,7 @@ func systemStat(label, value string) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 90, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 75, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -184,113 +183,6 @@ func systemStat(label, value string) templ.Component {
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
-		}
-		return nil
-	})
-}
-
-// UpdateCheckResult renders the HTMX fragment returned by the update check endpoint.
-func UpdateCheckResult(info version.UpdateInfo, err error) templ.Component {
-	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
-			return templ_7745c5c3_CtxErr
-		}
-		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-		if !templ_7745c5c3_IsBuffer {
-			defer func() {
-				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err == nil {
-					templ_7745c5c3_Err = templ_7745c5c3_BufErr
-				}
-			}()
-		}
-		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
-		}
-		ctx = templ.ClearChildren(ctx)
-		if err != nil {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"alert alert-warning text-sm py-2\"><span>Failed to check for updates: ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(err.Error())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 98, Col: 51}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</span></div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else if info.NewerAvail {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"alert alert-info text-sm py-2\"><div class=\"flex flex-col gap-1\"><span>Update available: <strong>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(info.Latest)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 104, Col: 44}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</strong> (current: ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var8 string
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(info.Current)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 104, Col: 80}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, ")</span> <a href=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var9 templ.SafeURL
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(info.ReleaseURL))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 106, Col: 44}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" target=\"_blank\" rel=\"noopener\" class=\"link link-primary text-xs\">View release notes</a><div class=\"mockup-code text-xs mt-1\"><pre><code>docker pull ghcr.io/catgoose/dothog:latest docker compose up -d</code></pre></div></div></div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div class=\"alert alert-success text-sm py-2\"><span>You're running the latest version (")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(info.Current)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 117, Col: 58}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, ").</span></div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
 		}
 		return nil
 	})
@@ -313,86 +205,86 @@ func AdminConfigPage(entries []admininfo.ConfigEntry) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var11 == nil {
-			templ_7745c5c3_Var11 = templ.NopComponent
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><h1 class=\"text-2xl font-bold\">Configuration</h1><p class=\"text-sm text-base-content/60\">Current application configuration. Secret values are redacted.</p><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><div class=\"overflow-x-auto\"><table class=\"table table-sm table-zebra w-full\"><thead><tr><th>Key</th><th>Value</th></tr></thead> <tbody>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><h1 class=\"text-2xl font-bold\">Configuration</h1><p class=\"text-sm text-base-content/60\">Current application configuration. Secret values are redacted.</p><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><div class=\"overflow-x-auto\"><table class=\"table table-sm table-zebra w-full\"><thead><tr><th>Key</th><th>Value</th></tr></thead> <tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, e := range entries {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<tr><td class=\"font-mono text-xs\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<tr><td class=\"font-mono text-xs\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var12 string
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(e.Key)
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(e.Key)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 143, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 100, Col: 46}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</td><td class=\"font-mono text-xs\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</td><td class=\"font-mono text-xs\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if e.Value == "***REDACTED***" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span class=\"badge badge-warning badge-sm\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span class=\"badge badge-warning badge-sm\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var13 string
-				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(e.Value)
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(e.Value)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 146, Col: 63}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 103, Col: 63}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else if e.Value == "(not set)" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span class=\"text-base-content/40\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<span class=\"text-base-content/40\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(e.Value)
+				var templ_7745c5c3_Var8 string
+				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(e.Value)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 148, Col: 55}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 105, Col: 55}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				var templ_7745c5c3_Var15 string
-				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(e.Value)
+				var templ_7745c5c3_Var9 string
+				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(e.Value)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 150, Col: 20}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_core.templ`, Line: 107, Col: 20}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td></tr>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</td></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</tbody></table></div></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</tbody></table></div></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -420,12 +312,12 @@ func UserDashboardPage() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var16 == nil {
-			templ_7745c5c3_Var16 = templ.NopComponent
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><h1 class=\"text-2xl font-bold\">Dashboard</h1><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-6 text-center\"><p class=\"text-base-content/60\">This is a placeholder dashboard. Replace it with your application's user-facing content.</p></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><h1 class=\"text-2xl font-bold\">Dashboard</h1><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-6 text-center\"><p class=\"text-base-content/60\">This is a placeholder dashboard. Replace it with your application's user-facing content.</p></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/views/admin_types.go
+++ b/web/views/admin_types.go
@@ -1,5 +1,4 @@
-// Package admininfo provides types for admin dashboard pages.
-package admininfo
+package views
 
 // SystemInfo holds runtime stats for the admin system page.
 type SystemInfo struct {
@@ -32,8 +31,6 @@ type ConfigEntry struct {
 }
 
 // UserPreferences holds per-session user preferences.
-// These are stored in-memory keyed by session cookie; applications should
-// persist them to their own database when needed.
 type UserPreferences struct {
 	PageSize             int
 	DateFormat           string

--- a/web/views/user_settings.templ
+++ b/web/views/user_settings.templ
@@ -2,10 +2,9 @@
 
 package views
 
-import "catgoose/dothog/internal/admininfo"
 
 // UserSettingsPage renders the user preferences dashboard.
-templ UserSettingsPage(prefs admininfo.UserPreferences) {
+templ UserSettingsPage(prefs UserPreferences) {
 	<div class="p-4 space-y-6 max-w-3xl mx-auto">
 		<h1 class="text-2xl font-bold">Preferences</h1>
 		<p class="text-sm text-base-content/60">

--- a/web/views/user_settings_templ.go
+++ b/web/views/user_settings_templ.go
@@ -10,10 +10,8 @@ package views
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "catgoose/dothog/internal/admininfo"
-
 // UserSettingsPage renders the user preferences dashboard.
-func UserSettingsPage(prefs admininfo.UserPreferences) templ.Component {
+func UserSettingsPage(prefs UserPreferences) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {


### PR DESCRIPTION
## Summary

- Moved types (SystemInfo, ConfigEntry, UserPreferences) from `internal/admininfo/` into `web/views/admin_types.go` where they are consumed
- Updated all references in route handlers and templ views to use the relocated types
- Deleted the now-empty `internal/admininfo/` package

Closes #403