### PR TITLE
fix: pre-declare theme variable outside session_settings gate

### DIFF
--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -71,8 +71,9 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 		csrfToken = t
 	}
 	// setup:feature:csrf:end
+	var theme string
 	// setup:feature:session_settings:start
-	theme := session.GetSettings(c.Request()).Theme
+	theme = session.GetSettings(c.Request()).Theme
 	// setup:feature:session_settings:end
 
 	var crumbs []linkwell.Breadcrumb


### PR DESCRIPTION
## Summary

- The `theme` variable in `getLayoutCtx` was declared inside a `setup:feature:session_settings` gate using `:=`, but referenced outside it at the return statement
- When scaffold generation strips the `session_settings` feature, the declaration is removed but the usage remains, causing `undefined: theme` compilation errors
- Fix: pre-declare `theme` as `var theme string` before the gate (matching the existing pattern used for `csrfToken` with the `csrf` gate), so the variable always exists with a zero-value default

## Test plan

- [x] `go test -run TestSetup_FeaturesNone ./tests/` passes
- [x] `go test -run TestSetup_FeaturesMSSQL ./tests/` passes