### PR TITLE
fix: prevent deploy crash from in-memory SQLite recycling and error handler panic

### DIFF
--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -112,6 +112,16 @@ func handleErrorWithContext(c echo.Context, ec linkwell.ErrorContext) error {
 // shared store on error so it can be retrieved for issue reports.
 func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Context) {
 	return func(err error, c echo.Context) {
+		// The error handler runs after the middleware chain returns. If the
+		// httpcompression middleware has already finalized its writer, rendering
+		// the error page can panic (nil pointer in compressWriter.Write).
+		// Recover here so the connection isn't killed outright.
+		defer func() {
+			if r := recover(); r != nil {
+				logger.WithContext(c.Request().Context()).Error("Panic in error handler (response writer likely finalized)",
+					"panic", r, "route", c.Request().URL.Path)
+			}
+		}()
 		// Determine status code from error type before promoting.
 		statusCode := http.StatusInternalServerError
 		var hhe *linkwell.HTTPError

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -284,10 +284,10 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 		}
 	})
 
+	e.Use(echoMiddleware.Recover())
 	e.Use(middleware.ServerTimingMiddleware())
 	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
 	e.Use(echoMiddleware.RequestLogger())
-	e.Use(echoMiddleware.Recover())
 	e.Use(echo.WrapMiddleware(porter.SecurityHeaders(porter.SecurityHeadersConfig{
 		PermissionsPolicy:       "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
 		CrossOriginOpenerPolicy: "same-origin",

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -165,7 +165,10 @@ func handleErrorTracesSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
 		c.Response().Header().Set("Connection", "keep-alive")
 		c.Response().WriteHeader(http.StatusOK)
 
-		flusher := c.Response().Writer.(http.Flusher)
+		flusher, ok := c.Response().Writer.(http.Flusher)
+		if !ok {
+			return fmt.Errorf("streaming unsupported")
+		}
 		ch, unsub := broker.Subscribe(TopicErrorTraces)
 		defer unsub()
 

--- a/main.go
+++ b/main.go
@@ -82,6 +82,11 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to open error traces database", "error", err)
 	}
+	// In-memory SQLite databases are destroyed when the connection closes.
+	// Override chuck's default ConnMaxLifetime/ConnMaxIdleTime so the single
+	// connection is never recycled.
+	traceDB.SetConnMaxLifetime(0)
+	traceDB.SetConnMaxIdleTime(0)
 	defer func() {
 		if closeErr := traceDB.Close(); closeErr != nil {
 			logger.Info("Error closing error traces database", "error", closeErr)


### PR DESCRIPTION
## Summary

- **In-memory SQLite table disappearing after ~10min**: `chuck.OpenSQLite(":memory:")` sets `ConnMaxLifetime(10min)` which recycles the connection, destroying the in-memory database and all tables. Overridden to 0 (never recycle).
- **Error handler panic → 502**: `HTTPErrorHandler` runs outside `Recover()` middleware scope. When rendering the error page through a finalized httpcompression writer, `compressWriter.Write` panics with nil pointer. Added `defer recover()` in the error handler.
- **Recover middleware position**: Moved `Recover()` to first middleware position — was behind `ServerTimingMiddleware`, `CorrelationMiddleware`, and `RequestLogger`, so panics there escaped recovery.
- **Unchecked Flusher assertion**: Fixed unchecked `http.Flusher` type assertion in SSE error traces handler that would panic with httpcompression.

## Note

Theme picker and error trace expansion are broken because **Cloudflare edge cache is serving the old standard Alpine.js build** (before the CSP migration). The repo has the correct CSP build. Purge the Cloudflare cache for `demo.dothog.org/public/js/*` after deploy.

## Test plan

- [ ] Deploy and verify `/admin/error-traces` no longer returns 502
- [ ] Confirm error traces persist beyond 10 minutes of uptime
- [ ] Purge Cloudflare cache, then verify theme switching works
- [ ] Verify error trace row expansion works after cache purge