### PR TITLE
Replace cheddar with htmx-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/a-h/templ v0.3.1001
-	github.com/catgoose/cheddar v0.2.1
+	github.com/angelofallars/htmx-go v0.5.0
 	github.com/catgoose/crooner v1.4.2
 	github.com/catgoose/dio v1.0.26
 	github.com/catgoose/flighty v0.2.3
@@ -27,7 +27,10 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
-require github.com/lib/pq v1.12.1 // indirect
+require (
+	github.com/catgoose/cheddar v0.2.1 // indirect
+	github.com/lib/pq v1.12.1 // indirect
+)
 
 require (
 	dario.cat/mergo v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/alexedwards/scs/v2 v2.9.0 h1:xa05mVpwTBm1iLeTMNFfAWpKUm4fXAW7CeAViqBV
 github.com/alexedwards/scs/v2 v2.9.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
+github.com/angelofallars/htmx-go v0.5.0 h1:L7M48cCH7nX8cV5wRYn04pN6AE4qNdh86iTbuKxhnIo=
+github.com/angelofallars/htmx-go v0.5.0/go.mod h1:izXk6A+Jllc3vXs1dUvxUJs/jE0weiEC07ZPlCVi4cc=
 github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c h1:651/eoCRnQ7YtSjAnSzRucrJz+3iGEFt+ysraELS81M=
 github.com/armon/go-radix v1.0.1-0.20221118154546-54df44f2176c/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/internal/routes/routes_catalog.go
+++ b/internal/routes/routes_catalog.go
@@ -5,7 +5,7 @@ package routes
 import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	"github.com/catgoose/cheddar"
+	htmx "github.com/angelofallars/htmx-go"
 	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/web/views"
@@ -39,7 +39,7 @@ func (cat *catalogRoutes) handleCatalogItems(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 500, "Failed to load items", err)
 	}
-	if cheddar.IsBoosted(c) {
+	if htmx.IsBoosted(c.Request()) {
 		return handler.RenderBaseLayout(c, views.CatalogPage(bar, container))
 	}
 	setTableReplaceURL(c, catalogBase)

--- a/internal/routes/routes_error_traces.go
+++ b/internal/routes/routes_error_traces.go
@@ -15,7 +15,7 @@ import (
 	"github.com/catgoose/flighty"
 	"catgoose/dothog/web/views"
 
-	"github.com/catgoose/cheddar"
+	htmx "github.com/angelofallars/htmx-go"
 	corecomponents "catgoose/dothog/web/components/core"
 
 	"github.com/a-h/templ"
@@ -50,12 +50,12 @@ func (ar *appRoutes) handleErrorTracesList(c echo.Context) error {
 	b := flighty.New(c).
 		Component(container).
 		OOB(corecomponents.FilterGroupOOB(group))
-	if cheddar.IsHTMX(c) {
+	if htmx.IsHTMX(c.Request()) {
 		pushURL := errorTracesBase
 		if q := c.Request().URL.RawQuery; q != "" {
 			pushURL += "?" + q
 		}
-		cheddar.ReplaceURL(c, pushURL)
+		htmx.NewResponse().ReplaceURL(pushURL).Write(c.Response())
 	}
 	return b.Send()
 }

--- a/internal/routes/routes_inventory.go
+++ b/internal/routes/routes_inventory.go
@@ -8,7 +8,7 @@ import (
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
-	"github.com/catgoose/cheddar"
+	htmx "github.com/angelofallars/htmx-go"
 	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/params"
 	"catgoose/dothog/web/views"
@@ -48,7 +48,7 @@ func (d *inventoryRoutes) handleInventoryItems(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 500, "Failed to load items", err)
 	}
-	if cheddar.IsBoosted(c) {
+	if htmx.IsBoosted(c.Request()) {
 		return handler.RenderBaseLayout(c, views.InventoryPage(bar, container))
 	}
 	setTableReplaceURL(c, inventoryBase)
@@ -102,7 +102,7 @@ func (d *inventoryRoutes) handleItemRow(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHypermediaError(c, 404, "Item not found", err)
 	}
-	if !cheddar.IsHTMX(c) || cheddar.IsBoosted(c) {
+	if !htmx.IsHTMX(c.Request()) || htmx.IsBoosted(c.Request()) {
 		handler.SetPageLabel(c, item.Name)
 		return handler.RenderBaseLayout(c, views.InventoryDetailPage(item))
 	}

--- a/internal/routes/routes_tables.go
+++ b/internal/routes/routes_tables.go
@@ -8,7 +8,7 @@ import (
 	"catgoose/dothog/internal/demo"
 	"github.com/catgoose/linkwell"
 
-	"github.com/catgoose/cheddar"
+	htmx "github.com/angelofallars/htmx-go"
 
 	"github.com/labstack/echo/v4"
 )
@@ -97,14 +97,14 @@ func filterQueryFromHXCurrentURL(c echo.Context) string {
 // setTableReplaceURL sets HX-Replace-Url to basePath?{currentQueryString} so the browser
 // URL stays in sync with the active filters after any table-replacing response.
 func setTableReplaceURL(c echo.Context, basePath string) {
-	if !cheddar.IsHTMX(c) {
+	if !htmx.IsHTMX(c.Request()) {
 		return
 	}
 	pushURL := basePath
 	if q := c.Request().URL.RawQuery; q != "" {
 		pushURL += "?" + q
 	}
-	cheddar.ReplaceURL(c, pushURL)
+	htmx.NewResponse().ReplaceURL(pushURL).Write(c.Response())
 }
 
 // applyFilterFromCurrentURL reads HX-Current-URL and sets the request URL's query string


### PR DESCRIPTION
## Summary

- Replace direct `github.com/catgoose/cheddar` usage with `github.com/angelofallars/htmx-go` in all 4 route handler files
- `IsHTMX(c)` and `IsBoosted(c)` now use htmx-go's `*http.Request`-based API: `htmx.IsHTMX(c.Request())`
- `cheddar.ReplaceURL(c, url)` replaced with htmx-go's builder: `htmx.NewResponse().ReplaceURL(url).Write(c.Response())`
- Cheddar remains as an indirect dependency (transitive through flighty)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [ ] Manual verification: HTMX-boosted navigation still works correctly
- [ ] Manual verification: URL replacement in browser bar works on table filter/sort/pagination