### PR TITLE
feat: add fetchpriority attributes to resource hints

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -260,9 +260,9 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			preloadLinks := []string{
-				"</public/css/tailwind.css>; rel=preload; as=style",
+				"</public/css/tailwind.css>; rel=preload; as=style; fetchpriority=high",
 				"</public/css/daisyui.css>; rel=preload; as=style",
-				"</public/js/htmx.min.js>; rel=preload; as=script",
+				"</public/js/htmx.min.js>; rel=preload; as=script; fetchpriority=high",
 			}
 			if !behindProxy && c.Request().ProtoMajor >= 2 {
 				w := c.Response().Writer

--- a/web/views/index.templ
+++ b/web/views/index.templ
@@ -63,9 +63,9 @@ templ header(csrfToken string, devMode bool, appName string, extraCSS []string) 
 		<meta charset="UTF-8"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 		<meta name="description" content={ appName + " - IT operations dashboard for managing infrastructure, inventory, and real-time monitoring" }/>
-		<link rel="preload" href="/public/css/tailwind.css" as="style"/>
+		<link rel="preload" href="/public/css/tailwind.css" as="style" fetchpriority="high"/>
+		<link rel="preload" href="/public/js/htmx.min.js" as="script" fetchpriority="high"/>
 		<link rel="preload" href="/public/js/_hyperscript.min.js" as="script"/>
-		<link rel="preload" href="/public/js/htmx.min.js" as="script"/>
 		<script>
 			if (window.trustedTypes) {
 				trustedTypes.createPolicy('default', {


### PR DESCRIPTION
## Summary

- Add `fetchpriority="high"` to critical-path resources (tailwind.css, htmx.min.js) in base layout preload tags and Early Hints middleware Link headers
- Reorder preload tags so high-priority resources are listed first
- Leave enhancement-layer resources (_hyperscript, daisyui) at default priority

## Test plan

- [ ] Verify preload tags in rendered HTML include `fetchpriority="high"` for tailwind.css and htmx.min.js
- [ ] Verify Early Hints 103 response Link headers include `fetchpriority=high` for tailwind.css and htmx.min.js
- [ ] Confirm _hyperscript and daisyui preloads have no fetchpriority attribute

Closes #475