### PR TITLE
fix: gate Show Issue Email button behind demo feature markers

### DIFF
--- a/web/components/core/error_page.templ
+++ b/web/components/core/error_page.templ
@@ -32,7 +32,9 @@ templ ErrorPage(ec linkwell.ErrorContext) {
 				</div>
 			</div>
 			<div id="report-modal-container"></div>
+			// setup:feature:demo:start
 			<div id="report-email-container"></div>
+			// setup:feature:demo:end
 		</body>
 	</html>
 }

--- a/web/views/app_nav_layout.templ
+++ b/web/views/app_nav_layout.templ
@@ -44,7 +44,9 @@ templ AppNavLayout(content templ.Component, cfg linkwell.NavConfig, csrfToken st
 					{ version }
 				</footer>
 				<div id="report-modal-container"></div>
+				// setup:feature:demo:start
 				<div id="report-email-container"></div>
+				// setup:feature:demo:end
 				// setup:feature:offline:start
 				@components.OfflineIndicator()
 				// setup:feature:offline:end

--- a/web/views/error_traces.templ
+++ b/web/views/error_traces.templ
@@ -109,6 +109,7 @@ templ ErrorTraceDetailContent(trace *promolog.ErrorTrace) {
 			<div class="flex items-start justify-between">
 				<h3 class="text-lg font-semibold">Error Trace Details</h3>
 				<div class="flex gap-1">
+					// setup:feature:demo:start
 					<button
 						class="btn btn-sm btn-warning btn-outline"
 						hx-post={ "/report-issue/" + trace.RequestID }
@@ -116,6 +117,7 @@ templ ErrorTraceDetailContent(trace *promolog.ErrorTrace) {
 					>
 						Show Issue Email
 					</button>
+					// setup:feature:demo:end
 					<button
 						class="btn btn-sm btn-error btn-outline"
 						hx-delete={ "/admin/error-traces/" + trace.RequestID }

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -56,7 +56,9 @@ templ Index(layoutContent templ.Component, menuContent templ.Component, csrfToke
 				{ version }
 			</footer>
 			<div id="report-modal-container"></div>
+			// setup:feature:demo:start
 			<div id="report-email-container"></div>
+			// setup:feature:demo:end
 			// setup:feature:offline:start
 			@components.OfflineIndicator()
 			// setup:feature:offline:end


### PR DESCRIPTION
## Summary

- Wrapped the "Show Issue Email" button in `web/views/error_traces.templ` with `setup:feature:demo:start/end` markers so it is stripped from derived apps
- Wrapped the `report-email-container` OOB swap target divs in `app_nav_layout.templ`, `index.templ`, and `error_page.templ` with the same markers (these are the swap targets for the demo email modal)
- The route handler (`routes_report_demo.go`) and modal template (`report_email.templ`) were already whole-file gated with `// setup:feature:demo`

## Test plan

- [x] `go test ./...` passes
- [ ] Verify the Show Issue Email button appears on the error traces page in the demo app
- [ ] Run setup tool on a derived app and confirm the button and containers are stripped

Fixes #423