### PR TITLE
fix: gate crooner fields and IntervalSlider behind setup feature markers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,8 +24,11 @@ import (
 // accessible via GetConfig()/MustGetConfig(). Extend by adding fields
 // and reading them in buildConfig().
 type AppConfig struct {
-	SessionMgr                crooner.SessionManager
-	CroonerConfig             *crooner.AuthConfigParams
+	// setup:feature:auth:start
+	SessionMgr      crooner.SessionManager
+	CroonerConfig   *crooner.AuthConfigParams
+	CroonerDisabled bool
+	// setup:feature:auth:end
 	DatabaseURL               string
 	SessionSecret             string
 	AppName                   string
@@ -33,7 +36,6 @@ type AppConfig struct {
 	CSRFPerRequestPaths       []string
 	CSRFExemptPaths           []string
 	GraphUserCacheRefreshHour int
-	CroonerDisabled           bool
 	EnableDatabase            bool
 	InitRepo                  bool
 	CSRFRotatePerRequest      bool

--- a/web/views/admin_health.templ
+++ b/web/views/admin_health.templ
@@ -2,7 +2,9 @@ package views
 
 import (
 	"catgoose/dothog/internal/health"
+	// setup:feature:demo:start
 	components "catgoose/dothog/web/components/core"
+	// setup:feature:demo:end
 )
 
 // AdminHealthPage renders the /admin/health page with live health status.
@@ -14,10 +16,12 @@ templ AdminHealthPage(h health.Response) {
 				<p class="text-sm text-base-content/60">Live application health status via SSE.</p>
 			</div>
 			<div class="flex items-center gap-3">
+				// setup:feature:demo:start
 				@components.IntervalSlider(components.IntervalSliderCfg{
 					TargetKey: "section", TargetValue: "health",
 					IntervalMs: 5000, Scale: "s", PostURL: "/admin/settings/interval",
 				})
+				// setup:feature:demo:end
 				<a href="/health" target="_blank" class="btn btn-sm btn-ghost font-mono">GET /health</a>
 			</div>
 		</div>

--- a/web/views/admin_health_templ.go
+++ b/web/views/admin_health_templ.go
@@ -10,7 +10,9 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"catgoose/dothog/internal/health"
+	// setup:feature:demo:start
 	components "catgoose/dothog/web/components/core"
+	// setup:feature:demo:end
 )
 
 // AdminHealthPage renders the /admin/health page with live health status.
@@ -39,6 +41,7 @@ func AdminHealthPage(h health.Response) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		// setup:feature:demo:start
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			TargetKey: "section", TargetValue: "health",
 			IntervalMs: 5000, Scale: "s", PostURL: "/admin/settings/interval",
@@ -46,6 +49,7 @@ func AdminHealthPage(h health.Response) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		// setup:feature:demo:end
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<a href=\"/health\" target=\"_blank\" class=\"btn btn-sm btn-ghost font-mono\">GET /health</a></div></div><div id=\"health-content\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -145,7 +149,7 @@ func healthContent(h health.Response) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(h.Status)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 50, Col: 18}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 54, Col: 18}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -158,7 +162,7 @@ func healthContent(h health.Response) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(h.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 56, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 60, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -171,7 +175,7 @@ func healthContent(h health.Response) templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(h.Version)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 60, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 64, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -184,7 +188,7 @@ func healthContent(h health.Response) templ.Component {
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(h.Uptime)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 64, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 68, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
@@ -228,7 +232,7 @@ func healthContent(h health.Response) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(h.Database)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 72, Col: 21}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_health.templ`, Line: 76, Col: 21}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Gate `SessionMgr`, `CroonerConfig`, and `CroonerDisabled` struct fields in `config.go` with `setup:feature:auth` markers so they are stripped when auth is removed
- Gate `IntervalSlider` import and usage in `admin_health.templ` (and generated `_templ.go`) with `setup:feature:demo` markers so the component reference is stripped when demo is removed

Fixes CI failures in `TestSetup_FeaturesNone` and `TestSetup_PWAWithoutCapacitor` where scaffolded apps with stripped features fail to compile due to undefined `crooner` and `components.IntervalSlider` references.

## Test plan

- [ ] CI passes: `TestSetup_FeaturesNone` and `TestSetup_PWAWithoutCapacitor` no longer fail
- [ ] Full build still compiles: `CGO_ENABLED=0 go build ./...`