### PR TITLE
fix: add missing feature markers and remove unused traits

### DIFF
--- a/internal/admininfo/types.go
+++ b/internal/admininfo/types.go
@@ -1,3 +1,5 @@
+// setup:feature:demo
+
 // Package admininfo provides types for admin dashboard pages.
 package admininfo
 

--- a/internal/domain/traits.go
+++ b/internal/domain/traits.go
@@ -18,13 +18,6 @@ type SoftDelete struct {
 	DeletedAt sql.NullTime `db:"DeletedAt" json:"deletedAt,omitzero"`
 }
 
-// AuditTrail provides CreatedBy, UpdatedBy, and DeletedBy fields for embedding in domain models.
-type AuditTrail struct {
-	CreatedBy sql.NullString `db:"CreatedBy" json:"createdBy,omitzero"`
-	UpdatedBy sql.NullString `db:"UpdatedBy" json:"updatedBy,omitzero"`
-	DeletedBy sql.NullString `db:"DeletedBy" json:"deletedBy,omitzero"`
-}
-
 // Version provides an optimistic concurrency control field for embedding in domain models.
 type Version struct {
 	Version int `db:"Version" json:"version"`
@@ -43,21 +36,6 @@ type Status struct {
 // Notes provides a nullable notes field for embedding in domain models.
 type Notes struct {
 	Notes sql.NullString `db:"Notes" json:"notes,omitzero"`
-}
-
-// UUID provides a unique identifier field for embedding in domain models.
-type UUID struct {
-	UUID string `db:"UUID" json:"uuid"`
-}
-
-// Parent provides a nullable parent reference for tree structures.
-type Parent struct {
-	ParentID sql.NullInt64 `db:"ParentID" json:"parentId,omitzero"`
-}
-
-// Expiry provides a nullable expiration timestamp for embedding in domain models.
-type Expiry struct {
-	ExpiresAt sql.NullTime `db:"ExpiresAt" json:"expiresAt,omitzero"`
 }
 
 // Archive provides a nullable ArchivedAt timestamp for embedding in domain models.

--- a/internal/routes/params/params.go
+++ b/internal/routes/params/params.go
@@ -1,3 +1,5 @@
+// setup:feature:demo
+
 // Package params provides utilities for parsing HTTP request parameters including pagination and filters.
 package params
 

--- a/internal/routes/params/params_test.go
+++ b/internal/routes/params/params_test.go
@@ -1,3 +1,5 @@
+// setup:feature:demo
+
 package params
 
 import (

--- a/internal/routes/sync_version_test.go
+++ b/internal/routes/sync_version_test.go
@@ -1,3 +1,5 @@
+// setup:feature:sync
+
 package routes
 
 import (

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -1,3 +1,5 @@
+// setup:feature:demo
+
 package version
 
 import (


### PR DESCRIPTION
## Summary

- Add `// setup:feature:demo` marker to `internal/admininfo/types.go`, `internal/routes/params/params.go`, `internal/routes/params/params_test.go`, and `internal/version/check.go` so they are stripped when the demo feature is not selected during `mage setup`
- Add `// setup:feature:sync` marker to `internal/routes/sync_version_test.go` to match its already-gated source file
- Remove 4 unused trait structs (AuditTrail, UUID, Parent, Expiry) from `internal/domain/traits.go`; keep the `graph` feature gate since `ToNullString()` is needed by graph-gated `user.go`

Fixes #403, Fixes #404, Fixes #405, Fixes #406, Fixes #407

## Test plan

- [x] `go test ./...` passes with all changes applied
- Verify `mage setup` correctly strips files when demo/sync features are not selected