### PR TITLE
fix: update promolog API (ErrorTrace->Trace, Attrs string->map)

### DIFF
--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -137,7 +137,7 @@ func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Con
 					logger.WithContext(c.Request().Context()).Warn("Error trace missing UserID: azureId not set on echo context")
 				}
 				// setup:feature:auth:end
-				if promoteErr := reqLogStore.Promote(c.Request().Context(), promolog.ErrorTrace{
+				if promoteErr := reqLogStore.Promote(c.Request().Context(), promolog.Trace{
 					RequestID:  requestID,
 					ErrorChain: err.Error(),
 					StatusCode: statusCode,

--- a/internal/routes/report.go
+++ b/internal/routes/report.go
@@ -12,11 +12,11 @@ type IssueReporter interface {
 	// context about what they were doing. trace contains the full error trace
 	// including the error chain, request metadata, and captured log entries
 	// (may be nil if the request aged out of the store).
-	Report(requestID string, description string, trace *promolog.ErrorTrace) error
+	Report(requestID string, description string, trace *promolog.Trace) error
 }
 
 // defaultReporter is a no-op implementation used when no IssueReporter is configured.
 // It always succeeds — the endpoint still triggers the browser alert.
 type defaultReporter struct{}
 
-func (defaultReporter) Report(string, string, *promolog.ErrorTrace) error { return nil }
+func (defaultReporter) Report(string, string, *promolog.Trace) error { return nil }

--- a/internal/routes/routes_error_traces.go
+++ b/internal/routes/routes_error_traces.go
@@ -211,11 +211,14 @@ func SeedErrorTraces(store promolog.Storer) {
 		return
 	}
 
+	type seedEntry struct {
+		Level, Message, Attrs string
+	}
 	type errorTemplate struct {
 		ErrorChain string
 		Route      string
 		Method     string
-		Entries    []promolog.Entry
+		Entries    []seedEntry
 		StatusCode int
 	}
 
@@ -223,7 +226,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "get user {id}: sql: no rows in result set",
 			StatusCode: 404, Route: "/api/users/{id}", Method: "GET",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=GET path=/api/users/{id}"},
 				{Level: "INFO", Message: "Querying user by ID", Attrs: "table=users query=SELECT * FROM users WHERE id=? params={id} duration_ms=3"},
 				{Level: "INFO", Message: "Database query completed", Attrs: "table=users rows_returned=0 duration_ms=3"},
@@ -233,7 +236,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "process order: validate inventory: insufficient stock for SKU-{id}",
 			StatusCode: 422, Route: "/api/orders/{id}", Method: "POST",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=POST path=/api/orders"},
 				{Level: "INFO", Message: "Parsing order payload", Attrs: "content_type=application/json items=3 total_cents=14995"},
 				{Level: "INFO", Message: "Validating inventory", Attrs: "sku=SKU-{id} requested_qty=10 warehouse=us-east-1"},
@@ -244,7 +247,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "render dashboard: query metrics: context deadline exceeded",
 			StatusCode: 504, Route: "/dashboard", Method: "GET",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=GET path=/dashboard"},
 				{Level: "INFO", Message: "Fetching metrics", Attrs: "range=7d source=prometheus endpoint=http://metrics:9090/api/v1/query_range"},
 				{Level: "INFO", Message: "Query executing", Attrs: "query=rate(http_requests_total[5m]) elapsed_ms=2100"},
@@ -255,7 +258,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "upload file: multipart: NextPart: unexpected EOF",
 			StatusCode: 400, Route: "/api/files/upload", Method: "POST",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=POST path=/api/files/upload content_length=1048576"},
 				{Level: "INFO", Message: "Parsing multipart form", Attrs: "content_type=multipart/form-data boundary=----WebKitFormBoundary{hex} max_size=10485760"},
 				{Level: "ERROR", Message: "Multipart parse failed", Attrs: "error=unexpected EOF bytes_read=524288 expected=1048576"},
@@ -264,7 +267,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "save settings: database is locked",
 			StatusCode: 500, Route: "/settings/theme", Method: "POST",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=POST path=/settings/theme"},
 				{Level: "INFO", Message: "Updating theme", Attrs: "theme=dark session=sess-{hex} table=SessionSettings"},
 				{Level: "INFO", Message: "Acquiring write lock", Attrs: "table=SessionSettings timeout_ms=30000"},
@@ -274,7 +277,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "fetch report: connect: connection refused",
 			StatusCode: 502, Route: "/api/reports/monthly", Method: "GET",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=GET path=/api/reports/monthly"},
 				{Level: "INFO", Message: "Calling reporting service", Attrs: "url=http://reports-svc:8080/v2/monthly timeout=10s"},
 				{Level: "INFO", Message: "DNS resolved", Attrs: "host=reports-svc addr=10.0.5.42 duration_ms=2"},
@@ -284,7 +287,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "authenticate: token expired",
 			StatusCode: 401, Route: "/api/protected/data", Method: "GET",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=GET path=/api/protected/data"},
 				{Level: "INFO", Message: "Extracting bearer token", Attrs: "header=Authorization scheme=Bearer"},
 				{Level: "WARN", Message: "Token validation failed", Attrs: "reason=expired exp=2026-03-13T23:59:59Z now=2026-03-14T00:01:12Z issuer=login.microsoftonline.com"},
@@ -294,7 +297,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "create item: UNIQUE constraint failed: items.name",
 			StatusCode: 409, Route: "/demo/inventory/items", Method: "POST",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=POST path=/demo/inventory/items"},
 				{Level: "INFO", Message: "Parsing item form", Attrs: "name=Widget-{id} category=Electronics price=29.99"},
 				{Level: "INFO", Message: "Creating item", Attrs: "table=items name=Widget-{id} category=Electronics"},
@@ -304,7 +307,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "authorize /admin/settings: role viewer cannot access admin resource",
 			StatusCode: 403, Route: "/admin/settings", Method: "GET",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=GET path=/admin/settings"},
 				{Level: "INFO", Message: "Authenticating user", Attrs: "session_id=sess-{hex} method=bearer_token"},
 				{Level: "INFO", Message: "User authenticated", Attrs: "user_id=usr-{id} email=user{id}@example.com roles=[viewer]"},
@@ -315,7 +318,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "update item {id}: optimistic lock: version mismatch",
 			StatusCode: 409, Route: "/api/items/{id}", Method: "PUT",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=PUT path=/api/items/{id}"},
 				{Level: "INFO", Message: "Loading item for update", Attrs: "item_id={id} table=items"},
 				{Level: "INFO", Message: "Comparing versions", Attrs: "item_id={id} client_version=3 server_version=4"},
@@ -325,7 +328,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "delete user {id}: foreign key constraint: user has active orders",
 			StatusCode: 409, Route: "/api/users/{id}", Method: "DELETE",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=DELETE path=/api/users/{id}"},
 				{Level: "INFO", Message: "Checking user dependencies", Attrs: "user_id={id} tables=[orders,sessions,audit_log]"},
 				{Level: "INFO", Message: "Found active references", Attrs: "user_id={id} orders=5 sessions=1 audit_entries=142"},
@@ -335,7 +338,7 @@ func SeedErrorTraces(store promolog.Storer) {
 		{
 			ErrorChain: "parse JSON body: unexpected end of JSON input",
 			StatusCode: 400, Route: "/api/webhooks/stripe", Method: "POST",
-			Entries: []promolog.Entry{
+			Entries: []seedEntry{
 				{Level: "INFO", Message: "Request started", Attrs: "method=POST path=/api/webhooks/stripe"},
 				{Level: "INFO", Message: "Receiving webhook", Attrs: "source=stripe event_type=payment_intent.succeeded content_length=2048"},
 				{Level: "INFO", Message: "Verifying signature", Attrs: "header=Stripe-Signature algo=hmac-sha256"},
@@ -382,14 +385,20 @@ func SeedErrorTraces(store promolog.Storer) {
 		// Format attrs with the current id so they have realistic values
 		entries := make([]promolog.Entry, len(tmpl.Entries))
 		for j, e := range tmpl.Entries {
+			attrMap := make(map[string]string)
+			for _, part := range strings.Fields(replacer.Replace(e.Attrs)) {
+				if k, v, ok := strings.Cut(part, "="); ok {
+					attrMap[k] = v
+				}
+			}
 			entries[j] = promolog.Entry{
 				Level:   e.Level,
 				Message: e.Message,
-				Attrs:   replacer.Replace(e.Attrs),
+				Attrs:   attrMap,
 			}
 		}
 
-		_ = store.PromoteAt(ctx, promolog.ErrorTrace{
+		_ = store.PromoteAt(ctx, promolog.Trace{
 			RequestID:  fmt.Sprintf("seed-%08x", i),
 			ErrorChain: errorChain,
 			StatusCode: tmpl.StatusCode,

--- a/internal/routes/routes_report_issue.go
+++ b/internal/routes/routes_report_issue.go
@@ -23,7 +23,7 @@ func (ar *appRoutes) initReportIssueRoutes() {
 	reportHandler := func(c echo.Context) error {
 		requestID := c.Param("requestID")
 		description := c.FormValue("description")
-		var trace *promolog.ErrorTrace
+		var trace *promolog.Trace
 		if ar.repos.ReqLogStore != nil && requestID != "" {
 			var err error
 			trace, err = ar.repos.ReqLogStore.Get(c.Request().Context(), requestID)

--- a/web/views/error_traces.templ
+++ b/web/views/error_traces.templ
@@ -2,24 +2,27 @@ package views
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/catgoose/promolog"
 	"github.com/catgoose/linkwell"
 	components "catgoose/dothog/web/components/core"
 )
 
-// parseAttrs splits a "key=value key2=value2" string into pairs.
-func parseAttrs(attrs string) [][]string {
-	if attrs == "" {
+// sortedAttrs returns map entries as sorted key-value pairs for display.
+func sortedAttrs(attrs map[string]string) [][]string {
+	if len(attrs) == 0 {
 		return nil
 	}
-	var pairs [][]string
-	for _, part := range strings.Fields(attrs) {
-		if k, v, ok := strings.Cut(part, "="); ok {
-			pairs = append(pairs, []string{k, v})
-		}
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([][]string, len(keys))
+	for i, k := range keys {
+		pairs[i] = []string{k, attrs[k]}
 	}
 	return pairs
 }
@@ -103,7 +106,7 @@ templ statusBadge(code int) {
 }
 
 // ErrorTraceDetailContent renders the expandable detail panel.
-templ ErrorTraceDetailContent(trace *promolog.ErrorTrace) {
+templ ErrorTraceDetailContent(trace *promolog.Trace) {
 	<td colspan="7" class="bg-base-200 p-4">
 		<div class="space-y-4">
 			<div class="flex items-start justify-between">
@@ -180,7 +183,7 @@ templ ErrorTraceDetailContent(trace *promolog.ErrorTrace) {
 					<span class="font-medium text-sm text-base-content/60">Log Entries ({ strconv.Itoa(len(trace.Entries)) })</span>
 					<div class="mt-1 space-y-1">
 						for _, entry := range trace.Entries {
-							{{ pairs := parseAttrs(entry.Attrs) }}
+							{{ pairs := sortedAttrs(entry.Attrs) }}
 							<div
 								class={ "rounded-lg border p-2", templ.KV("border-error/30 bg-error/5", entry.Level == "ERROR"), templ.KV("border-warning/30 bg-warning/5", entry.Level == "WARN"), templ.KV("border-base-300 bg-base-200", entry.Level != "ERROR" && entry.Level != "WARN") }
 								if len(pairs) > 0 {

--- a/web/views/error_traces_templ.go
+++ b/web/views/error_traces_templ.go
@@ -10,24 +10,27 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
-	"strings"
 
 	components "catgoose/dothog/web/components/core"
 	"github.com/catgoose/linkwell"
 	"github.com/catgoose/promolog"
 )
 
-// parseAttrs splits a "key=value key2=value2" string into pairs.
-func parseAttrs(attrs string) [][]string {
-	if attrs == "" {
+// sortedAttrs returns map entries as sorted key-value pairs for display.
+func sortedAttrs(attrs map[string]string) [][]string {
+	if len(attrs) == 0 {
 		return nil
 	}
-	var pairs [][]string
-	for _, part := range strings.Fields(attrs) {
-		if k, v, ok := strings.Cut(part, "="); ok {
-			pairs = append(pairs, []string{k, v})
-		}
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([][]string, len(keys))
+	for i, k := range keys {
+		pairs[i] = []string{k, attrs[k]}
 	}
 	return pairs
 }
@@ -383,7 +386,7 @@ func statusBadge(code int) templ.Component {
 }
 
 // ErrorTraceDetailContent renders the expandable detail panel.
-func ErrorTraceDetailContent(trace *promolog.ErrorTrace) templ.Component {
+func ErrorTraceDetailContent(trace *promolog.Trace) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -572,7 +575,7 @@ func ErrorTraceDetailContent(trace *promolog.ErrorTrace) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			for _, entry := range trace.Entries {
-				pairs := parseAttrs(entry.Attrs)
+				pairs := sortedAttrs(entry.Attrs)
 				var templ_7745c5c3_Var29 = []any{"rounded-lg border p-2", templ.KV("border-error/30 bg-error/5", entry.Level == "ERROR"), templ.KV("border-warning/30 bg-warning/5", entry.Level == "WARN"), templ.KV("border-base-300 bg-base-200", entry.Level != "ERROR" && entry.Level != "WARN")}
 				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var29...)
 				if templ_7745c5c3_Err != nil {

--- a/web/views/logging.templ
+++ b/web/views/logging.templ
@@ -180,7 +180,7 @@ templ loggingStatusBadge(code int) {
 }
 
 // LoggingReportOutput renders the simulated support report as formatted JSON.
-templ LoggingReportOutput(trace *promolog.ErrorTrace, jsonPayload string) {
+templ LoggingReportOutput(trace *promolog.Trace, jsonPayload string) {
 	<div class="card bg-base-100 shadow border border-base-300 mt-4">
 		<div class="card-body p-4">
 			<div class="flex items-center justify-between">

--- a/web/views/logging_templ.go
+++ b/web/views/logging_templ.go
@@ -426,7 +426,7 @@ func loggingStatusBadge(code int) templ.Component {
 }
 
 // LoggingReportOutput renders the simulated support report as formatted JSON.
-func LoggingReportOutput(trace *promolog.ErrorTrace, jsonPayload string) templ.Component {
+func LoggingReportOutput(trace *promolog.Trace, jsonPayload string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {


### PR DESCRIPTION
## Summary

- Rename all `promolog.ErrorTrace` references to `promolog.Trace` to match the upstream library rename
- Update `Entry.Attrs` usage from `string` to `map[string]string` across templates and seed data
- Introduce local `seedEntry` type in seed function to keep string-based attrs for template definitions, converting to maps at runtime

Fixes #207