### PR TITLE
refactor: migrate publishers to tavern ScheduledPublisher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/catgoose/linkwell v0.2.14
 	github.com/catgoose/porter v0.4.4
 	github.com/catgoose/promolog/sqlite v0.0.0-20260402134330-814f9e6c453d
-	github.com/catgoose/tavern v0.4.18
+	github.com/catgoose/tavern v0.4.26
 	github.com/charmbracelet/huh v1.0.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/jmoiron/sqlx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/catgoose/promolog v0.2.17 h1:ruoQKlfsVeefCFOXNnAV3lJJPwsFw6KwQrJNNg9b
 github.com/catgoose/promolog v0.2.17/go.mod h1:jEsBpxvJjXW8FTaCBi+vXaIwN5ISr3ylR6Z5AId+Yb4=
 github.com/catgoose/promolog/sqlite v0.0.0-20260402134330-814f9e6c453d h1:2bb263RI3TxT+4VMYMS7w+/nAvU0Exoyvf5S5LdfQEQ=
 github.com/catgoose/promolog/sqlite v0.0.0-20260402134330-814f9e6c453d/go.mod h1:DlhnBaX+j0c6CvlOt+xzk1Rt8O+UB+pcx75RndMa70o=
-github.com/catgoose/tavern v0.4.18 h1:+eK3fu1PbsAL1EEOc95vO4+hKUkwpZZ3VGSN4szk35U=
-github.com/catgoose/tavern v0.4.18/go.mod h1:DhiRI7tzfzB+pNwV8JeFjNI5Qx+PFZE1Wfy2dmavs1M=
+github.com/catgoose/tavern v0.4.26 h1:ahFSDYL18hSiOw1ggRPSafsXKfAQ0E3ACXNYfMvwM2c=
+github.com/catgoose/tavern v0.4.26/go.mod h1:DhiRI7tzfzB+pNwV8JeFjNI5Qx+PFZE1Wfy2dmavs1M=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/internal/routes/interval_tracker.go
+++ b/internal/routes/interval_tracker.go
@@ -1,0 +1,60 @@
+// setup:feature:demo
+
+package routes
+
+import (
+	"sync"
+	"time"
+
+	"github.com/catgoose/tavern"
+)
+
+// intervalTracker stores per-section durations and supports save/restore for
+// master-control overrides.
+type intervalTracker struct {
+	mu    sync.RWMutex
+	cur   map[string]time.Duration
+	saved map[string]time.Duration
+}
+
+func newIntervalTracker(defaults map[string]time.Duration) *intervalTracker {
+	cur := make(map[string]time.Duration, len(defaults))
+	for k, v := range defaults {
+		cur[k] = v
+	}
+	return &intervalTracker{cur: cur}
+}
+
+func (t *intervalTracker) set(pub *tavern.ScheduledPublisher, name string, d time.Duration) {
+	t.mu.Lock()
+	t.cur[name] = d
+	t.mu.Unlock()
+	pub.SetInterval(name, d)
+}
+
+func (t *intervalTracker) saveAndOverride(pub *tavern.ScheduledPublisher, d time.Duration) {
+	t.mu.Lock()
+	if t.saved == nil {
+		t.saved = make(map[string]time.Duration, len(t.cur))
+		for k, v := range t.cur {
+			t.saved[k] = v
+		}
+	}
+	for k := range t.cur {
+		t.cur[k] = d
+		pub.SetInterval(k, d)
+	}
+	t.mu.Unlock()
+}
+
+func (t *intervalTracker) restore(pub *tavern.ScheduledPublisher) {
+	t.mu.Lock()
+	if t.saved != nil {
+		for k, v := range t.saved {
+			t.cur[k] = v
+			pub.SetInterval(k, v)
+		}
+		t.saved = nil
+	}
+	t.mu.Unlock()
+}

--- a/internal/routes/routes_admin_settings.go
+++ b/internal/routes/routes_admin_settings.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"catgoose/dothog/internal/health"
@@ -21,48 +20,32 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// ── Per-section interval state ──────────────────────────────────────────────
+// ── ScheduledPublisher for admin panel ─────────────────────────────────────
 
-var adminDefaultIntervals = map[string]int{
-	"system-metrics": 5000,  // 5s
-	"sse-counts":     3000,  // 3s
-	"health":         5000,  // 5s
-}
-
-var adminIntervals struct {
-	intervals map[string]int
-	lastSent  map[string]time.Time
-	mu        sync.RWMutex
-}
-
-func initAdminIntervals() {
-	adminIntervals.intervals = make(map[string]int, len(adminDefaultIntervals))
-	adminIntervals.lastSent = make(map[string]time.Time, len(adminDefaultIntervals))
-	for id, iv := range adminDefaultIntervals {
-		adminIntervals.intervals[id] = iv
-	}
-}
-
-func getAdminInterval(id string) int {
-	adminIntervals.mu.RLock()
-	defer adminIntervals.mu.RUnlock()
-	if iv, ok := adminIntervals.intervals[id]; ok {
-		return iv
-	}
-	return 5000
-}
+var adminPub *tavern.ScheduledPublisher
 
 // ── Routes ──────────────────────────────────────────────────────────────────
 
-var adminBufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
-
 func (ar *appRoutes) initAdminSettingsRoutes(broker *tavern.SSEBroker) {
-	initAdminIntervals()
 	ar.e.GET("/admin/settings", ar.handleAdminSettings(broker))
 	ar.e.POST("/admin/settings/interval", handleAdminInterval)
 	ar.e.GET("/sse/admin", handleSSEAdmin(broker))
 
-	go ar.publishAdminPanel(broker)
+	adminPub = broker.NewScheduledPublisher(TopicAdminPanel, tavern.WithBaseTick(500*time.Millisecond))
+	adminPub.Register("system-metrics", 5*time.Second, func(ctx context.Context, buf *bytes.Buffer) error {
+		stats := health.CollectRuntimeStats(ar.startTime)
+		uptime := formatUptime(time.Since(ar.startTime))
+		return views.OOBAdminSystemMetrics(stats, uptime).Render(ctx, buf)
+	})
+	adminPub.Register("sse-counts", 3*time.Second, func(ctx context.Context, buf *bytes.Buffer) error {
+		counts := broker.TopicCounts()
+		return views.OOBAdminSSECounts(counts).Render(ctx, buf)
+	})
+	adminPub.Register("health", 5*time.Second, func(ctx context.Context, buf *bytes.Buffer) error {
+		h := health.Check(ctx, ar.healthCfg)
+		return views.OOBAdminHealth(h).Render(ctx, buf)
+	})
+	broker.RunPublisher(ar.ctx, adminPub.Start)
 }
 
 func (ar *appRoutes) handleAdminSettings(broker *tavern.SSEBroker) echo.HandlerFunc {
@@ -80,9 +63,7 @@ func handleAdminInterval(c echo.Context) error {
 	} else if ms > 600000 {
 		ms = 600000
 	}
-	adminIntervals.mu.Lock()
-	adminIntervals.intervals[section] = ms
-	adminIntervals.mu.Unlock()
+	adminPub.SetInterval(section, time.Duration(ms)*time.Millisecond)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -110,76 +91,8 @@ func handleSSEAdmin(broker *tavern.SSEBroker) echo.HandlerFunc {
 				if !ok {
 					return nil
 				}
-				fmt.Fprint(c.Response(), msg)
+				fmt.Fprint(c.Response(), tavern.NewSSEMessage("admin-panel", msg).String())
 				flusher.Flush()
-			}
-		}
-	}
-}
-
-// ── Publisher ────────────────────────────────────────────────────────────────
-
-func (ar *appRoutes) publishAdminPanel(broker *tavern.SSEBroker) {
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	ctx := context.Background()
-
-	for {
-		select {
-		case <-ar.ctx.Done():
-			return
-		case <-ticker.C:
-			if !broker.HasSubscribers(TopicAdminPanel) {
-				continue
-			}
-
-			now := time.Now()
-			buf := adminBufPool.Get().(*bytes.Buffer)
-			buf.Reset()
-			needsPublish := false
-
-			adminIntervals.mu.Lock()
-
-			// System metrics
-			if ms := adminIntervals.intervals["system-metrics"]; ms > 0 {
-				if now.Sub(adminIntervals.lastSent["system-metrics"]) >= time.Duration(ms)*time.Millisecond {
-					stats := health.CollectRuntimeStats(ar.startTime)
-					uptime := formatUptime(time.Since(ar.startTime))
-					_ = views.OOBAdminSystemMetrics(stats, uptime).Render(ctx, buf)
-					adminIntervals.lastSent["system-metrics"] = now
-					needsPublish = true
-				}
-			}
-
-			// SSE topic counts
-			if ms := adminIntervals.intervals["sse-counts"]; ms > 0 {
-				if now.Sub(adminIntervals.lastSent["sse-counts"]) >= time.Duration(ms)*time.Millisecond {
-					counts := broker.TopicCounts()
-					_ = views.OOBAdminSSECounts(counts).Render(ctx, buf)
-					adminIntervals.lastSent["sse-counts"] = now
-					needsPublish = true
-				}
-			}
-
-			// Health (for /admin/health page)
-			if ms := adminIntervals.intervals["health"]; ms > 0 {
-				if now.Sub(adminIntervals.lastSent["health"]) >= time.Duration(ms)*time.Millisecond {
-					h := health.Check(ctx, ar.healthCfg)
-					_ = views.OOBAdminHealth(h).Render(ctx, buf)
-					adminIntervals.lastSent["health"] = now
-					needsPublish = true
-				}
-			}
-
-			adminIntervals.mu.Unlock()
-
-			if needsPublish {
-				msg := tavern.NewSSEMessage("admin-panel", buf.String()).String()
-				adminBufPool.Put(buf)
-				broker.Publish(TopicAdminPanel, msg)
-			} else {
-				adminBufPool.Put(buf)
 			}
 		}
 	}

--- a/internal/routes/routes_numerical.go
+++ b/internal/routes/routes_numerical.go
@@ -10,7 +10,6 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"catgoose/dothog/internal/routes/handler"
@@ -312,20 +311,19 @@ func clampF(v, lo, hi float64) float64 {
 
 // ── Per-tile interval state ─────────────────────────────────────────────────
 
-// Default intervals (milliseconds) — tuned per metric context.
-var numDefaultIntervals = map[string]int{
-	"num-txn":     500,    // volatile, sub-second
-	"num-queue":   500,    // operational, sub-second
-	"num-p99":     500,    // performance critical, sub-second
-	"num-cpu":     3000,   // 3s — OS-level, moderate
-	"num-users":   5000,   // 5s — moderate churn
-	"num-errors":  5000,   // 5s — accumulating counter
-	"num-revenue": 10000,  // 10s — accumulating slowly
-	"num-cache":   10000,  // 10s — relatively stable
-	"num-mem":     15000,  // 15s — changes slowly
-	"num-sla":     15000,  // 15s — derived, slow-moving
-	"num-uptime":  60000,  // 1min — minutes-level granularity
-	"num-deploys": 300000, // 5min — rare events
+var numDefaultIntervals = map[string]time.Duration{
+	"num-txn":     500 * time.Millisecond,
+	"num-queue":   500 * time.Millisecond,
+	"num-p99":     500 * time.Millisecond,
+	"num-cpu":     3000 * time.Millisecond,
+	"num-users":   5000 * time.Millisecond,
+	"num-errors":  5000 * time.Millisecond,
+	"num-revenue": 10000 * time.Millisecond,
+	"num-cache":   10000 * time.Millisecond,
+	"num-mem":     15000 * time.Millisecond,
+	"num-sla":     15000 * time.Millisecond,
+	"num-uptime":  60000 * time.Millisecond,
+	"num-deploys": 300000 * time.Millisecond,
 }
 
 // numTileScales determines slider unit for each tile.
@@ -344,25 +342,16 @@ var numTileScales = map[string]string{
 	"num-deploys": "min",
 }
 
-var numTileIntervals struct {
-	intervals map[string]int       // seconds per tile
-	lastSent  map[string]time.Time // last publish time per tile
-	mu        sync.RWMutex
-}
-
-func initTileIntervals() {
-	numTileIntervals.intervals = make(map[string]int, len(numDefaultIntervals))
-	numTileIntervals.lastSent = make(map[string]time.Time, len(numDefaultIntervals))
-	for id, iv := range numDefaultIntervals {
-		numTileIntervals.intervals[id] = iv
-	}
-}
+var (
+	numPub     *tavern.ScheduledPublisher
+	numTracker *intervalTracker
+)
 
 func getTileInterval(id string) int {
-	numTileIntervals.mu.RLock()
-	defer numTileIntervals.mu.RUnlock()
-	if iv, ok := numTileIntervals.intervals[id]; ok {
-		return iv
+	numTracker.mu.RLock()
+	defer numTracker.mu.RUnlock()
+	if d, ok := numTracker.cur[id]; ok {
+		return int(d.Milliseconds())
 	}
 	return 1000
 }
@@ -376,16 +365,13 @@ func getTileScale(id string) string {
 
 // ── Routes ──────────────────────────────────────────────────────────────────
 
-var numBufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
-
 func (ar *appRoutes) initNumericalRoutes(broker *tavern.SSEBroker) {
-	initTileIntervals()
 	ar.e.GET(numericalBase, ar.handleNumericalPage)
 	ar.e.GET(numericalBase+"/sse-connect", handleNumericalSSEConnect)
 	ar.e.POST(numericalBase+"/interval", handleNumericalInterval)
 	ar.e.GET("/sse/numerical", handleSSENumerical(broker))
 
-	go ar.publishNumerical(broker)
+	ar.initNumericalPublisher(broker)
 }
 
 func (ar *appRoutes) handleNumericalPage(c echo.Context) error {
@@ -403,14 +389,10 @@ func handleNumericalInterval(c echo.Context) error {
 	ms, _ := strconv.Atoi(c.FormValue("interval_ms"))
 	if ms < 100 {
 		ms = 100
-	} else if ms > 600000 {
-		ms = 600000
+	} else if ms > 86400000 {
+		ms = 86400000
 	}
-
-	numTileIntervals.mu.Lock()
-	numTileIntervals.intervals[tileID] = ms
-	numTileIntervals.mu.Unlock()
-
+	numTracker.set(numPub, tileID, time.Duration(ms)*time.Millisecond)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -438,68 +420,46 @@ func handleSSENumerical(broker *tavern.SSEBroker) echo.HandlerFunc {
 				if !ok {
 					return nil
 				}
-				fmt.Fprint(c.Response(), msg)
+				fmt.Fprint(c.Response(), tavern.NewSSEMessage("numerical-dash", msg).String())
 				flusher.Flush()
 			}
 		}
 	}
 }
 
-// ── Publisher ────────────────────────────────────────────────────────────────
+// ── Numerical Publisher ────────────────────────────────────────────────────
 
-func (ar *appRoutes) publishNumerical(broker *tavern.SSEBroker) {
-	// Fast tick: check tile intervals at 100ms resolution.
-	// Simulation also advances each tick with scaled deltas.
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
+func (ar *appRoutes) initNumericalPublisher(broker *tavern.SSEBroker) {
+	numTracker = newIntervalTracker(numDefaultIntervals)
+	numPub = broker.NewScheduledPublisher(TopicNumericalDash, tavern.WithBaseTick(100*time.Millisecond))
 
 	sim := newNumSim()
-	ctx := context.Background()
+	var tileMap map[string]views.NumTile
 
-	for {
-		select {
-		case <-ar.ctx.Done():
-			return
-		case <-ticker.C:
-			if !broker.HasSubscribers(TopicNumericalDash) {
-				continue
+	// Sim advance + build tiles every tick
+	numPub.Register("_sim", 100*time.Millisecond, func(_ context.Context, _ *bytes.Buffer) error {
+		sim.tick()
+		tiles := sim.buildTiles()
+		tileMap = make(map[string]views.NumTile, len(tiles))
+		for _, t := range tiles {
+			tileMap[t.ID] = t
+		}
+		return nil
+	})
+
+	// Register each tile as its own section
+	tileRender := func(id string) tavern.RenderFunc {
+		return func(ctx context.Context, buf *bytes.Buffer) error {
+			if t, ok := tileMap[id]; ok {
+				return views.NumericalOOB([]views.NumTile{t}).Render(ctx, buf)
 			}
-
-			now := time.Now()
-			sim.tick()
-
-			// Build all tiles, filter to those whose interval has elapsed
-			allTiles := sim.buildTiles()
-			var due []views.NumTile
-
-			numTileIntervals.mu.Lock()
-			for _, t := range allTiles {
-				ms := numTileIntervals.intervals[t.ID]
-				if ms < 100 {
-					ms = 100
-				}
-				last := numTileIntervals.lastSent[t.ID]
-				if now.Sub(last) >= time.Duration(ms)*time.Millisecond {
-					due = append(due, t)
-					numTileIntervals.lastSent[t.ID] = now
-				}
-			}
-			numTileIntervals.mu.Unlock()
-
-			if len(due) == 0 {
-				continue
-			}
-
-			buf := numBufPool.Get().(*bytes.Buffer)
-			buf.Reset()
-			if err := views.NumericalOOB(due).Render(ctx, buf); err != nil {
-				numBufPool.Put(buf)
-				continue
-			}
-
-			msg := tavern.NewSSEMessage("numerical-dash", buf.String()).String()
-			numBufPool.Put(buf)
-			broker.Publish(TopicNumericalDash, msg)
+			return nil
 		}
 	}
+
+	for id, d := range numDefaultIntervals {
+		numPub.Register(id, d, tileRender(id))
+	}
+
+	broker.RunPublisher(ar.ctx, numPub.Start)
 }

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -13,68 +13,77 @@ import (
 	"sync"
 	"time"
 
+	"catgoose/dothog/internal/health"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/shared"
-	"catgoose/dothog/internal/health"
-	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
 
+	"github.com/catgoose/tavern"
 	"github.com/labstack/echo/v4"
 )
 
-// ── Per-section interval state ──────────────────────────────────────────────
-
-var rtDefaultIntervals = map[string]int{
-	"metrics":  1000, // 1s — KPIs, charts, gauges
-	"services": 3000, // 3s — service health, per-service latency
-	"events":   1500, // 1.5s — live event feed
+// statsBufPool is a shared buffer pool used by various SSE publishers in the
+// routes package.
+var statsBufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
 }
 
-var rtIntervals struct {
-	intervals map[string]int
-	mu        sync.RWMutex
+// ── ScheduledPublishers ────────────────────────────────────────────────────
+
+var (
+	dashPub     *tavern.ScheduledPublisher
+	dashTracker *intervalTracker
+	sysPub      *tavern.ScheduledPublisher
+)
+
+var rtCardDefaults = map[string]time.Duration{
+	"metrics":  1000 * time.Millisecond,
+	"services": 3000 * time.Millisecond,
+	"events":   1500 * time.Millisecond,
 }
 
-func initRTIntervals() {
-	rtIntervals.intervals = make(map[string]int, len(rtDefaultIntervals))
-	for id, iv := range rtDefaultIntervals {
-		rtIntervals.intervals[id] = iv
-	}
-}
-
-func getRTInterval(id string) time.Duration {
-	rtIntervals.mu.RLock()
-	defer rtIntervals.mu.RUnlock()
-	if ms, ok := rtIntervals.intervals[id]; ok && ms > 0 {
-		return time.Duration(ms) * time.Millisecond
-	}
-	return time.Second
-}
+// ── Routes ──────────────────────────────────────────────────────────────────
 
 func (ar *appRoutes) initRealtimeRoutes(broker *tavern.SSEBroker) {
-	initRTIntervals()
 	ar.e.GET("/hypermedia/realtime", ar.handleRealtimePage())
 	ar.e.POST("/hypermedia/realtime/interval", handleRTInterval)
+	ar.e.POST("/hypermedia/realtime/interval-all", handleRTIntervalAll)
+	ar.e.POST("/hypermedia/realtime/interval-restore", handleRTIntervalRestore)
 	ar.e.GET("/sse/system", handleSSESystem(broker))
 	ar.e.GET("/sse/dashboard", handleSSEDashboard(broker))
 
-	go ar.publishSystemStats(broker)
-	go ar.publishMetrics(broker)
-	go ar.publishServices(broker)
-	go ar.publishEvents(broker)
+	ar.initDashboardPublisher(broker)
+	ar.initSystemStatsPublisher(broker)
 }
 
 func handleRTInterval(c echo.Context) error {
 	section := c.FormValue("section")
 	ms, _ := strconv.Atoi(c.FormValue("interval_ms"))
-	if ms < 500 {
-		ms = 500
-	} else if ms > 30000 {
-		ms = 30000
+	if ms < 100 {
+		ms = 100
+	} else if ms > 86400000 {
+		ms = 86400000
 	}
-	rtIntervals.mu.Lock()
-	rtIntervals.intervals[section] = ms
-	rtIntervals.mu.Unlock()
+	dashTracker.set(dashPub, section, time.Duration(ms)*time.Millisecond)
+	return c.NoContent(http.StatusNoContent)
+}
+
+func handleRTIntervalAll(c echo.Context) error {
+	ms, _ := strconv.Atoi(c.FormValue("interval_ms"))
+	if ms < 100 {
+		ms = 100
+	} else if ms > 86400000 {
+		ms = 86400000
+	}
+	d := time.Duration(ms) * time.Millisecond
+	dashTracker.saveAndOverride(dashPub, d)
+	numTracker.saveAndOverride(numPub, d)
+	return c.NoContent(http.StatusNoContent)
+}
+
+func handleRTIntervalRestore(c echo.Context) error {
+	dashTracker.restore(dashPub)
+	numTracker.restore(numPub)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -87,6 +96,8 @@ func (ar *appRoutes) handleRealtimePage() echo.HandlerFunc {
 		return handler.RenderBaseLayout(c, views.RealtimePage(stats, snap, services, svcLatencies))
 	}
 }
+
+// ── SSE handlers ───────────────────────────────────────────────────────────
 
 func handleSSESystem(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
@@ -112,15 +123,13 @@ func handleSSESystem(broker *tavern.SSEBroker) echo.HandlerFunc {
 				if !ok {
 					return nil
 				}
-				_, _ = fmt.Fprint(c.Response(), msg)
+				_, _ = fmt.Fprint(c.Response(), tavern.NewSSEMessage("system-stats", msg).String())
 				flusher.Flush()
 			}
 		}
 	}
 }
 
-// handleSSEDashboard multiplexes 3 SSE topics into one event stream.
-// Each publisher controls its own rate via rtIntervals — no handler-side throttling.
 func handleSSEDashboard(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		c.Response().Header().Set("Content-Type", "text/event-stream")
@@ -133,72 +142,37 @@ func handleSSEDashboard(broker *tavern.SSEBroker) echo.HandlerFunc {
 			return fmt.Errorf("streaming unsupported")
 		}
 
-		chMetrics, unsubMetrics := broker.Subscribe(TopicDashMetrics)
-		defer unsubMetrics()
-		chServices, unsubServices := broker.Subscribe(TopicDashServices)
-		defer unsubServices()
-		chEvents, unsubEvents := broker.Subscribe(TopicDashEvents)
-		defer unsubEvents()
+		ch, unsub := broker.Subscribe(TopicDashMetrics)
+		defer unsub()
 
 		ctx := c.Request().Context()
 		for {
 			select {
 			case <-ctx.Done():
 				return nil
-			case msg, ok := <-chMetrics:
+			case msg, ok := <-ch:
 				if !ok {
 					return nil
 				}
-				_, _ = fmt.Fprint(c.Response(), msg)
-				flusher.Flush()
-			case msg, ok := <-chServices:
-				if !ok {
-					return nil
-				}
-				_, _ = fmt.Fprint(c.Response(), msg)
-				flusher.Flush()
-			case msg, ok := <-chEvents:
-				if !ok {
-					return nil
-				}
-				_, _ = fmt.Fprint(c.Response(), msg)
+				_, _ = fmt.Fprint(c.Response(), tavern.NewSSEMessage("dashboard-metrics", msg).String())
 				flusher.Flush()
 			}
 		}
 	}
 }
 
-var statsBufPool = sync.Pool{
-	New: func() any { return new(bytes.Buffer) },
+// ── System stats publisher ─────────────────────────────────────────────────
+
+func (ar *appRoutes) initSystemStatsPublisher(broker *tavern.SSEBroker) {
+	sysPub = broker.NewScheduledPublisher(TopicSystemStats)
+	sysPub.Register("stats", 2*time.Second, func(ctx context.Context, buf *bytes.Buffer) error {
+		stats := health.CollectRuntimeStats(ar.startTime)
+		return views.SystemStatsOOB(stats).Render(shared.WithContextIDAndDescription(ctx, shared.GenerateContextID(), "publish system stats"), buf)
+	})
+	broker.RunPublisher(ar.ctx, sysPub.Start)
 }
 
-func (ar *appRoutes) publishSystemStats(broker *tavern.SSEBroker) {
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-	start := time.Now()
-	for {
-		select {
-		case <-ar.ctx.Done():
-			return
-		case <-ticker.C:
-			if !broker.HasSubscribers(TopicSystemStats) {
-				continue
-			}
-			stats := health.CollectRuntimeStats(start)
-			buf := statsBufPool.Get().(*bytes.Buffer)
-			buf.Reset()
-			if err := views.SystemStatsOOB(stats).Render(shared.WithContextIDAndDescription(context.Background(), shared.GenerateContextID(), "publish system stats"), buf); err != nil {
-				statsBufPool.Put(buf)
-				continue
-			}
-			msg := tavern.NewSSEMessage("system-stats", buf.String()).String()
-			statsBufPool.Put(buf)
-			broker.Publish(TopicSystemStats, msg)
-		}
-	}
-}
-
-// --- Metrics publisher ---
+// ── Dashboard publisher ────────────────────────────────────────────────────
 
 func initialMetrics() views.MetricsSnapshot {
 	return views.MetricsSnapshot{
@@ -223,193 +197,6 @@ func initialMetrics() views.MetricsSnapshot {
 		MaxDiskIO:    100,
 	}
 }
-
-func (ar *appRoutes) publishMetrics(broker *tavern.SSEBroker) {
-	snap := initialMetrics()
-
-	// Simulation state
-	rps := snap.RPS
-	errPct := snap.ErrorPct
-	p99 := snap.P99Ms
-	cpu := snap.CPUPercent
-	mem := snap.MemPercent
-	netIn := 12.5
-	netOut := 8.3
-	connActive := snap.ConnActive
-	connIdle := snap.ConnIdle
-	connWait := snap.ConnWait
-	// New chart state
-	p50 := 15.0
-	p90 := 35.0
-	diskRead := 50.0
-	diskWrite := 30.0
-
-	for {
-		select {
-		case <-ar.ctx.Done():
-			return
-		case <-time.After(getRTInterval("metrics")):
-			if !broker.HasSubscribers(TopicDashMetrics) {
-				continue
-			}
-
-			// Random walk for RPS with occasional spikes
-			rps += (rand.Float64() - 0.48) * 120
-			if rand.Float64() < 0.05 {
-				rps += 400 + rand.Float64()*300
-				errPct += 1.5 + rand.Float64()*2
-			}
-			rps = math.Max(200, math.Min(3000, rps))
-
-			// Error rate drifts back toward baseline
-			errPct += (rand.Float64() - 0.55) * 0.4
-			errPct = math.Max(0.1, math.Min(8.0, errPct))
-
-			// P99 latency correlates loosely with RPS
-			p99 += (rand.Float64() - 0.5) * 15
-			if rps > 2000 {
-				p99 += 10
-			}
-			p99 = math.Max(10, math.Min(300, p99))
-
-			// CPU/Memory drift
-			cpu += (rand.Float64() - 0.48) * 5
-			cpu = math.Max(5, math.Min(98, cpu))
-			mem += (rand.Float64() - 0.5) * 3
-			mem = math.Max(15, math.Min(95, mem))
-
-			// Network traffic drift
-			netIn += (rand.Float64() - 0.48) * 8
-			netIn = math.Max(1, math.Min(80, netIn))
-			netOut += (rand.Float64() - 0.5) * 6
-			netOut = math.Max(0.5, math.Min(60, netOut))
-
-			pt := views.NetworkPoint{
-				InMBps:  math.Round(netIn*10) / 10,
-				OutMBps: math.Round(netOut*10) / 10,
-			}
-			snap.Network = append(snap.Network, pt)
-			if len(snap.Network) > 15 {
-				snap.Network = snap.Network[len(snap.Network)-15:]
-			}
-
-			// Recalculate max network for normalization
-			maxNet := 0.0
-			for _, p := range snap.Network {
-				combined := p.InMBps + p.OutMBps
-				if combined > maxNet {
-					maxNet = combined
-				}
-			}
-			snap.MaxNetwork = maxNet * 1.1
-
-			// Connection pool redistribution (total ~35)
-			total := connActive + connIdle + connWait
-			shift := rand.IntN(5) - 2
-			connActive += shift
-			if connActive < 3 {
-				connActive = 3
-			}
-			if connActive > total-4 {
-				connActive = total - 4
-			}
-			remaining := total - connActive
-			connIdle = remaining/2 + rand.IntN(3) - 1
-			if connIdle < 1 {
-				connIdle = 1
-			}
-			if connIdle > remaining-1 {
-				connIdle = remaining - 1
-			}
-			connWait = remaining - connIdle
-
-			// P50/P90 random walk (enforce ordering)
-			p50 += (rand.Float64() - 0.5) * 8
-			p50 = math.Max(5, math.Min(p90-5, p50))
-			p90 += (rand.Float64() - 0.5) * 12
-			p90 = math.Max(p50+5, math.Min(p99-5, p90))
-
-			// Latency histogram (rolling 10)
-			snap.LatencyHist = append(snap.LatencyHist, views.LatencyBucket{
-				P50: math.Round(p50*10) / 10,
-				P90: math.Round(p90*10) / 10,
-				P99: math.Round(p99*10) / 10,
-			})
-			if len(snap.LatencyHist) > 10 {
-				snap.LatencyHist = snap.LatencyHist[len(snap.LatencyHist)-10:]
-			}
-			maxLat := 0.0
-			for _, b := range snap.LatencyHist {
-				if b.P99 > maxLat {
-					maxLat = b.P99
-				}
-			}
-			snap.MaxLatency = maxLat * 1.1
-
-			// Error history (rolling 30)
-			snap.ErrorHistory = append(snap.ErrorHistory, views.ErrorRatePoint{Value: math.Round(errPct*10) / 10})
-			if len(snap.ErrorHistory) > 30 {
-				snap.ErrorHistory = snap.ErrorHistory[len(snap.ErrorHistory)-30:]
-			}
-
-			// Disk I/O random walk (rolling 15)
-			diskRead += (rand.Float64() - 0.48) * 12
-			diskRead = math.Max(1, math.Min(200, diskRead))
-			diskWrite += (rand.Float64() - 0.5) * 10
-			diskWrite = math.Max(1, math.Min(150, diskWrite))
-			snap.DiskIO = append(snap.DiskIO, views.DiskIOPoint{
-				ReadMBps:  math.Round(diskRead*10) / 10,
-				WriteMBps: math.Round(diskWrite*10) / 10,
-			})
-			if len(snap.DiskIO) > 15 {
-				snap.DiskIO = snap.DiskIO[len(snap.DiskIO)-15:]
-			}
-			maxDisk := 0.0
-			for _, d := range snap.DiskIO {
-				combined := d.ReadMBps + d.WriteMBps
-				if combined > maxDisk {
-					maxDisk = combined
-				}
-			}
-			snap.MaxDiskIO = maxDisk * 1.1
-
-			// Status distribution (derived from RPS)
-			reqTotal := int(math.Round(rps))
-			s5xx := int(math.Round(errPct / 100 * float64(reqTotal)))
-			s4xx := int(float64(reqTotal) * (0.02 + rand.Float64()*0.02))
-			s3xx := int(float64(reqTotal) * (0.02 + rand.Float64()*0.02))
-			s2xx := reqTotal - s3xx - s4xx - s5xx
-			if s2xx < 0 {
-				s2xx = 0
-			}
-			snap.StatusDist = views.StatusDistribution{S2xx: s2xx, S3xx: s3xx, S4xx: s4xx, S5xx: s5xx}
-
-			snap.RPS = math.Round(rps)
-			snap.ErrorPct = math.Round(errPct*10) / 10
-			snap.P99Ms = math.Round(p99*10) / 10
-			snap.CPUPercent = math.Round(cpu*10) / 10
-			snap.MemPercent = math.Round(mem*10) / 10
-			snap.ConnActive = connActive
-			snap.ConnIdle = connIdle
-			snap.ConnWait = connWait
-
-			// Collect runtime stats for dashboard system metrics cards
-			stats := health.CollectRuntimeStats(ar.startTime)
-
-			buf := statsBufPool.Get().(*bytes.Buffer)
-			buf.Reset()
-			if err := views.MetricsOOB(snap, stats).Render(shared.WithContextIDAndDescription(context.Background(), shared.GenerateContextID(), "publish metrics"), buf); err != nil {
-				statsBufPool.Put(buf)
-				continue
-			}
-			msg := tavern.NewSSEMessage("dashboard-metrics", buf.String()).String()
-			statsBufPool.Put(buf)
-			broker.Publish(TopicDashMetrics, msg)
-		}
-	}
-}
-
-// --- Services publisher ---
 
 var serviceNames = []string{"api-gateway", "auth-svc", "user-svc", "order-svc", "payment-svc"}
 
@@ -448,57 +235,6 @@ func initialServiceLatencies() []views.ServiceLatency {
 	return svcLats
 }
 
-func (ar *appRoutes) publishServices(broker *tavern.SSEBroker) {
-	services := initialServices()
-	svcLatencies := initialServiceLatencies()
-
-	for {
-		select {
-		case <-ar.ctx.Done():
-			return
-		case <-time.After(getRTInterval("services")):
-			if !broker.HasSubscribers(TopicDashServices) {
-				continue
-			}
-
-			maxMs := 0.0
-			for i := range services {
-				services[i].Load += (rand.Float64() - 0.48) * 0.12
-				services[i].Load = math.Max(0.05, math.Min(1.0, services[i].Load))
-				services[i].Load = math.Round(services[i].Load*100) / 100
-				services[i].Status = statusFromLoad(services[i].Load)
-
-				// Per-service latency correlates with load
-				baseLat := 20 + services[i].Load*80
-				lat := baseLat + (rand.Float64()-0.5)*20
-				lat = math.Max(5, math.Min(300, lat))
-				lat = math.Round(lat*10) / 10
-				svcLatencies[i].History = append(svcLatencies[i].History, lat)
-				if len(svcLatencies[i].History) > 20 {
-					svcLatencies[i].History = svcLatencies[i].History[len(svcLatencies[i].History)-20:]
-				}
-				for _, v := range svcLatencies[i].History {
-					if v > maxMs {
-						maxMs = v
-					}
-				}
-			}
-
-			buf := statsBufPool.Get().(*bytes.Buffer)
-			buf.Reset()
-			if err := views.ServicesOOB(services, svcLatencies, maxMs*1.1).Render(shared.WithContextIDAndDescription(context.Background(), shared.GenerateContextID(), "publish services"), buf); err != nil {
-				statsBufPool.Put(buf)
-				continue
-			}
-			msg := tavern.NewSSEMessage("dashboard-services", buf.String()).String()
-			statsBufPool.Put(buf)
-			broker.Publish(TopicDashServices, msg)
-		}
-	}
-}
-
-// --- Events publisher ---
-
 type eventTemplate struct {
 	Kind     string
 	Messages []string
@@ -531,36 +267,221 @@ var eventTemplates = []eventTemplate{
 	}},
 }
 
-func (ar *appRoutes) publishEvents(broker *tavern.SSEBroker) {
-	for {
-		// Random jitter ±30% around configured interval
-		base := getRTInterval("events")
-		jitter := time.Duration(float64(base) * (0.7 + rand.Float64()*0.6))
+func (ar *appRoutes) initDashboardPublisher(broker *tavern.SSEBroker) {
+	dashTracker = newIntervalTracker(rtCardDefaults)
+	dashPub = broker.NewScheduledPublisher(TopicDashMetrics, tavern.WithBaseTick(500*time.Millisecond))
 
-		select {
-		case <-ar.ctx.Done():
-			return
-		case <-time.After(jitter):
-			if !broker.HasSubscribers(TopicDashEvents) {
-				continue
-			}
+	// Shared simulation state
+	snap := initialMetrics()
+	rps := snap.RPS
+	errPct := snap.ErrorPct
+	p99 := snap.P99Ms
+	cpu := snap.CPUPercent
+	mem := snap.MemPercent
+	netIn := 12.5
+	netOut := 8.3
+	connActive := snap.ConnActive
+	connIdle := snap.ConnIdle
+	connWait := snap.ConnWait
+	p50 := 15.0
+	p90 := 35.0
+	diskRead := 50.0
+	diskWrite := 30.0
 
-			tmpl := eventTemplates[rand.IntN(len(eventTemplates))]
-			evt := views.DashboardEvent{
-				Time:    time.Now(),
-				Kind:    tmpl.Kind,
-				Message: tmpl.Messages[rand.IntN(len(tmpl.Messages))],
-			}
+	services := initialServices()
+	svcLatencies := initialServiceLatencies()
 
-			buf := statsBufPool.Get().(*bytes.Buffer)
-			buf.Reset()
-			if err := views.EventOOB(evt).Render(shared.WithContextIDAndDescription(context.Background(), shared.GenerateContextID(), "publish events"), buf); err != nil {
-				statsBufPool.Put(buf)
-				continue
-			}
-			msg := tavern.NewSSEMessage("dashboard-events", buf.String()).String()
-			statsBufPool.Put(buf)
-			broker.Publish(TopicDashEvents, msg)
+	// _sim: advance simulation state every tick, writes nothing
+	dashPub.Register("_sim", 500*time.Millisecond, func(_ context.Context, _ *bytes.Buffer) error {
+		// Random walk for RPS with occasional spikes
+		rps += (rand.Float64() - 0.48) * 120
+		if rand.Float64() < 0.05 {
+			rps += 400 + rand.Float64()*300
+			errPct += 1.5 + rand.Float64()*2
 		}
-	}
+		rps = math.Max(200, math.Min(3000, rps))
+
+		// Error rate drifts back toward baseline
+		errPct += (rand.Float64() - 0.55) * 0.4
+		errPct = math.Max(0.1, math.Min(8.0, errPct))
+
+		// P99 latency correlates loosely with RPS
+		p99 += (rand.Float64() - 0.5) * 15
+		if rps > 2000 {
+			p99 += 10
+		}
+		p99 = math.Max(10, math.Min(300, p99))
+
+		// CPU/Memory drift
+		cpu += (rand.Float64() - 0.48) * 5
+		cpu = math.Max(5, math.Min(98, cpu))
+		mem += (rand.Float64() - 0.5) * 3
+		mem = math.Max(15, math.Min(95, mem))
+
+		// Network traffic drift
+		netIn += (rand.Float64() - 0.48) * 8
+		netIn = math.Max(1, math.Min(80, netIn))
+		netOut += (rand.Float64() - 0.5) * 6
+		netOut = math.Max(0.5, math.Min(60, netOut))
+
+		pt := views.NetworkPoint{
+			InMBps:  math.Round(netIn*10) / 10,
+			OutMBps: math.Round(netOut*10) / 10,
+		}
+		snap.Network = append(snap.Network, pt)
+		if len(snap.Network) > 15 {
+			snap.Network = snap.Network[len(snap.Network)-15:]
+		}
+
+		// Recalculate max network for normalization
+		maxNet := 0.0
+		for _, p := range snap.Network {
+			combined := p.InMBps + p.OutMBps
+			if combined > maxNet {
+				maxNet = combined
+			}
+		}
+		snap.MaxNetwork = maxNet * 1.1
+
+		// Connection pool redistribution (total ~35)
+		total := connActive + connIdle + connWait
+		shift := rand.IntN(5) - 2
+		connActive += shift
+		if connActive < 3 {
+			connActive = 3
+		}
+		if connActive > total-4 {
+			connActive = total - 4
+		}
+		remaining := total - connActive
+		connIdle = remaining/2 + rand.IntN(3) - 1
+		if connIdle < 1 {
+			connIdle = 1
+		}
+		if connIdle > remaining-1 {
+			connIdle = remaining - 1
+		}
+		connWait = remaining - connIdle
+
+		// P50/P90 random walk (enforce ordering)
+		p50 += (rand.Float64() - 0.5) * 8
+		p50 = math.Max(5, math.Min(p90-5, p50))
+		p90 += (rand.Float64() - 0.5) * 12
+		p90 = math.Max(p50+5, math.Min(p99-5, p90))
+
+		// Latency histogram (rolling 10)
+		snap.LatencyHist = append(snap.LatencyHist, views.LatencyBucket{
+			P50: math.Round(p50*10) / 10,
+			P90: math.Round(p90*10) / 10,
+			P99: math.Round(p99*10) / 10,
+		})
+		if len(snap.LatencyHist) > 10 {
+			snap.LatencyHist = snap.LatencyHist[len(snap.LatencyHist)-10:]
+		}
+		maxLat := 0.0
+		for _, b := range snap.LatencyHist {
+			if b.P99 > maxLat {
+				maxLat = b.P99
+			}
+		}
+		snap.MaxLatency = maxLat * 1.1
+
+		// Error history (rolling 30)
+		snap.ErrorHistory = append(snap.ErrorHistory, views.ErrorRatePoint{Value: math.Round(errPct*10) / 10})
+		if len(snap.ErrorHistory) > 30 {
+			snap.ErrorHistory = snap.ErrorHistory[len(snap.ErrorHistory)-30:]
+		}
+
+		// Disk I/O random walk (rolling 15)
+		diskRead += (rand.Float64() - 0.48) * 12
+		diskRead = math.Max(1, math.Min(200, diskRead))
+		diskWrite += (rand.Float64() - 0.5) * 10
+		diskWrite = math.Max(1, math.Min(150, diskWrite))
+		snap.DiskIO = append(snap.DiskIO, views.DiskIOPoint{
+			ReadMBps:  math.Round(diskRead*10) / 10,
+			WriteMBps: math.Round(diskWrite*10) / 10,
+		})
+		if len(snap.DiskIO) > 15 {
+			snap.DiskIO = snap.DiskIO[len(snap.DiskIO)-15:]
+		}
+		maxDisk := 0.0
+		for _, d := range snap.DiskIO {
+			combined := d.ReadMBps + d.WriteMBps
+			if combined > maxDisk {
+				maxDisk = combined
+			}
+		}
+		snap.MaxDiskIO = maxDisk * 1.1
+
+		// Status distribution (derived from RPS)
+		reqTotal := int(math.Round(rps))
+		s5xx := int(math.Round(errPct / 100 * float64(reqTotal)))
+		s4xx := int(float64(reqTotal) * (0.02 + rand.Float64()*0.02))
+		s3xx := int(float64(reqTotal) * (0.02 + rand.Float64()*0.02))
+		s2xx := reqTotal - s3xx - s4xx - s5xx
+		if s2xx < 0 {
+			s2xx = 0
+		}
+		snap.StatusDist = views.StatusDistribution{S2xx: s2xx, S3xx: s3xx, S4xx: s4xx, S5xx: s5xx}
+
+		snap.RPS = math.Round(rps)
+		snap.ErrorPct = math.Round(errPct*10) / 10
+		snap.P99Ms = math.Round(p99*10) / 10
+		snap.CPUPercent = math.Round(cpu*10) / 10
+		snap.MemPercent = math.Round(mem*10) / 10
+		snap.ConnActive = connActive
+		snap.ConnIdle = connIdle
+		snap.ConnWait = connWait
+
+		// Advance services simulation
+		for i := range services {
+			services[i].Load += (rand.Float64() - 0.48) * 0.12
+			services[i].Load = math.Max(0.05, math.Min(1.0, services[i].Load))
+			services[i].Load = math.Round(services[i].Load*100) / 100
+			services[i].Status = statusFromLoad(services[i].Load)
+
+			baseLat := 20 + services[i].Load*80
+			lat := baseLat + (rand.Float64()-0.5)*20
+			lat = math.Max(5, math.Min(300, lat))
+			lat = math.Round(lat*10) / 10
+			svcLatencies[i].History = append(svcLatencies[i].History, lat)
+			if len(svcLatencies[i].History) > 20 {
+				svcLatencies[i].History = svcLatencies[i].History[len(svcLatencies[i].History)-20:]
+			}
+		}
+
+		return nil
+	})
+
+	// Metrics section — KPIs, charts, gauges, system stats
+	dashPub.Register("metrics", rtCardDefaults["metrics"], func(ctx context.Context, buf *bytes.Buffer) error {
+		stats := health.CollectRuntimeStats(ar.startTime)
+		return views.MetricsOOB(snap, stats).Render(shared.WithContextIDAndDescription(ctx, shared.GenerateContextID(), "publish metrics"), buf)
+	})
+
+	// Services section — service health bars + per-service latency
+	dashPub.Register("services", rtCardDefaults["services"], func(ctx context.Context, buf *bytes.Buffer) error {
+		maxMs := 0.0
+		for _, sl := range svcLatencies {
+			for _, v := range sl.History {
+				if v > maxMs {
+					maxMs = v
+				}
+			}
+		}
+		return views.ServicesOOB(services, svcLatencies, maxMs*1.1).Render(shared.WithContextIDAndDescription(ctx, shared.GenerateContextID(), "publish services"), buf)
+	})
+
+	// Events section — live event feed
+	dashPub.Register("events", rtCardDefaults["events"], func(ctx context.Context, buf *bytes.Buffer) error {
+		tmpl := eventTemplates[rand.IntN(len(eventTemplates))]
+		evt := views.DashboardEvent{
+			Time:    time.Now(),
+			Kind:    tmpl.Kind,
+			Message: tmpl.Messages[rand.IntN(len(tmpl.Messages))],
+		}
+		return views.EventOOB(evt).Render(shared.WithContextIDAndDescription(ctx, shared.GenerateContextID(), "publish events"), buf)
+	})
+
+	broker.RunPublisher(ar.ctx, dashPub.Start)
 }

--- a/internal/routes/topics.go
+++ b/internal/routes/topics.go
@@ -4,9 +4,7 @@ package routes
 // used by the real-time features (dashboard, canvas, feed, etc.).
 const (
 	TopicSystemStats  = "system-stats"
-	TopicDashMetrics  = "dashboard-metrics"
-	TopicDashServices = "dashboard-services"
-	TopicDashEvents   = "dashboard-events"
+	TopicDashMetrics = "dashboard-metrics"
 	TopicPeopleUpdate = "people-update"
 	TopicActivityFeed = "activity-feed"
 	TopicErrorTraces  = "error-traces"


### PR DESCRIPTION
## Summary
- Upgrade tavern to v0.4.26 with ScheduledPublisher, debounce/throttle, and other new features
- Replace hand-rolled isDue/lastSent interval tracking with tavern ScheduledPublisher across all 3 publisher loops (admin panel, dashboard charts, numerical tiles)
- Extract intervalTracker helper for master control save/restore pattern
- SSE handlers now format messages as SSE events (publisher sends raw OOB HTML)

## Test plan
- [ ] Admin settings page SSE updates work
- [ ] Dashboard charts update at correct intervals
- [ ] Numerical tiles update at correct intervals
- [ ] Per-card interval sliders work
- [ ] Master control enable/disable with save/restore works
- [ ] Unit cycling on interval controls works