### PR TITLE
fix: correct tavern broker lifecycle and linkwell usage

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -168,7 +168,6 @@ func (ar *appRoutes) InitRoutes() error {
 	// setup:feature:demo:start
 	ar.initPwaRoutes()
 	ar.initReportDemoRoutes()
-	ar.initLoggingRoutes()
 	ar.initControlsGalleryRoutes()
 	ar.initComponentsRoutes()
 	ar.initComponents2Routes()
@@ -181,6 +180,10 @@ func (ar *appRoutes) InitRoutes() error {
 	// setup:feature:session_settings:start
 	ar.initThemeRoutes(ar.broker)
 	// setup:feature:session_settings:end
+
+	// setup:feature:demo:start
+	ar.initLoggingRoutes(ar.broker)
+	// setup:feature:demo:end
 
 	// setup:feature:demo:start
 	ar.initHypermediaRoutes()

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -22,7 +22,7 @@ import (
 
 const loggingBase = "/demo/logging"
 
-func (ar *appRoutes) initLoggingRoutes() {
+func (ar *appRoutes) initLoggingRoutes(broker *tavern.SSEBroker) {
 	// Client beacon endpoint — fire-and-forget analytics via navigator.sendBeacon.
 	ar.e.POST("/log/beacon", func(c echo.Context) error {
 		var entry struct {
@@ -46,8 +46,6 @@ func (ar *appRoutes) initLoggingRoutes() {
 	})
 
 	// setup:feature:sse:start
-	broker := tavern.NewSSEBroker()
-
 	// Wire up SSE broadcasting on error trace promotion.
 	if ar.repos.ReqLogStore != nil {
 		ar.repos.ReqLogStore.SetOnPromote(func(summary promolog.TraceSummary) {


### PR DESCRIPTION
## Summary

- **Fix orphaned SSE broker in logging routes**: `routes_logging.go` was creating its own `tavern.NewSSEBroker()` instead of using the shared `ar.broker` from `routes.go`. This orphaned broker was never closed in `AppRoutes.Close()`, leaking resources.
- **Fix initialization order**: `initLoggingRoutes()` was called at line 171 before the shared broker was created at line 179. Moved the call to after broker initialization and updated the signature to accept `broker *tavern.SSEBroker`.

## Audit findings

- **linkwell usage**: All usage is correct — `SetActiveNavItemPrefix` for prefix-based nav matching in handler, `SetActiveNavItem` for exact matching in hypermedia controls, Hub/Ring/Link API properly used in `routes_links.go`, breadcrumbs via `RegisterFrom`/`ResolveFromMask`. No manual nav building that should use linkwell helpers.
- **tavern usage**: All other SSE handlers properly use `Subscribe`/`unsub` cleanup, `HasSubscribers` guards before publishing, and `tavern.NewSSEMessage` for message formatting. No manual SSE formatting found.

## Test plan

- [ ] Verify logging demo page SSE error traces still stream correctly
- [ ] Verify `AppRoutes.Close()` properly shuts down all brokers (no orphaned goroutines)
- [ ] Verify other SSE features (realtime dashboard, theme, feed, canvas) unaffected

Closes #487