### PR TITLE
fix: correct feature gate boundaries for setup test variants

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,20 +25,22 @@ import (
 // and reading them in buildConfig().
 type AppConfig struct {
 	// setup:feature:auth:start
-	SessionMgr      crooner.SessionManager
-	CroonerConfig   *crooner.AuthConfigParams
-	CroonerDisabled bool
+	SessionMgr    crooner.SessionManager
+	CroonerConfig *crooner.AuthConfigParams
 	// setup:feature:auth:end
+	ServerPort                string
 	DatabaseURL               string
 	SessionSecret             string
 	AppName                   string
-	ServerPort                string
 	CSRFPerRequestPaths       []string
 	CSRFExemptPaths           []string
 	GraphUserCacheRefreshHour int
-	EnableDatabase            bool
-	InitRepo                  bool
-	CSRFRotatePerRequest      bool
+	// setup:feature:auth:start
+	CroonerDisabled bool
+	// setup:feature:auth:end
+	EnableDatabase       bool
+	InitRepo             bool
+	CSRFRotatePerRequest bool
 }
 
 func buildConfig() (*AppConfig, error) {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -11,20 +11,20 @@ import (
 	"github.com/catgoose/tavern"
 	// setup:feature:sse:end
 	"catgoose/dothog/internal/health"
+	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/version"
 	"github.com/catgoose/promolog"
-	"catgoose/dothog/internal/routes/handler"
 	// setup:feature:demo:start
 	"github.com/catgoose/linkwell"
 	// setup:feature:demo:end
-	"catgoose/dothog/web/views"
 	"catgoose/dothog/internal/routes/middleware"
+	"catgoose/dothog/web/views"
 	// setup:feature:session_settings:start
 	"catgoose/dothog/internal/session"
 	// setup:feature:session_settings:end
-	"github.com/catgoose/porter"
 	"context"
 	"fmt"
+	"github.com/catgoose/porter"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -72,20 +72,20 @@ type Repos struct {
 
 // appRoutes implements AppRoutes
 type appRoutes struct {
-	e         *echo.Echo
-	ctx       context.Context
 	repos     Repos
 	startTime time.Time
-	healthCfg health.Config
+	ctx       context.Context
 	// setup:feature:sync:start
 	versionChecker VersionChecker
 	// setup:feature:sync:end
+	e *echo.Echo
 	// setup:feature:demo:start
 	demoDB *demo.DB
 	// setup:feature:demo:end
 	// setup:feature:sse:start
 	broker *tavern.SSEBroker
 	// setup:feature:sse:end
+	healthCfg health.Config
 }
 
 // Close shuts down the SSE broker and releases resources.
@@ -403,4 +403,3 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 
 	return e, nil
 }
-

--- a/internal/routes/routes_numerical.go
+++ b/internal/routes/routes_numerical.go
@@ -23,20 +23,19 @@ import (
 // ── Simulation state ────────────────────────────────────────────────────────
 
 type numSim struct {
-	txnSec    float64
-	revenue   float64
-	users     float64
+	uptime    time.Time
+	mem       float64
+	sla       float64
 	queue     float64
 	cacheHit  float64
 	errors    float64
 	p99       float64
 	cpu       float64
-	mem       float64
-	uptime    time.Time
+	txnSec    float64
+	users     float64
+	revenue   float64
 	deploys   int
-	sla       float64
 	incidents int
-
 	prevTxn   float64
 	prevUsers float64
 	prevQueue float64


### PR DESCRIPTION
## Summary

- `fieldalignment -fix` (run by CI) reorders struct fields and strips comments, breaking `// setup:feature:NAME:start/end` markers
- Reordered struct fields in `config.go`, `routes.go`, and `routes_numerical.go` to match fieldalignment output so the tool is idempotent
- Feature gates now survive CI runs without being disrupted

Fixes #207

## Test plan

- [ ] `go test -run TestSetup_Features -v ./tests/` passes locally
- [ ] CI Pipeline workflow passes (all feature variants build successfully)