### PR TITLE
fix: compile Tailwind CSS in pipeline to fix deployed themes

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Update vendored assets
         run: mage updateAssets
 
+      - name: Compile Tailwind CSS
+        run: mage tailwind
+
       - name: Check for changes
         id: check-changes
         run: |


### PR DESCRIPTION
## Summary

- The pipeline runs `mage updateAssets` (downloads Tailwind binary + DaisyUI CSS) but never runs `mage tailwind` to compile `input.css` into `tailwind.css`
- Deployed builds therefore have no compiled Tailwind output, breaking theme selection
- Adds `mage tailwind` step between "Update vendored assets" and "Check for changes" so compiled CSS is committed with the other asset updates

## Notes

- `main.yml` already handles this via `mage build` which includes Tailwind compilation, so no change needed there
- The new step runs after `mage tailwindUpdate` (installs the binary) and `mage updateAssets` (downloads DaisyUI), so all dependencies are in place