### PR TITLE
refactor: use form components in views instead of raw markup

### DIFF
--- a/web/components/core/context_templ.go
+++ b/web/components/core/context_templ.go
@@ -99,7 +99,7 @@ func ContextLink(href, label, from string) templ.Component {
 		var templ_7745c5c3_Var3 templ.SafeURL
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(linkwell.FromNav(href, from)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 28, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/context.templ`, Line: 28, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {

--- a/web/views/admin_error_reports_templ.go
+++ b/web/views/admin_error_reports_templ.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // AdminErrorReportsPage is the full page for /admin/error-reports.

--- a/web/views/admin_sessions_templ.go
+++ b/web/views/admin_sessions_templ.go
@@ -89,7 +89,7 @@ func AdminSessionsTable(sessions []porter.SessionSettings) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", s.ID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_sessions.templ`, Line: 45, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_sessions.templ`, Line: 46, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -102,7 +102,7 @@ func AdminSessionsTable(sessions []porter.SessionSettings) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(s.SessionUUID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_sessions.templ`, Line: 46, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_sessions.templ`, Line: 47, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -115,7 +115,7 @@ func AdminSessionsTable(sessions []porter.SessionSettings) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(s.Theme)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_sessions.templ`, Line: 48, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_sessions.templ`, Line: 49, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -128,7 +128,7 @@ func AdminSessionsTable(sessions []porter.SessionSettings) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(formatAge(s.UpdatedAt))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_sessions.templ`, Line: 50, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_sessions.templ`, Line: 51, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {

--- a/web/views/admin_settings_templ.go
+++ b/web/views/admin_settings_templ.go
@@ -11,8 +11,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	"github.com/catgoose/tavern"
 	"fmt"
+	"github.com/catgoose/tavern"
 )
 
 // AdminPanelData holds all data for the admin control panel.

--- a/web/views/app_nav_layout_templ.go
+++ b/web/views/app_nav_layout_templ.go
@@ -9,8 +9,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // AppNavLayout is a responsive page layout with CSS-driven auto-positioning:

--- a/web/views/approvals_templ.go
+++ b/web/views/approvals_templ.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 var approvalStatusBadge = map[string]string{

--- a/web/views/bulk_templ.go
+++ b/web/views/bulk_templ.go
@@ -15,8 +15,8 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // bulkColAttrs builds templ.Attributes for a sortable column header link in the bulk table.

--- a/web/views/catalog_templ.go
+++ b/web/views/catalog_templ.go
@@ -15,8 +15,8 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // CatalogPage is the full page content for /demo/catalog.

--- a/web/views/error_traces_templ.go
+++ b/web/views/error_traces_templ.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 	"github.com/catgoose/promolog"
 )
 

--- a/web/views/hypermedia_controls_fragments_templ.go
+++ b/web/views/hypermedia_controls_fragments_templ.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // GalleryItem is a simple named item for the empty-state demo.

--- a/web/views/hypermedia_controls_templ.go
+++ b/web/views/hypermedia_controls_templ.go
@@ -11,8 +11,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // HypermediaControlsPage is the interactive gallery of every hypermedia control,

--- a/web/views/hypermedia_lists_templ.go
+++ b/web/views/hypermedia_lists_templ.go
@@ -13,8 +13,8 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	"strconv"
 
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // ListsDemoItem is a dummy row for the pagination demo table.

--- a/web/views/hypermedia_realtime_templ.go
+++ b/web/views/hypermedia_realtime_templ.go
@@ -11,8 +11,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	"github.com/catgoose/tavern"
 	"fmt"
+	"github.com/catgoose/tavern"
 )
 
 // RealtimePage is the full-page layout for /hypermedia/realtime.

--- a/web/views/index_templ.go
+++ b/web/views/index_templ.go
@@ -9,8 +9,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // Root template

--- a/web/views/inventory_templ.go
+++ b/web/views/inventory_templ.go
@@ -15,8 +15,8 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // InventoryPage is the full page content for /demo/inventory.

--- a/web/views/kanban_templ.go
+++ b/web/views/kanban_templ.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 var kanbanStatusLabels = map[string]string{

--- a/web/views/people_templ.go
+++ b/web/views/people_templ.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 func PeoplePage(people []demo.Person, total int, bar linkwell.FilterBar, cols []linkwell.TableCol, info linkwell.PageInfo, from string) templ.Component {

--- a/web/views/pwa.templ
+++ b/web/views/pwa.templ
@@ -2,6 +2,8 @@
 
 package views
 
+import components "catgoose/dothog/web/components/core"
+
 // PwaIndexPage renders the PWA landing page with offline data collection forms.
 templ PwaIndexPage() {
 	<div class="p-4 space-y-6 max-w-4xl mx-auto">
@@ -64,20 +66,16 @@ templ PwaSiteInspectionForm() {
 			hx-swap="outerHTML"
 			class="space-y-4"
 		>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Location</span></label>
+			@components.FormField("Location") {
 				<input type="text" name="location" class="input input-bordered w-full" placeholder="Site address or identifier" required/>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Inspector</span></label>
+			}
+			@components.FormField("Inspector") {
 				<input type="text" name="inspector" class="input input-bordered w-full" placeholder="Your name" required/>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Date</span></label>
+			}
+			@components.FormField("Date") {
 				<input type="date" name="date" class="input input-bordered w-full" required/>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Condition</span></label>
+			}
+			@components.FormField("Condition") {
 				<select name="condition" class="select select-bordered w-full" required>
 					<option value="" disabled selected>Select condition</option>
 					<option value="good">Good</option>
@@ -85,15 +83,13 @@ templ PwaSiteInspectionForm() {
 					<option value="poor">Poor</option>
 					<option value="critical">Critical</option>
 				</select>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Notes</span></label>
+			}
+			@components.FormField("Notes") {
 				<textarea name="notes" class="textarea textarea-bordered w-full" rows="4" placeholder="Observations, issues, or follow-up items"></textarea>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Photo Reference</span></label>
+			}
+			@components.FormField("Photo Reference") {
 				<input type="text" name="photo_ref" class="input input-bordered w-full" placeholder="Photo filename or reference number"/>
-			</div>
+			}
 			<div class="flex gap-2">
 				<button type="submit" class="btn btn-primary">Submit Inspection</button>
 				<a href="/pwa" hx-get="/pwa" hx-target="#base-content" hx-swap="innerHTML" hx-push-url="true" class="btn btn-ghost">Cancel</a>
@@ -114,16 +110,13 @@ templ PwaFieldReportForm() {
 			hx-swap="outerHTML"
 			class="space-y-4"
 		>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Reporter</span></label>
+			@components.FormField("Reporter") {
 				<input type="text" name="reporter" class="input input-bordered w-full" placeholder="Your name" required/>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Date</span></label>
+			}
+			@components.FormField("Date") {
 				<input type="date" name="date" class="input input-bordered w-full" required/>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Category</span></label>
+			}
+			@components.FormField("Category") {
 				<select name="category" class="select select-bordered w-full" required>
 					<option value="" disabled selected>Select category</option>
 					<option value="safety">Safety</option>
@@ -132,9 +125,8 @@ templ PwaFieldReportForm() {
 					<option value="quality">Quality</option>
 					<option value="other">Other</option>
 				</select>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Priority</span></label>
+			}
+			@components.FormField("Priority") {
 				<select name="priority" class="select select-bordered w-full" required>
 					<option value="" disabled selected>Select priority</option>
 					<option value="low">Low</option>
@@ -142,15 +134,13 @@ templ PwaFieldReportForm() {
 					<option value="high">High</option>
 					<option value="urgent">Urgent</option>
 				</select>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Description</span></label>
+			}
+			@components.FormField("Description") {
 				<textarea name="description" class="textarea textarea-bordered w-full" rows="4" placeholder="Describe the incident or observation" required></textarea>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Action Taken</span></label>
+			}
+			@components.FormField("Action Taken") {
 				<textarea name="action_taken" class="textarea textarea-bordered w-full" rows="3" placeholder="Corrective actions or next steps"></textarea>
-			</div>
+			}
 			<div class="flex gap-2">
 				<button type="submit" class="btn btn-primary">Submit Report</button>
 				<a href="/pwa" hx-get="/pwa" hx-target="#base-content" hx-swap="innerHTML" hx-push-url="true" class="btn btn-ghost">Cancel</a>
@@ -171,22 +161,18 @@ templ PwaNotesForm() {
 			hx-swap="outerHTML"
 			class="space-y-4"
 		>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Author</span></label>
+			@components.FormField("Author") {
 				<input type="text" name="author" class="input input-bordered w-full" placeholder="Your name" required/>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Subject</span></label>
+			}
+			@components.FormField("Subject") {
 				<input type="text" name="subject" class="input input-bordered w-full" placeholder="Brief subject line" required/>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Body</span></label>
+			}
+			@components.FormField("Body") {
 				<textarea name="body" class="textarea textarea-bordered w-full" rows="6" placeholder="Your notes" required></textarea>
-			</div>
-			<div class="form-control">
-				<label class="label"><span class="label-text">Tags</span></label>
+			}
+			@components.FormField("Tags") {
 				<input type="text" name="tags" class="input input-bordered w-full" placeholder="Comma-separated tags"/>
-			</div>
+			}
 			<div class="flex gap-2">
 				<button type="submit" class="btn btn-primary">Save Notes</button>
 				<a href="/pwa" hx-get="/pwa" hx-target="#base-content" hx-swap="innerHTML" hx-push-url="true" class="btn btn-ghost">Cancel</a>

--- a/web/views/pwa_templ.go
+++ b/web/views/pwa_templ.go
@@ -10,6 +10,8 @@ package views
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
+import components "catgoose/dothog/web/components/core"
+
 // PwaIndexPage renders the PWA landing page with offline data collection forms.
 func PwaIndexPage() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -84,7 +86,7 @@ func pwaFormCard(href string, title string, desc string, iconPath string) templ.
 		var templ_7745c5c3_Var3 templ.SafeURL
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(href))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 34, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 36, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -97,7 +99,7 @@ func pwaFormCard(href string, title string, desc string, iconPath string) templ.
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(href)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 35, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 37, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -110,7 +112,7 @@ func pwaFormCard(href string, title string, desc string, iconPath string) templ.
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(iconPath)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 45, Col: 88}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 47, Col: 88}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -123,7 +125,7 @@ func pwaFormCard(href string, title string, desc string, iconPath string) templ.
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 48, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 50, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -136,7 +138,7 @@ func pwaFormCard(href string, title string, desc string, iconPath string) templ.
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(desc)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 50, Col: 54}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 52, Col: 54}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -172,7 +174,143 @@ func PwaSiteInspectionForm() templ.Component {
 			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"p-4 max-w-2xl mx-auto space-y-4\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">Site Inspection</h1><p class=\"text-sm text-base-content/60\">Record on-site conditions and observations.</p></div><form hx-post=\"/pwa/inspection\" hx-swap=\"outerHTML\" class=\"space-y-4\"><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Location</span></label> <input type=\"text\" name=\"location\" class=\"input input-bordered w-full\" placeholder=\"Site address or identifier\" required></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Inspector</span></label> <input type=\"text\" name=\"inspector\" class=\"input input-bordered w-full\" placeholder=\"Your name\" required></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Date</span></label> <input type=\"date\" name=\"date\" class=\"input input-bordered w-full\" required></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Condition</span></label> <select name=\"condition\" class=\"select select-bordered w-full\" required><option value=\"\" disabled selected>Select condition</option> <option value=\"good\">Good</option> <option value=\"fair\">Fair</option> <option value=\"poor\">Poor</option> <option value=\"critical\">Critical</option></select></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Notes</span></label> <textarea name=\"notes\" class=\"textarea textarea-bordered w-full\" rows=\"4\" placeholder=\"Observations, issues, or follow-up items\"></textarea></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Photo Reference</span></label> <input type=\"text\" name=\"photo_ref\" class=\"input input-bordered w-full\" placeholder=\"Photo filename or reference number\"></div><div class=\"flex gap-2\"><button type=\"submit\" class=\"btn btn-primary\">Submit Inspection</button> <a href=\"/pwa\" hx-get=\"/pwa\" hx-target=\"#base-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" class=\"btn btn-ghost\">Cancel</a></div></form></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"p-4 max-w-2xl mx-auto space-y-4\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">Site Inspection</h1><p class=\"text-sm text-base-content/60\">Record on-site conditions and observations.</p></div><form hx-post=\"/pwa/inspection\" hx-swap=\"outerHTML\" class=\"space-y-4\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var9 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<input type=\"text\" name=\"location\" class=\"input input-bordered w-full\" placeholder=\"Site address or identifier\" required>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Location").Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<input type=\"text\" name=\"inspector\" class=\"input input-bordered w-full\" placeholder=\"Your name\" required>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Inspector").Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var11 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<input type=\"date\" name=\"date\" class=\"input input-bordered w-full\" required>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Date").Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var12 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<select name=\"condition\" class=\"select select-bordered w-full\" required><option value=\"\" disabled selected>Select condition</option> <option value=\"good\">Good</option> <option value=\"fair\">Fair</option> <option value=\"poor\">Poor</option> <option value=\"critical\">Critical</option></select>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Condition").Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var13 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<textarea name=\"notes\" class=\"textarea textarea-bordered w-full\" rows=\"4\" placeholder=\"Observations, issues, or follow-up items\"></textarea>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Notes").Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<input type=\"text\" name=\"photo_ref\" class=\"input input-bordered w-full\" placeholder=\"Photo filename or reference number\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Photo Reference").Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<div class=\"flex gap-2\"><button type=\"submit\" class=\"btn btn-primary\">Submit Inspection</button> <a href=\"/pwa\" hx-get=\"/pwa\" hx-target=\"#base-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" class=\"btn btn-ghost\">Cancel</a></div></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -197,12 +335,148 @@ func PwaFieldReportForm() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"p-4 max-w-2xl mx-auto space-y-4\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">Field Report</h1><p class=\"text-sm text-base-content/60\">Log incidents, observations, and corrective actions.</p></div><form hx-post=\"/pwa/report\" hx-swap=\"outerHTML\" class=\"space-y-4\"><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Reporter</span></label> <input type=\"text\" name=\"reporter\" class=\"input input-bordered w-full\" placeholder=\"Your name\" required></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Date</span></label> <input type=\"date\" name=\"date\" class=\"input input-bordered w-full\" required></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Category</span></label> <select name=\"category\" class=\"select select-bordered w-full\" required><option value=\"\" disabled selected>Select category</option> <option value=\"safety\">Safety</option> <option value=\"maintenance\">Maintenance</option> <option value=\"environmental\">Environmental</option> <option value=\"quality\">Quality</option> <option value=\"other\">Other</option></select></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Priority</span></label> <select name=\"priority\" class=\"select select-bordered w-full\" required><option value=\"\" disabled selected>Select priority</option> <option value=\"low\">Low</option> <option value=\"medium\">Medium</option> <option value=\"high\">High</option> <option value=\"urgent\">Urgent</option></select></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Description</span></label> <textarea name=\"description\" class=\"textarea textarea-bordered w-full\" rows=\"4\" placeholder=\"Describe the incident or observation\" required></textarea></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Action Taken</span></label> <textarea name=\"action_taken\" class=\"textarea textarea-bordered w-full\" rows=\"3\" placeholder=\"Corrective actions or next steps\"></textarea></div><div class=\"flex gap-2\"><button type=\"submit\" class=\"btn btn-primary\">Submit Report</button> <a href=\"/pwa\" hx-get=\"/pwa\" hx-target=\"#base-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" class=\"btn btn-ghost\">Cancel</a></div></form></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div class=\"p-4 max-w-2xl mx-auto space-y-4\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">Field Report</h1><p class=\"text-sm text-base-content/60\">Log incidents, observations, and corrective actions.</p></div><form hx-post=\"/pwa/report\" hx-swap=\"outerHTML\" class=\"space-y-4\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<input type=\"text\" name=\"reporter\" class=\"input input-bordered w-full\" placeholder=\"Your name\" required>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Reporter").Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var17 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<input type=\"date\" name=\"date\" class=\"input input-bordered w-full\" required>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Date").Render(templ.WithChildren(ctx, templ_7745c5c3_Var17), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<select name=\"category\" class=\"select select-bordered w-full\" required><option value=\"\" disabled selected>Select category</option> <option value=\"safety\">Safety</option> <option value=\"maintenance\">Maintenance</option> <option value=\"environmental\">Environmental</option> <option value=\"quality\">Quality</option> <option value=\"other\">Other</option></select>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Category").Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var19 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<select name=\"priority\" class=\"select select-bordered w-full\" required><option value=\"\" disabled selected>Select priority</option> <option value=\"low\">Low</option> <option value=\"medium\">Medium</option> <option value=\"high\">High</option> <option value=\"urgent\">Urgent</option></select>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Priority").Render(templ.WithChildren(ctx, templ_7745c5c3_Var19), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<textarea name=\"description\" class=\"textarea textarea-bordered w-full\" rows=\"4\" placeholder=\"Describe the incident or observation\" required></textarea>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Description").Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var21 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<textarea name=\"action_taken\" class=\"textarea textarea-bordered w-full\" rows=\"3\" placeholder=\"Corrective actions or next steps\"></textarea>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Action Taken").Render(templ.WithChildren(ctx, templ_7745c5c3_Var21), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"flex gap-2\"><button type=\"submit\" class=\"btn btn-primary\">Submit Report</button> <a href=\"/pwa\" hx-get=\"/pwa\" hx-target=\"#base-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" class=\"btn btn-ghost\">Cancel</a></div></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -227,12 +501,104 @@ func PwaNotesForm() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var10 == nil {
-			templ_7745c5c3_Var10 = templ.NopComponent
+		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var22 == nil {
+			templ_7745c5c3_Var22 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"p-4 max-w-2xl mx-auto space-y-4\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">General Notes</h1><p class=\"text-sm text-base-content/60\">Capture field observations, reminders, and free-form notes.</p></div><form hx-post=\"/pwa/notes\" hx-swap=\"outerHTML\" class=\"space-y-4\"><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Author</span></label> <input type=\"text\" name=\"author\" class=\"input input-bordered w-full\" placeholder=\"Your name\" required></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Subject</span></label> <input type=\"text\" name=\"subject\" class=\"input input-bordered w-full\" placeholder=\"Brief subject line\" required></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Body</span></label> <textarea name=\"body\" class=\"textarea textarea-bordered w-full\" rows=\"6\" placeholder=\"Your notes\" required></textarea></div><div class=\"form-control\"><label class=\"label\"><span class=\"label-text\">Tags</span></label> <input type=\"text\" name=\"tags\" class=\"input input-bordered w-full\" placeholder=\"Comma-separated tags\"></div><div class=\"flex gap-2\"><button type=\"submit\" class=\"btn btn-primary\">Save Notes</button> <a href=\"/pwa\" hx-get=\"/pwa\" hx-target=\"#base-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" class=\"btn btn-ghost\">Cancel</a></div></form></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div class=\"p-4 max-w-2xl mx-auto space-y-4\"><div class=\"space-y-1\"><h1 class=\"text-2xl font-bold\">General Notes</h1><p class=\"text-sm text-base-content/60\">Capture field observations, reminders, and free-form notes.</p></div><form hx-post=\"/pwa/notes\" hx-swap=\"outerHTML\" class=\"space-y-4\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var23 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<input type=\"text\" name=\"author\" class=\"input input-bordered w-full\" placeholder=\"Your name\" required>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Author").Render(templ.WithChildren(ctx, templ_7745c5c3_Var23), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var24 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<input type=\"text\" name=\"subject\" class=\"input input-bordered w-full\" placeholder=\"Brief subject line\" required>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Subject").Render(templ.WithChildren(ctx, templ_7745c5c3_Var24), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var25 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<textarea name=\"body\" class=\"textarea textarea-bordered w-full\" rows=\"6\" placeholder=\"Your notes\" required></textarea>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Body").Render(templ.WithChildren(ctx, templ_7745c5c3_Var25), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var26 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<input type=\"text\" name=\"tags\" class=\"input input-bordered w-full\" placeholder=\"Comma-separated tags\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormField("Tags").Render(templ.WithChildren(ctx, templ_7745c5c3_Var26), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"flex gap-2\"><button type=\"submit\" class=\"btn btn-primary\">Save Notes</button> <a href=\"/pwa\" hx-get=\"/pwa\" hx-target=\"#base-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" class=\"btn btn-ghost\">Cancel</a></div></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -257,25 +623,25 @@ func PwaFormSuccess(message string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var11 == nil {
-			templ_7745c5c3_Var11 = templ.NopComponent
+		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var27 == nil {
+			templ_7745c5c3_Var27 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"p-4 max-w-2xl mx-auto\"><div class=\"card bg-base-200 shadow-sm\"><div class=\"card-body items-center text-center space-y-3\"><div class=\"bg-success/10 rounded-full p-3\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-8 w-8 text-success\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M5 13l4 4L19 7\"></path></svg></div><h2 class=\"card-title text-lg\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"p-4 max-w-2xl mx-auto\"><div class=\"card bg-base-200 shadow-sm\"><div class=\"card-body items-center text-center space-y-3\"><div class=\"bg-success/10 rounded-full p-3\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-8 w-8 text-success\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M5 13l4 4L19 7\"></path></svg></div><h2 class=\"card-title text-lg\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+		var templ_7745c5c3_Var28 string
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 208, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/pwa.templ`, Line: 194, Col: 44}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</h2><p class=\"text-sm text-base-content/60\">Your data has been saved and will sync when online.</p><a href=\"/pwa\" hx-get=\"/pwa\" hx-target=\"#base-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" class=\"btn btn-primary btn-sm\">Back to Forms</a></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</h2><p class=\"text-sm text-base-content/60\">Your data has been saved and will sync when online.</p><a href=\"/pwa\" hx-get=\"/pwa\" hx-target=\"#base-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" class=\"btn btn-primary btn-sm\">Back to Forms</a></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/views/repository_templ.go
+++ b/web/views/repository_templ.go
@@ -15,8 +15,8 @@ import (
 	"strconv"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 // RepositoryPage is the full page for /demo/repository.

--- a/web/views/settings.templ
+++ b/web/views/settings.templ
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
+	components "catgoose/dothog/web/components/core"
 )
 
 var settingsIcons = map[string]string{
@@ -101,10 +102,9 @@ templ SettingsSectionForm(sec demo.SettingsSection) {
 templ settingsField(f demo.SettingField) {
 	switch f.Kind {
 		case "toggle":
-			<label class="flex items-center justify-between max-w-sm cursor-pointer">
-				<span class="text-sm">{ f.Label }</span>
+			@components.FormToggle(f.Label) {
 				<input type="checkbox" name={ f.Key } value="true" class="toggle toggle-sm toggle-primary" checked?={ f.Value == "true" }/>
-			</label>
+			}
 		default:
 			<div class="fieldset max-w-sm">
 				<label class="label py-1">

--- a/web/views/settings_templ.go
+++ b/web/views/settings_templ.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
+	components "catgoose/dothog/web/components/core"
 )
 
 var settingsIcons = map[string]string{
@@ -76,7 +77,7 @@ func SettingsPage(sections []demo.SettingsSection) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(loadURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 37, Col: 22}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 38, Col: 22}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -99,7 +100,7 @@ func SettingsPage(sections []demo.SettingsSection) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(settingsIcons[sec.ID])
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 46, Col: 85}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 47, Col: 85}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -112,7 +113,7 @@ func SettingsPage(sections []demo.SettingsSection) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(sec.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 49, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 50, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -125,7 +126,7 @@ func SettingsPage(sections []demo.SettingsSection) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(sec.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 50, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 51, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -212,7 +213,7 @@ func SettingsSectionForm(sec demo.SettingsSection) templ.Component {
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(sec.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 77, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 78, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -225,7 +226,7 @@ func SettingsSectionForm(sec demo.SettingsSection) templ.Component {
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(sec.Description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 78, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 79, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
@@ -238,7 +239,7 @@ func SettingsSectionForm(sec demo.SettingsSection) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(formID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 79, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 80, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -261,7 +262,7 @@ func SettingsSectionForm(sec demo.SettingsSection) templ.Component {
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(saveURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 88, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 89, Col: 21}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -274,7 +275,7 @@ func SettingsSectionForm(sec demo.SettingsSection) templ.Component {
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs("#" + resultID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 89, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 90, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -287,7 +288,7 @@ func SettingsSectionForm(sec demo.SettingsSection) templ.Component {
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs("#" + formID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 91, Col: 30}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 92, Col: 30}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -300,7 +301,7 @@ func SettingsSectionForm(sec demo.SettingsSection) templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(resultID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 95, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 96, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
@@ -337,48 +338,53 @@ func settingsField(f demo.SettingField) templ.Component {
 		ctx = templ.ClearChildren(ctx)
 		switch f.Kind {
 		case "toggle":
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<label class=\"flex items-center justify-between max-w-sm cursor-pointer\"><span class=\"text-sm\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var18 string
-			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(f.Label)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 105, Col: 35}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</span> <input type=\"checkbox\" name=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var19 string
-			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(f.Key)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 106, Col: 39}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" value=\"true\" class=\"toggle toggle-sm toggle-primary\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if f.Value == "true" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " checked")
+			templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+				if !templ_7745c5c3_IsBuffer {
+					defer func() {
+						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err == nil {
+							templ_7745c5c3_Err = templ_7745c5c3_BufErr
+						}
+					}()
+				}
+				ctx = templ.InitializeContext(ctx)
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<input type=\"checkbox\" name=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "></label>")
+				var templ_7745c5c3_Var19 string
+				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(f.Key)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/settings.templ`, Line: 106, Col: 39}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" value=\"true\" class=\"toggle toggle-sm toggle-primary\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if f.Value == "true" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " checked")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, ">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = components.FormToggle(f.Label).Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		default:
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"fieldset max-w-sm\"><label class=\"label py-1\"><span class=\"label-text text-sm font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<div class=\"fieldset max-w-sm\"><label class=\"label py-1\"><span class=\"label-text text-sm font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -391,13 +397,13 @@ func settingsField(f demo.SettingField) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</span></label> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</span></label> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			switch f.Kind {
 			case "text":
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<input type=\"text\" name=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<input type=\"text\" name=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -410,7 +416,7 @@ func settingsField(f demo.SettingField) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" class=\"input input-sm w-full\" value=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" class=\"input input-sm w-full\" value=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -423,12 +429,12 @@ func settingsField(f demo.SettingField) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			case "select":
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<select name=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<select name=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -441,12 +447,12 @@ func settingsField(f demo.SettingField) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" class=\"select select-sm w-full\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" class=\"select select-sm w-full\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, opt := range f.Options {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<option value=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<option value=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -459,17 +465,17 @@ func settingsField(f demo.SettingField) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					if f.Value == opt {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " selected")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " selected")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, ">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, ">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -482,17 +488,17 @@ func settingsField(f demo.SettingField) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</option>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</option>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</select>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</select>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			case "textarea":
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<textarea name=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<textarea name=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -505,7 +511,7 @@ func settingsField(f demo.SettingField) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" class=\"textarea w-full\" rows=\"3\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\" class=\"textarea w-full\" rows=\"3\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -518,12 +524,12 @@ func settingsField(f demo.SettingField) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</textarea>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</textarea>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -554,7 +560,7 @@ func SettingsSaveResult(ok bool, msg string) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if ok {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<span class=\"text-sm text-success animate-fade-in\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<span class=\"text-sm text-success animate-fade-in\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -567,12 +573,12 @@ func SettingsSaveResult(ok bool, msg string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<span class=\"text-sm text-error\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<span class=\"text-sm text-error\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -585,7 +591,7 @@ func SettingsSaveResult(ok bool, msg string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/web/views/user_settings.templ
+++ b/web/views/user_settings.templ
@@ -2,7 +2,10 @@
 
 package views
 
-import "catgoose/dothog/internal/admininfo"
+import (
+	"catgoose/dothog/internal/admininfo"
+	components "catgoose/dothog/web/components/core"
+)
 
 // UserSettingsPage renders the user preferences dashboard.
 templ UserSettingsPage(prefs admininfo.UserPreferences) {
@@ -40,42 +43,37 @@ templ UserSettingsPage(prefs admininfo.UserPreferences) {
 						</select>
 					</div>
 					<div class="fieldset">
-						<label class="label cursor-pointer justify-start gap-3">
+						@components.FormCheckbox("Compact table rows") {
 							<input type="checkbox" name="compact_tables" value="true" class="checkbox checkbox-sm" checked?={ prefs.CompactTables } />
-							<span class="label-text">Compact table rows</span>
-						</label>
+						}
 					</div>
 					<div class="divider my-0"></div>
 
 					<!-- Notifications -->
 					<h3 class="font-semibold text-sm">Notifications</h3>
 					<div class="fieldset">
-						<label class="label cursor-pointer justify-start gap-3">
+						@components.FormCheckbox("Email me when an error is reported") {
 							<input type="checkbox" name="email_on_error" value="true" class="checkbox checkbox-sm" checked?={ prefs.EmailOnError } />
-							<span class="label-text">Email me when an error is reported</span>
-						</label>
+						}
 					</div>
 					<div class="fieldset">
-						<label class="label cursor-pointer justify-start gap-3">
+						@components.FormCheckbox("Desktop notifications for real-time events") {
 							<input type="checkbox" name="desktop_notifications" value="true" class="checkbox checkbox-sm" checked?={ prefs.DesktopNotifications } />
-							<span class="label-text">Desktop notifications for real-time events</span>
-						</label>
+						}
 					</div>
 					<div class="divider my-0"></div>
 
 					<!-- Accessibility -->
 					<h3 class="font-semibold text-sm">Accessibility</h3>
 					<div class="fieldset">
-						<label class="label cursor-pointer justify-start gap-3">
+						@components.FormCheckbox("Reduce motion and animations") {
 							<input type="checkbox" name="reduce_motion" value="true" class="checkbox checkbox-sm" checked?={ prefs.ReduceMotion } />
-							<span class="label-text">Reduce motion and animations</span>
-						</label>
+						}
 					</div>
 					<div class="fieldset">
-						<label class="label cursor-pointer justify-start gap-3">
+						@components.FormCheckbox("High contrast mode") {
 							<input type="checkbox" name="high_contrast" value="true" class="checkbox checkbox-sm" checked?={ prefs.HighContrast } />
-							<span class="label-text">High contrast mode</span>
-						</label>
+						}
 					</div>
 
 					<div class="flex justify-end gap-2 pt-2">

--- a/web/views/user_settings_templ.go
+++ b/web/views/user_settings_templ.go
@@ -10,7 +10,10 @@ package views
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "catgoose/dothog/internal/admininfo"
+import (
+	"catgoose/dothog/internal/admininfo"
+	components "catgoose/dothog/web/components/core"
+)
 
 // UserSettingsPage renders the user preferences dashboard.
 func UserSettingsPage(prefs admininfo.UserPreferences) templ.Component {
@@ -104,57 +107,187 @@ func UserSettingsPage(prefs admininfo.UserPreferences) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, ">ISO (2026-03-16)</option></select></div><div class=\"fieldset\"><label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" name=\"compact_tables\" value=\"true\" class=\"checkbox checkbox-sm\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, ">ISO (2026-03-16)</option></select></div><div class=\"fieldset\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if prefs.CompactTables {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " checked")
+		templ_7745c5c3_Var2 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<input type=\"checkbox\" name=\"compact_tables\" value=\"true\" class=\"checkbox checkbox-sm\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "> <span class=\"label-text\">Compact table rows</span></label></div><div class=\"divider my-0\"></div><!-- Notifications --><h3 class=\"font-semibold text-sm\">Notifications</h3><div class=\"fieldset\"><label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" name=\"email_on_error\" value=\"true\" class=\"checkbox checkbox-sm\"")
+			if prefs.CompactTables {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, " checked")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormCheckbox("Compact table rows").Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if prefs.EmailOnError {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, " checked")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "> <span class=\"label-text\">Email me when an error is reported</span></label></div><div class=\"fieldset\"><label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" name=\"desktop_notifications\" value=\"true\" class=\"checkbox checkbox-sm\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><div class=\"divider my-0\"></div><!-- Notifications --><h3 class=\"font-semibold text-sm\">Notifications</h3><div class=\"fieldset\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if prefs.DesktopNotifications {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, " checked")
+		templ_7745c5c3_Var3 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<input type=\"checkbox\" name=\"email_on_error\" value=\"true\" class=\"checkbox checkbox-sm\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "> <span class=\"label-text\">Desktop notifications for real-time events</span></label></div><div class=\"divider my-0\"></div><!-- Accessibility --><h3 class=\"font-semibold text-sm\">Accessibility</h3><div class=\"fieldset\"><label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" name=\"reduce_motion\" value=\"true\" class=\"checkbox checkbox-sm\"")
+			if prefs.EmailOnError {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " checked")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormCheckbox("Email me when an error is reported").Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if prefs.ReduceMotion {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " checked")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "> <span class=\"label-text\">Reduce motion and animations</span></label></div><div class=\"fieldset\"><label class=\"label cursor-pointer justify-start gap-3\"><input type=\"checkbox\" name=\"high_contrast\" value=\"true\" class=\"checkbox checkbox-sm\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div><div class=\"fieldset\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if prefs.HighContrast {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " checked")
+		templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<input type=\"checkbox\" name=\"desktop_notifications\" value=\"true\" class=\"checkbox checkbox-sm\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			if prefs.DesktopNotifications {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " checked")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormCheckbox("Desktop notifications for real-time events").Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "> <span class=\"label-text\">High contrast mode</span></label></div><div class=\"flex justify-end gap-2 pt-2\"><button type=\"submit\" class=\"btn btn-sm btn-primary\">Save Preferences</button></div></form><div id=\"settings-result\"></div></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div><div class=\"divider my-0\"></div><!-- Accessibility --><h3 class=\"font-semibold text-sm\">Accessibility</h3><div class=\"fieldset\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var5 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<input type=\"checkbox\" name=\"reduce_motion\" value=\"true\" class=\"checkbox checkbox-sm\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if prefs.ReduceMotion {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " checked")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormCheckbox("Reduce motion and animations").Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div><div class=\"fieldset\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var6 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<input type=\"checkbox\" name=\"high_contrast\" value=\"true\" class=\"checkbox checkbox-sm\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if prefs.HighContrast {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " checked")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = components.FormCheckbox("High contrast mode").Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div><div class=\"flex justify-end gap-2 pt-2\"><button type=\"submit\" class=\"btn btn-sm btn-primary\">Save Preferences</button></div></form><div id=\"settings-result\"></div></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -179,12 +312,12 @@ func UserSettingsSaved() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var2 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var2 == nil {
-			templ_7745c5c3_Var2 = templ.NopComponent
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<div class=\"alert alert-success text-sm mt-2\"><span>Preferences saved.</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div class=\"alert alert-success text-sm mt-2\"><span>Preferences saved.</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/views/vendors_contacts_templ.go
+++ b/web/views/vendors_contacts_templ.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 
 	"catgoose/dothog/internal/demo"
-	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
 )
 
 func VendorContactsPage(vendors []demo.Vendor, bar linkwell.FilterBar) templ.Component {


### PR DESCRIPTION
## Summary

- Replace 14 raw `<div class="form-control">` + `<label>` + `<input>` patterns in `pwa.templ` (3 forms) with `FormField` component calls
- Replace toggle switch markup in `settings.templ` with `FormToggle` component
- Replace 5 checkbox label patterns in `user_settings.templ` with `FormCheckbox` component
- Skipped views where the raw markup uses different wrappers (`fieldset`), different styling (compact `text-xs` labels), or complex child content that doesn't fit the component signatures

All `_templ.go` files regenerated via `templ generate`. Tests pass.

Fixes #420