### PR TITLE
fix: add Secure flag to session and canvas cookies

### DIFF
--- a/internal/routes/routes_canvas.go
+++ b/internal/routes/routes_canvas.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	appenv "catgoose/dothog/internal/env"
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
 	"github.com/catgoose/tavern"
@@ -185,6 +186,7 @@ func getOrCreateClientID(c echo.Context) string {
 		Path:     "/",
 		MaxAge:   86400 * 30,
 		HttpOnly: true,
+		Secure:   !appenv.Dev(),
 		SameSite: http.SameSiteLaxMode,
 	})
 	return id

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+
+	appenv "catgoose/dothog/internal/env"
 	"time"
 )
 
@@ -184,6 +186,7 @@ func getOrCreateSessionCookie(w http.ResponseWriter, r *http.Request, cookieName
 		Path:     "/",
 		MaxAge:   365 * 24 * 60 * 60,
 		HttpOnly: true,
+		Secure:   !appenv.Dev(),
 		SameSite: http.SameSiteLaxMode,
 	})
 	return id, nil


### PR DESCRIPTION
## Summary
- Add `Secure` flag to session and canvas client cookies
- Gated on `!appenv.Dev()` so local HTTP development still works

Closes #454