### PR TITLE
fix: update e2e test routes after nav reorganization

### DIFF
--- a/e2e/approvals.spec.ts
+++ b/e2e/approvals.spec.ts
@@ -7,24 +7,24 @@ test.describe("Approval Queue", () => {
   });
 
   test("renders page with title", async ({ page }) => {
-    await navigateTo(page, "/demo/approvals");
+    await navigateTo(page, "/apps/approvals");
     await expect(page.locator("h1")).toContainText("Approval Queue");
   });
 
   test("approval list is visible", async ({ page }) => {
-    await navigateTo(page, "/demo/approvals");
+    await navigateTo(page, "/apps/approvals");
     await expect(page.locator("#approvals-list")).toBeVisible();
   });
 
   test("approval cards show required fields", async ({ page }) => {
-    await navigateTo(page, "/demo/approvals");
+    await navigateTo(page, "/apps/approvals");
     const cards = page.locator('[id^="approval-"]');
     const count = await cards.count();
     expect(count).toBeGreaterThan(0);
   });
 
   test("approve action works", async ({ page }) => {
-    await navigateTo(page, "/demo/approvals");
+    await navigateTo(page, "/apps/approvals");
     const approveBtn = page
       .locator('button:has-text("Approve")')
       .first();
@@ -37,7 +37,7 @@ test.describe("Approval Queue", () => {
   });
 
   test("reject action works", async ({ page }) => {
-    await navigateTo(page, "/demo/approvals");
+    await navigateTo(page, "/apps/approvals");
     const rejectBtn = page
       .locator('button:has-text("Reject")')
       .first();
@@ -49,7 +49,7 @@ test.describe("Approval Queue", () => {
   });
 
   test("status badges have correct styling", async ({ page }) => {
-    await navigateTo(page, "/demo/approvals");
+    await navigateTo(page, "/apps/approvals");
     const pendingBadges = page.locator(".badge-warning");
     if ((await pendingBadges.count()) > 0) {
       await expect(pendingBadges.first()).toBeVisible();

--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -13,7 +13,7 @@ test.describe("Inventory: silent parse failures", () => {
   test("price input is type=number (prevents non-numeric at HTML level)", async ({
     page,
   }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     const addBtn = page.locator('button:has-text("+ Add Item")');
     await addBtn.click();
     await waitForHtmx(page);
@@ -31,7 +31,7 @@ test.describe("Inventory: silent parse failures", () => {
   }) => {
     // BUG: If the HTML type=number is bypassed (API call), server silently
     // converts invalid price to 0 via strconv.ParseFloat defaulting
-    const resp = await request.post("/demo/inventory/items", {
+    const resp = await request.post("/apps/inventory/items", {
       form: {
         name: "Bug Test Item",
         price: "not-a-number",
@@ -47,7 +47,7 @@ test.describe("Inventory: silent parse failures", () => {
   test("creating item with empty name succeeds (missing validation)", async ({
     page,
   }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     const addBtn = page.locator('button:has-text("+ Add Item")');
     await addBtn.click();
     await waitForHtmx(page);
@@ -79,20 +79,20 @@ test.describe("Inventory: delete and update edge cases", () => {
 
   test("delete item via API removes it", async ({ request }) => {
     // First get inventory to verify items exist
-    const listResp = await request.get("/demo/inventory/items");
+    const listResp = await request.get("/apps/inventory/items");
     expect(listResp.ok()).toBe(true);
 
     // Delete item 1
-    const resp = await request.delete("/demo/inventory/items/1");
+    const resp = await request.delete("/apps/inventory/items/1");
     expect(resp.ok()).toBe(true);
 
     // Verify item 1 is gone
-    const getResp = await request.get("/demo/inventory/items/1");
+    const getResp = await request.get("/apps/inventory/items/1");
     expect(getResp.status()).toBe(404);
   });
 
   test("editing item preserves values after save", async ({ page }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
 
     // Click edit on first visible item
     const editBtn = page.locator(
@@ -127,7 +127,7 @@ test.describe("Bulk: silent failures on invalid operations", () => {
   });
 
   test("bulk activate changes status badges", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
 
     // Select a few rows
     const checkboxes = page.locator('tbody input[type="checkbox"]');
@@ -150,7 +150,7 @@ test.describe("Bulk: silent failures on invalid operations", () => {
   });
 
   test("bulk deactivate changes status badges", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
 
     const checkboxes = page.locator('tbody input[type="checkbox"]');
     const count = await checkboxes.count();
@@ -169,7 +169,7 @@ test.describe("Bulk: silent failures on invalid operations", () => {
   });
 
   test("bulk delete removes selected rows", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
 
     const rowsBefore = await page.locator("tbody tr").count();
     const checkboxes = page.locator('tbody input[type="checkbox"]');
@@ -187,7 +187,7 @@ test.describe("Bulk: silent failures on invalid operations", () => {
   });
 
   test("bulk action with no selection does nothing", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
 
     const rowsBefore = await page.locator("tbody tr").count();
     // Try activate without selecting anything
@@ -210,7 +210,7 @@ test.describe("People: missing field validation", () => {
     page,
   }) => {
     // Navigate to a person detail page
-    await navigateTo(page, "/demo/people");
+    await navigateTo(page, "/apps/people");
     const personRow = page.locator("tbody tr[hx-get]").first();
     if (await personRow.isVisible()) {
       await personRow.click();
@@ -252,7 +252,7 @@ test.describe("Kanban: edge cases", () => {
   });
 
   test("move task through all columns", async ({ page }) => {
-    await navigateTo(page, "/demo/kanban");
+    await navigateTo(page, "/apps/kanban");
 
     // Find first movable card and keep moving it right
     for (let i = 0; i < 4; i++) {
@@ -270,7 +270,7 @@ test.describe("Kanban: edge cases", () => {
   });
 
   test("move task left from first column does nothing", async ({ page }) => {
-    await navigateTo(page, "/demo/kanban");
+    await navigateTo(page, "/apps/kanban");
 
     // Find a card in the Backlog column and try to move left
     const backlogCol = page.locator('#kanban-col-backlog, [id*="backlog"]').first();
@@ -291,7 +291,7 @@ test.describe("Approvals: state transitions", () => {
   });
 
   test("approve then try to approve again (idempotency)", async ({ page }) => {
-    await navigateTo(page, "/demo/approvals");
+    await navigateTo(page, "/apps/approvals");
 
     const approveBtn = page.locator('button:has-text("Approve")').first();
     if (await approveBtn.isVisible()) {
@@ -306,7 +306,7 @@ test.describe("Approvals: state transitions", () => {
   });
 
   test("escalate then resubmit cycle", async ({ page }) => {
-    await navigateTo(page, "/demo/approvals");
+    await navigateTo(page, "/apps/approvals");
 
     const escalateBtn = page.locator('button:has-text("Escalate")').first();
     if (await escalateBtn.isVisible()) {
@@ -332,7 +332,7 @@ test.describe("Controls Gallery: error recovery flows", () => {
   test("transient error: first attempt fails, second succeeds", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     // Find the transient error trigger button
     const triggerBtn = page.locator('[hx-post*="errors/transient"]').first();
@@ -357,7 +357,7 @@ test.describe("Controls Gallery: error recovery flows", () => {
   });
 
   test("validation error with short name triggers 422", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     // Find validation trigger
     const triggerBtn = page.locator('[hx-post*="errors/validate"]').first();
@@ -372,7 +372,7 @@ test.describe("Controls Gallery: error recovery flows", () => {
   test("resource delete and re-view recovers automatically", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     // Find resource delete button
     const deleteBtn = page.locator('[hx-delete*="controls/resource"]').first();
@@ -394,7 +394,7 @@ test.describe("Controls Gallery: error recovery flows", () => {
     request,
   }) => {
     // API-level test: delete non-existent row
-    const resp = await request.delete("/hypermedia/controls/rows/99999");
+    const resp = await request.delete("/patterns/controls/rows/99999");
     // BUG: Returns 200 even though row 99999 doesn't exist
     expect(resp.status()).toBe(200);
     console.log(
@@ -403,7 +403,7 @@ test.describe("Controls Gallery: error recovery flows", () => {
   });
 
   test("stale data version mismatch triggers 412", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     const staleBtn = page.locator('[hx-post*="errors/stale"]').first();
     if (await staleBtn.isVisible()) {
@@ -412,7 +412,7 @@ test.describe("Controls Gallery: error recovery flows", () => {
       await waitForHtmx(page);
 
       // Re-navigate to reset UI state but keep server version incremented
-      await navigateTo(page, "/hypermedia/controls");
+      await navigateTo(page, "/patterns/controls");
 
       // Second submit with old version should fail with 412
       const staleBtn2 = page.locator('[hx-post*="errors/stale"]').first();
@@ -430,19 +430,19 @@ test.describe("CRUD: edge cases", () => {
   test("delete non-existent item via API returns 204 (idempotent)", async ({
     request,
   }) => {
-    const resp = await request.delete("/hypermedia/crud/items/99999");
+    const resp = await request.delete("/patterns/crud/items/99999");
     // DELETE is idempotent: returns 204 No Content regardless of existence
     expect(resp.status()).toBe(204);
   });
 
   test("update item with empty name returns 400", async ({ request }) => {
     // Create an item first
-    await request.post("/hypermedia/crud/items", {
+    await request.post("/patterns/crud/items", {
       form: { name: "Test Item", notes: "test" },
     });
 
     // Try to update with empty name
-    const resp = await request.put("/hypermedia/crud/items/1", {
+    const resp = await request.put("/patterns/crud/items/1", {
       form: { name: "", notes: "test" },
     });
     // This should return 400 (name is required)
@@ -452,7 +452,7 @@ test.describe("CRUD: edge cases", () => {
   test("create item with empty name defaults to 'New Item'", async ({
     request,
   }) => {
-    const resp = await request.post("/hypermedia/crud/items", {
+    const resp = await request.post("/patterns/crud/items", {
       form: { name: "", notes: "" },
     });
     expect(resp.ok()).toBe(true);
@@ -467,7 +467,7 @@ test.describe("CRUD: edge cases", () => {
   test("toggle item status flips between active and inactive", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/crud");
+    await navigateTo(page, "/patterns/crud");
     await waitForHtmx(page);
 
     // Find a toggle button
@@ -491,7 +491,7 @@ test.describe("CRUD: edge cases", () => {
 
 test.describe("Components: chat and timeline edge cases", () => {
   test("chat with empty message returns 204", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components");
+    await navigateTo(page, "/components/widgets");
     await waitForHtmx(page);
 
     const chatWindow = page.locator("#chat-window");
@@ -513,7 +513,7 @@ test.describe("Components: chat and timeline edge cases", () => {
   });
 
   test("chat appends user and bot messages", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components");
+    await navigateTo(page, "/components/widgets");
     await waitForHtmx(page);
 
     const chatWindow = page.locator("#chat-window");
@@ -543,39 +543,39 @@ test.describe("Components: chat and timeline edge cases", () => {
 
   test("steps wizard validates step boundaries", async ({ request }) => {
     // Step 0 should be invalid
-    const resp0 = await request.get("/hypermedia/components/steps/0");
+    const resp0 = await request.get("/components/widgets/steps/0");
     expect(resp0.status()).toBe(400);
 
     // Step 5 should be invalid (max is 4)
-    const resp5 = await request.get("/hypermedia/components/steps/5");
+    const resp5 = await request.get("/components/widgets/steps/5");
     expect(resp5.status()).toBe(400);
 
     // Step 1 should be valid
-    const resp1 = await request.get("/hypermedia/components/steps/1");
+    const resp1 = await request.get("/components/widgets/steps/1");
     expect(resp1.ok()).toBe(true);
 
     // Step 4 should be valid
-    const resp4 = await request.get("/hypermedia/components/steps/4");
+    const resp4 = await request.get("/components/widgets/steps/4");
     expect(resp4.ok()).toBe(true);
   });
 
   test("tabs reject invalid tab name", async ({ request }) => {
     const resp = await request.get(
-      "/hypermedia/components/tabs/nonexistent",
+      "/components/widgets/tabs/nonexistent",
     );
     expect(resp.status()).toBe(400);
   });
 
   test("rating rejects out of range values", async ({ request }) => {
     // Rating > 5 should be clamped or rejected
-    const resp = await request.post("/hypermedia/components/rating", {
+    const resp = await request.post("/components/widgets/rating", {
       form: { rating: "10" },
     });
     // If it silently clamps to 5, that's not ideal but acceptable
     expect(resp.ok()).toBe(true);
 
     // Rating of -1
-    const respNeg = await request.post("/hypermedia/components/rating", {
+    const respNeg = await request.post("/components/widgets/rating", {
       form: { rating: "-1" },
     });
     expect(respNeg.ok()).toBe(true);
@@ -586,7 +586,7 @@ test.describe("Components2: carousel and cascading", () => {
   test("carousel boundary: index beyond range is clamped", async ({
     request,
   }) => {
-    const resp = await request.get("/hypermedia/components2/carousel/999");
+    const resp = await request.get("/components/cards/carousel/999");
     // BUG: Returns 200 with clamped content instead of 400/404
     expect(resp.ok()).toBe(true);
     console.log(
@@ -597,7 +597,7 @@ test.describe("Components2: carousel and cascading", () => {
   test("BUG: carousel accepts negative index (should be 400)", async ({
     request,
   }) => {
-    const resp = await request.get("/hypermedia/components2/carousel/-1");
+    const resp = await request.get("/components/cards/carousel/-1");
     // BUG: Returns 200 with clamped content instead of 400
     // Negative index is silently clamped to 0
     expect(resp.status()).toBe(200);
@@ -605,7 +605,7 @@ test.describe("Components2: carousel and cascading", () => {
 
   test("cascading select with invalid country", async ({ request }) => {
     const resp = await request.get(
-      "/hypermedia/components2/cascading/Narnia",
+      "/components/cards/cascading/Narnia",
     );
     expect(resp.status()).toBe(400);
   });
@@ -613,7 +613,7 @@ test.describe("Components2: carousel and cascading", () => {
   test("BUG: dropdown search creates duplicate #dropdown-results elements", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/components2");
+    await navigateTo(page, "/components/cards");
     await waitForHtmx(page);
 
     const searchInput = page.locator('input[name="q"]').first();
@@ -638,13 +638,13 @@ test.describe("Components2: carousel and cascading", () => {
   });
 
   test("file upload without file returns 400", async ({ request }) => {
-    const resp = await request.post("/hypermedia/components2/upload");
+    const resp = await request.post("/components/cards/upload");
     expect(resp.status()).toBe(400);
   });
 
   test("accordion panel out of range returns 400", async ({ request }) => {
     const resp = await request.get(
-      "/hypermedia/components2/accordion/999",
+      "/components/cards/accordion/999",
     );
     expect(resp.status()).toBe(400);
   });
@@ -652,7 +652,7 @@ test.describe("Components2: carousel and cascading", () => {
 
 test.describe("Components3: soft delete edge cases", () => {
   test("favorite toggle works via UI", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components3");
+    await navigateTo(page, "/components/advanced");
     await waitForHtmx(page);
 
     // Find a favorite/heart button
@@ -668,7 +668,7 @@ test.describe("Components3: soft delete edge cases", () => {
   });
 
   test("soft delete and restore cycle", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components3");
+    await navigateTo(page, "/components/advanced");
     await waitForHtmx(page);
 
     // Find a delete button
@@ -695,10 +695,10 @@ test.describe("Components3: soft delete edge cases", () => {
     request,
   }) => {
     // Reset state by visiting the page
-    await request.get("/hypermedia/components3");
+    await request.get("/components/advanced");
 
     const resp = await request.get(
-      "/hypermedia/components3/feed?page=9999",
+      "/components/advanced/feed?page=9999",
     );
     // BUG: Returns 200 instead of expected 204 for out-of-bounds page
     // The server returns an empty response with 200 status
@@ -712,7 +712,7 @@ test.describe("Settings: field type handling", () => {
   });
 
   test("save settings and verify persistence", async ({ page }) => {
-    await navigateTo(page, "/demo/settings");
+    await navigateTo(page, "/platform/settings");
 
     // Find a toggle and change it
     const toggle = page.locator('input[type="checkbox"]').first();
@@ -726,7 +726,7 @@ test.describe("Settings: field type handling", () => {
         await waitForHtmx(page);
 
         // Reload page and check toggle state persisted
-        await navigateTo(page, "/demo/settings");
+        await navigateTo(page, "/platform/settings");
         const toggleAfter = page.locator('input[type="checkbox"]').first();
         const isAfter = await toggleAfter.isChecked();
         expect(isAfter).not.toBe(wasBefore);
@@ -740,7 +740,7 @@ test.describe("Admin: database reset", () => {
     request,
   }) => {
     // Create some items first
-    await request.post("/hypermedia/crud/items", {
+    await request.post("/patterns/crud/items", {
       form: { name: "Item to be wiped", notes: "test" },
     });
 
@@ -749,7 +749,7 @@ test.describe("Admin: database reset", () => {
     expect(resetResp.ok()).toBe(true);
 
     // Verify inventory has fresh data (not empty)
-    const invResp = await request.get("/demo/inventory");
+    const invResp = await request.get("/apps/inventory");
     expect(invResp.ok()).toBe(true);
     const body = await invResp.text();
     // Should have seeded items
@@ -781,41 +781,41 @@ test.describe("Admin: database reset", () => {
 
 test.describe("API: invalid ID handling across endpoints", () => {
   test("inventory: non-numeric ID returns 400", async ({ request }) => {
-    const resp = await request.get("/demo/inventory/items/abc");
+    const resp = await request.get("/apps/inventory/items/abc");
     expect(resp.status()).toBe(400);
   });
 
   test("inventory: negative ID returns 400", async ({ request }) => {
-    const resp = await request.get("/demo/inventory/items/-1");
+    const resp = await request.get("/apps/inventory/items/-1");
     expect(resp.status()).toBe(400);
   });
 
   test("inventory: ID 0 returns 400", async ({ request }) => {
-    const resp = await request.get("/demo/inventory/items/0");
+    const resp = await request.get("/apps/inventory/items/0");
     expect(resp.status()).toBe(400);
   });
 
   test("people: non-numeric ID returns 400", async ({ request }) => {
-    const resp = await request.get("/demo/people/abc");
+    const resp = await request.get("/apps/people/abc");
     expect(resp.status()).toBe(400);
   });
 
   test("people: missing person returns 404", async ({ request }) => {
-    const resp = await request.get("/demo/people/99999");
+    const resp = await request.get("/apps/people/99999");
     expect(resp.status()).toBe(404);
   });
 
   test("kanban move without status sets empty status on task", async ({
     request,
   }) => {
-    // PATCH /demo/kanban/tasks/:id with status in form body (V4 compliance)
+    // PATCH /apps/kanban/tasks/:id with status in form body (V4 compliance)
     // Missing status is accepted — MoveTask sets empty status on the task
-    const resp = await request.patch("/demo/kanban/tasks/1");
+    const resp = await request.patch("/apps/kanban/tasks/1");
     expect(resp.status()).toBe(200);
   });
 
   test("settings: non-existent section returns 404", async ({ request }) => {
-    const resp = await request.get("/demo/settings/nonexistent");
+    const resp = await request.get("/platform/settings/nonexistent");
     expect(resp.status()).toBe(404);
   });
 });
@@ -826,25 +826,25 @@ test.describe("Navigation: all pages load without 500 errors", () => {
     "/health",
     "/admin",
     "/dashboard",
-    "/demo/inventory",
-    "/demo/catalog",
-    "/demo/bulk",
-    "/demo/people",
-    "/demo/people/list",
-    "/demo/kanban",
-    "/demo/approvals",
-    "/demo/feed",
-    "/demo/settings",
-    "/demo/vendors",
-    "/hypermedia/controls",
-    "/hypermedia/crud",
-    "/hypermedia/lists",
-    "/hypermedia/interactions",
-    "/hypermedia/state",
-    "/hypermedia/components",
-    "/hypermedia/components2",
-    "/hypermedia/components3",
-    "/hypermedia/realtime",
+    "/apps/inventory",
+    "/apps/catalog",
+    "/apps/bulk",
+    "/apps/people",
+    "/apps/people/list",
+    "/apps/kanban",
+    "/apps/approvals",
+    "/realtime/feed",
+    "/platform/settings",
+    "/apps/vendors",
+    "/patterns/controls",
+    "/patterns/crud",
+    "/patterns/lists",
+    "/patterns/interactions",
+    "/patterns/state",
+    "/components/widgets",
+    "/components/cards",
+    "/components/advanced",
+    "/realtime/dashboard",
   ];
 
   for (const path of pages) {

--- a/e2e/bulk.spec.ts
+++ b/e2e/bulk.spec.ts
@@ -7,20 +7,20 @@ test.describe("Bulk Operations Page", () => {
   });
 
   test("renders page with title and table", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
     await expect(page.locator("h1")).toContainText("Bulk Operations");
     await expect(page.locator("#bulk-table-container")).toBeVisible();
   });
 
   test("table has checkboxes for row selection", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
     const checkboxes = page.locator('input[type="checkbox"]');
     const count = await checkboxes.count();
     expect(count).toBeGreaterThan(1); // at least header + 1 row
   });
 
   test("select individual row checkbox", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
     const rowCheckbox = page.locator('.row-check, tbody input[type="checkbox"]').first();
     await expect(rowCheckbox).toBeVisible();
     await rowCheckbox.check();
@@ -28,7 +28,7 @@ test.describe("Bulk Operations Page", () => {
   });
 
   test("status badges show Active or Inactive", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
     // Scope to table body to avoid picking up unrelated badges elsewhere on the page
     const badges = page.locator("#bulk-table-container tbody .badge");
     const count = await badges.count();
@@ -42,7 +42,7 @@ test.describe("Bulk Operations Page", () => {
   });
 
   test("table columns are correct", async ({ page }) => {
-    await navigateTo(page, "/demo/bulk");
+    await navigateTo(page, "/apps/bulk");
     for (const col of ["Name", "Category", "Price", "Stock", "Status"]) {
       await expect(page.locator(`th:has-text("${col}")`)).toBeVisible();
     }

--- a/e2e/catalog.spec.ts
+++ b/e2e/catalog.spec.ts
@@ -7,20 +7,20 @@ test.describe("Catalog Page", () => {
   });
 
   test("renders page with title and table", async ({ page }) => {
-    await navigateTo(page, "/demo/catalog");
+    await navigateTo(page, "/apps/catalog");
     await expect(page.locator("h1")).toContainText("Product Catalog");
     await expect(page.locator("#catalog-table-container")).toBeVisible();
   });
 
   test("table has expected columns", async ({ page }) => {
-    await navigateTo(page, "/demo/catalog");
+    await navigateTo(page, "/apps/catalog");
     for (const col of ["Name", "Category", "Price", "Stock", "Status"]) {
       await expect(page.locator(`th:has-text("${col}")`)).toBeVisible();
     }
   });
 
   test("expand and collapse item details", async ({ page }) => {
-    await navigateTo(page, "/demo/catalog");
+    await navigateTo(page, "/apps/catalog");
     const detailsBtn = page
       .locator('button:has-text("Details"), a:has-text("Details")')
       .first();
@@ -42,7 +42,7 @@ test.describe("Catalog Page", () => {
   });
 
   test("status badges render correctly", async ({ page }) => {
-    await navigateTo(page, "/demo/catalog");
+    await navigateTo(page, "/apps/catalog");
     const badges = page.locator(".badge");
     await expect(badges.first()).toBeVisible();
   });

--- a/e2e/components.spec.ts
+++ b/e2e/components.spec.ts
@@ -7,12 +7,12 @@ test.describe("Component Patterns", () => {
   });
 
   test("page 1 loads with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components");
+    await navigateTo(page, "/components/widgets");
     await expect(page.locator("h1")).toContainText("Component Patterns");
   });
 
   test("tabs switch content", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components");
+    await navigateTo(page, "/components/widgets");
     // Wait for initial tab load
     await waitForHtmx(page);
     // Click "Details" tab (role="tab")
@@ -25,7 +25,7 @@ test.describe("Component Patterns", () => {
   });
 
   test("steps wizard navigates forward", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components");
+    await navigateTo(page, "/components/widgets");
     const nextBtn = page.locator('button:has-text("Next")').first();
     if (await nextBtn.isVisible()) {
       await nextBtn.click();
@@ -36,12 +36,12 @@ test.describe("Component Patterns", () => {
 
 test.describe("Component Patterns 2", () => {
   test("page loads with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components2");
+    await navigateTo(page, "/components/cards");
     await expect(page.locator("h1")).toContainText("Component Patterns 2");
   });
 
   test("carousel navigation works", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components2");
+    await navigateTo(page, "/components/cards");
     const carouselPanel = page.locator("#carousel-panel").first();
     await expect(carouselPanel).toBeVisible();
     // The "Next →" button — scroll to it and click
@@ -54,7 +54,7 @@ test.describe("Component Patterns 2", () => {
   });
 
   test("dropdown search input exists", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components2");
+    await navigateTo(page, "/components/cards");
     const searchInput = page.locator("#dropdown-results, input[hx-trigger*='keyup']").first();
     if (await searchInput.isVisible()) {
       await expect(searchInput).toBeVisible();
@@ -64,12 +64,12 @@ test.describe("Component Patterns 2", () => {
 
 test.describe("Component Patterns 3", () => {
   test("page loads with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components3");
+    await navigateTo(page, "/components/advanced");
     await expect(page.locator("h1")).toContainText("Component Patterns 3");
   });
 
   test("feed container exists", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/components3");
+    await navigateTo(page, "/components/advanced");
     await expect(page.locator("#feed-container")).toBeVisible();
   });
 });

--- a/e2e/controls-gallery.spec.ts
+++ b/e2e/controls-gallery.spec.ts
@@ -7,17 +7,17 @@ test.describe("Controls Gallery", () => {
   });
 
   test("renders page with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     await expect(page.locator("h1")).toContainText("Controls Gallery");
   });
 
   test("button variants section is present", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     await expect(page.locator("text=Button Variants").first()).toBeVisible();
   });
 
   test("clicking variant button echoes response", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     const primaryBtn = page
       .locator('button:has-text("Primary")')
       .first();
@@ -28,7 +28,7 @@ test.describe("Controls Gallery", () => {
   });
 
   test("all variant buttons respond", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     for (const variant of [
       "Primary",
       "Secondary",
@@ -50,7 +50,7 @@ test.describe("Controls Gallery", () => {
   });
 
   test("retry button works", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     const retryBtn = page.locator('button:has-text("Retry")').first();
     if (await retryBtn.isVisible()) {
       await retryBtn.click();
@@ -60,7 +60,7 @@ test.describe("Controls Gallery", () => {
   });
 
   test("resource CRUD section works", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     // Look for the resource section
     const resourceSection = page.locator("text=Resource CRUD").first();
     if (await resourceSection.isVisible()) {
@@ -69,17 +69,17 @@ test.describe("Controls Gallery", () => {
   });
 
   test("form demo section exists", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     await expect(page.locator("text=Form").first()).toBeVisible();
   });
 
   test("filter controls section exists", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     await expect(page.locator("text=Filter").first()).toBeVisible();
   });
 
   test("error recovery sections exist", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     for (const section of ["Transient", "Validation", "Conflict", "Stale"]) {
       await expect(
         page.locator(`text=${section}`).first(),
@@ -88,7 +88,7 @@ test.describe("Controls Gallery", () => {
   });
 
   test("transient error triggers retry UI", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     const transientBtn = page
       .locator('[hx-post*="errors/transient"], button:has-text("Trigger 500")')
       .first();
@@ -100,7 +100,7 @@ test.describe("Controls Gallery", () => {
   });
 
   test("validation error shows fix button", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     const validateBtn = page
       .locator('[hx-post*="errors/validate"], button:has-text("Trigger 422")')
       .first();
@@ -111,7 +111,7 @@ test.describe("Controls Gallery", () => {
   });
 
   test("inline row CRUD works", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
     // Look for row editing
     const editBtn = page
       .locator('[hx-get*="/rows/"] button:has-text("Edit"), [hx-get*="edit"]')

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -29,9 +29,9 @@ test.describe("Dashboard", () => {
 
   test("inventory card links to demo pages", async ({ page }) => {
     await navigateTo(page, "/dashboard");
-    await expect(page.locator('main a[href*="/demo/inventory"]').first()).toBeVisible();
-    await expect(page.locator('main a[href*="/demo/catalog"]')).toBeVisible();
-    await expect(page.locator('main a[href*="/demo/bulk"]')).toBeVisible();
+    await expect(page.locator('main a[href*="/apps/inventory"]').first()).toBeVisible();
+    await expect(page.locator('main a[href*="/apps/catalog"]')).toBeVisible();
+    await expect(page.locator('main a[href*="/apps/bulk"]')).toBeVisible();
   });
 
   test("kanban card shows status badges", async ({ page }) => {
@@ -54,7 +54,7 @@ test.describe("Dashboard", () => {
 
   test("clicking inventory link navigates to inventory page", async ({ page }) => {
     await navigateTo(page, "/dashboard");
-    await page.locator('main a[href*="/demo/inventory"]').first().click();
+    await page.locator('main a[href*="/apps/inventory"]').first().click();
     await expect(page.locator("h1")).toContainText("Items Inventory");
   });
 });

--- a/e2e/error-controls.spec.ts
+++ b/e2e/error-controls.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page } from "@playwright/test";
 import { navigateTo, waitForHtmx, resetDB } from "./helpers";
 
-// ─── Error Patterns Page (/hypermedia/errors) ────────────────────────────────
+// ─── Error Patterns Page (/patterns/errors) ────────────────────────────────
 // Tests the error handling philosophy: every error is a navigable state with
 // hypermedia controls and proper recovery paths. Report Issue appears on 5xx
 // errors and inline error panels.
@@ -20,7 +20,7 @@ test.describe("Error Patterns Page", () => {
   });
 
   test("page loads with all error pattern sections", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
     await expect(page.locator("h1")).toContainText("Error Patterns");
     await expect(page.locator("text=Banner Errors").first()).toBeVisible();
     await expect(page.locator("text=Inline Form Errors").first()).toBeVisible();
@@ -37,7 +37,7 @@ test.describe("Error Patterns Page", () => {
   test("trigger 404 shows banner with Close control", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
     await page.locator('button:has-text("Trigger 404")').click();
     await waitForHtmx(page);
 
@@ -61,7 +61,7 @@ test.describe("Error Patterns Page", () => {
   test("trigger 400 shows banner with Close control", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
     await page.locator('button:has-text("Trigger 400")').click();
     await waitForHtmx(page);
 
@@ -83,7 +83,7 @@ test.describe("Error Patterns Page", () => {
   test("trigger 500 shows banner with Close and Report Issue controls", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
     await page.locator('button:has-text("Trigger 500")').click();
     await waitForHtmx(page);
 
@@ -107,7 +107,7 @@ test.describe("Error Patterns Page", () => {
   test("trigger 403 shows banner with Close control", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
     await page.locator('button:has-text("Trigger 403")').click();
     await waitForHtmx(page);
 
@@ -127,7 +127,7 @@ test.describe("Error Patterns Page", () => {
   });
 
   test("close button clears the error banner", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
 
     // Trigger a 400 (has Close)
     await page.locator('button:has-text("Trigger 400")').click();
@@ -154,7 +154,7 @@ test.describe("Error Patterns Page", () => {
   });
 
   test("error banner shows request ID with copy button", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
     await page.locator('button:has-text("Trigger 404")').click();
     await waitForHtmx(page);
 
@@ -172,7 +172,7 @@ test.describe("Error Patterns Page", () => {
   test("form with empty fields shows inline 422 validation errors", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
 
     // Submit with both fields empty/invalid
     const form = page.locator('form[hx-post*="errors/form"]');
@@ -194,7 +194,7 @@ test.describe("Error Patterns Page", () => {
   });
 
   test("form with valid fields shows success", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
 
     const form = page.locator('form[hx-post*="errors/form"]');
     await form.locator('input[name="name"]').fill("Jane Doe");
@@ -215,7 +215,7 @@ test.describe("Error Patterns Page", () => {
   });
 
   test("form with only missing email shows single error", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
 
     const form = page.locator('form[hx-post*="errors/form"]');
     await form.locator('input[name="name"]').fill("Jane");
@@ -234,7 +234,7 @@ test.describe("Error Patterns Page", () => {
   test("OOB warning shows success content AND error banner simultaneously", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
 
     await page.locator('button:has-text("Load with Warning")').click();
     await waitForHtmx(page);
@@ -265,7 +265,7 @@ test.describe("Error Patterns Page", () => {
   test("flaky endpoint: first call fails with retry button, second succeeds", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
 
     // First call — should fail (odd attempt)
     await page.locator('button:has-text("Call Flaky Endpoint")').click();
@@ -302,7 +302,7 @@ test.describe("Error Patterns Page", () => {
   // ─── Report Issue Modal ────────────────────────────────────────────────────
 
   test("Report Issue button opens report modal", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
 
     // Trigger an error to get a Report Issue button
     await page.locator('button:has-text("Trigger 500")').click();
@@ -328,7 +328,7 @@ test.describe("Error Patterns Page", () => {
   // ─── Pattern Summary Cards ─────────────────────────────────────────────────
 
   test("pattern summary cards are visible", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/errors");
+    await navigateTo(page, "/patterns/errors");
 
     for (const title of [
       "Banner",
@@ -346,7 +346,7 @@ test.describe("Error Patterns Page", () => {
 });
 
 // ─── Controls Gallery: Strengthened Error Recovery Tests ─────────────────────
-// These test the error controls in /hypermedia/controls more thoroughly than
+// These test the error controls in /patterns/controls more thoroughly than
 // the existing controls-gallery.spec.ts.
 
 test.describe("Error Controls: transient error recovery", () => {
@@ -357,7 +357,7 @@ test.describe("Error Controls: transient error recovery", () => {
   test("transient error shows inline error with Retry and Report Issue", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     const trigger = page.locator('[hx-post*="errors/transient"]').first();
     await trigger.click();
@@ -380,7 +380,7 @@ test.describe("Error Controls: transient error recovery", () => {
   });
 
   test("transient retry succeeds on second attempt", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     // First attempt fails
     await page.locator('[hx-post*="errors/transient"]').first().click();
@@ -412,7 +412,7 @@ test.describe("Error Controls: validation error recovery", () => {
   test("validation error shows inline error with Fix and Report Issue", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     // The hx-post is on the <form> — click the Submit button inside it
     const form = page.locator('form[hx-post*="errors/validate"]').first();
@@ -438,7 +438,7 @@ test.describe("Error Controls: conflict error", () => {
   });
 
   test("conflict error shows 409 with recovery controls", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     const trigger = page.locator('[hx-post*="errors/conflict"]').first();
     if (await trigger.isVisible()) {
@@ -467,7 +467,7 @@ test.describe("Error Controls: stale data error", () => {
   test("stale data shows 412 with Load Fresh and Report Issue", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     const trigger = page.locator('[hx-post*="errors/stale"]').first();
     if (await trigger.isVisible()) {
@@ -505,7 +505,7 @@ test.describe("Error Controls: cascade delete", () => {
   test("cascade delete shows 409 with reassign and force delete controls", async ({
     page,
   }) => {
-    await navigateTo(page, "/hypermedia/controls");
+    await navigateTo(page, "/patterns/controls");
 
     const trigger = page.locator('[hx-delete*="errors/cascade"]').first();
     if (await trigger.isVisible()) {

--- a/e2e/feed.spec.ts
+++ b/e2e/feed.spec.ts
@@ -7,17 +7,17 @@ test.describe("Activity Feed", () => {
   });
 
   test("renders page with title", async ({ page }) => {
-    await navigateTo(page, "/demo/feed");
+    await navigateTo(page, "/realtime/feed");
     await expect(page.locator("h1")).toContainText("Activity Feed");
   });
 
   test("feed container is present", async ({ page }) => {
-    await navigateTo(page, "/demo/feed");
+    await navigateTo(page, "/realtime/feed");
     await expect(page.locator("#feed-container")).toBeVisible();
   });
 
   test("feed items display", async ({ page }) => {
-    await navigateTo(page, "/demo/feed");
+    await navigateTo(page, "/realtime/feed");
     await expect(page.locator("#feed-items")).toBeVisible();
   });
 });

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -10,7 +10,7 @@ test.describe("Home Page", () => {
     ).toHaveAttribute("href", "/dashboard");
     await expect(
       page.locator('a:has-text("Controls Gallery")'),
-    ).toHaveAttribute("href", "/hypermedia/controls");
+    ).toHaveAttribute("href", "/patterns/controls");
   });
 
   test("renders reach-up pyramid sections", async ({ page }) => {

--- a/e2e/hypermedia.spec.ts
+++ b/e2e/hypermedia.spec.ts
@@ -7,19 +7,19 @@ test.describe("CRUD Patterns", () => {
   });
 
   test("page loads with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/crud");
+    await navigateTo(page, "/patterns/crud");
     await expect(page.locator("h1")).toContainText("CRUD Patterns");
   });
 
   test("table has expected columns", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/crud");
+    await navigateTo(page, "/patterns/crud");
     for (const col of ["ID", "Name", "Status", "Notes", "Actions"]) {
       await expect(page.locator(`th:has-text("${col}")`)).toBeVisible();
     }
   });
 
   test("add item button creates new row", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/crud");
+    await navigateTo(page, "/patterns/crud");
     const addBtn = page.locator('button:has-text("+ Add Item")').first();
     await expect(addBtn).toBeVisible();
     // Count rows before adding
@@ -32,7 +32,7 @@ test.describe("CRUD Patterns", () => {
   });
 
   test("inline edit works", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/crud");
+    await navigateTo(page, "/patterns/crud");
     await waitForHtmx(page);
     const editBtn = page.locator('button:has-text("Edit")').first();
     await expect(editBtn).toBeVisible();
@@ -50,24 +50,24 @@ test.describe("List Patterns", () => {
   });
 
   test("page loads with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/lists");
+    await navigateTo(page, "/patterns/lists");
     await expect(page.locator("h1")).toContainText("List Patterns");
   });
 
   test("table and filters load", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/lists");
+    await navigateTo(page, "/patterns/lists");
     await expect(page.locator("#lists-table-container")).toBeVisible();
     await expect(page.locator("#filter-form").first()).toBeVisible();
   });
 
   test("search input exists", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/lists");
+    await navigateTo(page, "/patterns/lists");
     const searchInput = page.locator('input[name="q"]').first();
     await expect(searchInput).toBeVisible();
   });
 
   test("category filter works", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/lists");
+    await navigateTo(page, "/patterns/lists");
     const catSelect = page.locator("select").first();
     if (await catSelect.isVisible()) {
       await catSelect.selectOption({ index: 1 });
@@ -78,12 +78,12 @@ test.describe("List Patterns", () => {
 
 test.describe("Interaction Patterns", () => {
   test("page loads with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/interactions");
+    await navigateTo(page, "/patterns/interactions");
     await expect(page.locator("h1")).toContainText("Interaction Patterns");
   });
 
   test("contact form has required fields", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/interactions");
+    await navigateTo(page, "/patterns/interactions");
     const form = page.locator("#interaction-form, form").first();
     if (await form.isVisible()) {
       await expect(form).toBeVisible();
@@ -91,7 +91,7 @@ test.describe("Interaction Patterns", () => {
   });
 
   test("form submission works", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/interactions");
+    await navigateTo(page, "/patterns/interactions");
     const nameInput = page.locator("#contact-name, input[name='name']").first();
     const emailInput = page.locator("#contact-email, input[name='email']").first();
     const msgInput = page.locator("#contact-message, textarea[name='message']").first();
@@ -112,12 +112,12 @@ test.describe("Interaction Patterns", () => {
 
 test.describe("State Patterns", () => {
   test("page loads with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/state");
+    await navigateTo(page, "/patterns/state");
     await expect(page.locator("h1")).toContainText("State Patterns");
   });
 
   test("like counter increments", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/state");
+    await navigateTo(page, "/patterns/state");
     const likeBtn = page
       .locator('button:has-text("Like"), button:has-text("♡"), button:has-text("❤")')
       .first();
@@ -128,7 +128,7 @@ test.describe("State Patterns", () => {
   });
 
   test("toggle state button works", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/state");
+    await navigateTo(page, "/patterns/state");
     const toggleBtn = page
       .locator('button:has-text("Toggle")')
       .first();
@@ -139,7 +139,7 @@ test.describe("State Patterns", () => {
   });
 
   test("reveal panel shows/hides", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/state");
+    await navigateTo(page, "/patterns/state");
     const revealBtn = page
       .locator('button:has-text("Show"), button:has-text("Reveal"), button:has-text("Load")')
       .first();
@@ -152,18 +152,18 @@ test.describe("State Patterns", () => {
 
 test.describe("Realtime Dashboard", () => {
   test("page loads with title", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/realtime");
+    await navigateTo(page, "/realtime/dashboard");
     await expect(page.locator("h1")).toContainText("Live Operations Dashboard");
   });
 
   test("SSE connection wrapper exists", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/realtime");
+    await navigateTo(page, "/realtime/dashboard");
     const sseWrapper = page.locator("#dashboard-sse, #sse-connect-wrapper");
     await expect(sseWrapper.first()).toBeVisible();
   });
 
   test("frequency slider exists", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/realtime");
+    await navigateTo(page, "/realtime/dashboard");
     const slider = page.locator("#freq-slider");
     if (await slider.isVisible()) {
       await expect(slider).toBeVisible();
@@ -171,7 +171,7 @@ test.describe("Realtime Dashboard", () => {
   });
 
   test("event feed container exists", async ({ page }) => {
-    await navigateTo(page, "/hypermedia/realtime");
+    await navigateTo(page, "/realtime/dashboard");
     const feed = page.locator("#event-feed");
     if (await feed.isVisible()) {
       await expect(feed).toBeVisible();

--- a/e2e/inventory.spec.ts
+++ b/e2e/inventory.spec.ts
@@ -7,7 +7,7 @@ test.describe("Inventory Page", () => {
   });
 
   test("renders page with title and table", async ({ page }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     await expect(page.locator("h1")).toContainText("Inventory");
     await expect(page.locator("#inventory-table-container")).toBeVisible();
     // Table should have visible data rows (skip hidden new-item-row placeholder)
@@ -17,7 +17,7 @@ test.describe("Inventory Page", () => {
   });
 
   test("filter by search narrows results", async ({ page }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     const searchInput = page.locator('input[name="q"]');
     await expect(searchInput).toBeVisible();
     // Type a search term and wait for HTMX update
@@ -29,7 +29,7 @@ test.describe("Inventory Page", () => {
   });
 
   test("filter by category", async ({ page }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     const categorySelect = page.locator('select[name="cat"]');
     if (await categorySelect.isVisible()) {
       await categorySelect.selectOption({ index: 1 });
@@ -41,7 +41,7 @@ test.describe("Inventory Page", () => {
   });
 
   test("pagination controls work", async ({ page }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     const nextBtn = page.locator('a:has-text("Next"), button:has-text("Next")');
     if (await nextBtn.isVisible()) {
       await nextBtn.click();
@@ -53,7 +53,7 @@ test.describe("Inventory Page", () => {
   });
 
   test("add new item form appears", async ({ page }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     const addBtn = page.locator('button:has-text("+ Add Item")');
     await expect(addBtn).toBeVisible();
     await addBtn.click();
@@ -64,7 +64,7 @@ test.describe("Inventory Page", () => {
   });
 
   test("sorting by column header", async ({ page }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     const nameHeader = page.locator("th >> text=Name");
     if (await nameHeader.isVisible()) {
       const sortLink = nameHeader.locator("a").first();
@@ -79,7 +79,7 @@ test.describe("Inventory Page", () => {
   });
 
   test("link to hypermedia controls exists", async ({ page }) => {
-    await navigateTo(page, "/demo/inventory");
+    await navigateTo(page, "/apps/inventory");
     await expect(
       page.locator('a:has-text("Hypermedia Controls")'),
     ).toBeVisible();

--- a/e2e/kanban.spec.ts
+++ b/e2e/kanban.spec.ts
@@ -7,13 +7,13 @@ test.describe("Kanban Board", () => {
   });
 
   test("renders page with title and board", async ({ page }) => {
-    await navigateTo(page, "/demo/kanban");
+    await navigateTo(page, "/apps/kanban");
     await expect(page.locator("h1")).toContainText("Kanban Board");
     await expect(page.locator("#kanban-board")).toBeVisible();
   });
 
   test("all kanban columns are present", async ({ page }) => {
-    await navigateTo(page, "/demo/kanban");
+    await navigateTo(page, "/apps/kanban");
     for (const col of [
       "Backlog",
       "To Do",
@@ -26,14 +26,14 @@ test.describe("Kanban Board", () => {
   });
 
   test("kanban cards have content", async ({ page }) => {
-    await navigateTo(page, "/demo/kanban");
+    await navigateTo(page, "/apps/kanban");
     const cards = page.locator('[id^="kanban-task-"]');
     const count = await cards.count();
     expect(count).toBeGreaterThan(0);
   });
 
   test("move card to next status", async ({ page }) => {
-    await navigateTo(page, "/demo/kanban");
+    await navigateTo(page, "/apps/kanban");
     // Find a move-right button on a card
     const moveBtn = page
       .locator('button:has-text("→"), a:has-text("→")')
@@ -47,7 +47,7 @@ test.describe("Kanban Board", () => {
   });
 
   test("priority badges render", async ({ page }) => {
-    await navigateTo(page, "/demo/kanban");
+    await navigateTo(page, "/apps/kanban");
     const badges = page.locator(".badge");
     const count = await badges.count();
     expect(count).toBeGreaterThan(0);

--- a/e2e/people.spec.ts
+++ b/e2e/people.spec.ts
@@ -7,20 +7,20 @@ test.describe("People Directory", () => {
   });
 
   test("renders page with title and table", async ({ page }) => {
-    await navigateTo(page, "/demo/people");
+    await navigateTo(page, "/apps/people");
     await expect(page.locator("h1")).toContainText("People Directory");
     await expect(page.locator("#people-table-container")).toBeVisible();
   });
 
   test("table has expected columns", async ({ page }) => {
-    await navigateTo(page, "/demo/people");
+    await navigateTo(page, "/apps/people");
     for (const col of ["Name", "Department", "Title", "Location", "Email"]) {
       await expect(page.locator(`th:has-text("${col}")`)).toBeVisible();
     }
   });
 
   test("search filters people", async ({ page }) => {
-    await navigateTo(page, "/demo/people");
+    await navigateTo(page, "/apps/people");
     const searchInput = page.locator('input[name="q"]');
     if (await searchInput.isVisible()) {
       await searchInput.fill("Engineering");
@@ -31,7 +31,7 @@ test.describe("People Directory", () => {
   });
 
   test("click person row loads profile", async ({ page }) => {
-    await navigateTo(page, "/demo/people");
+    await navigateTo(page, "/apps/people");
     // Click the first row that has hx-get for a person detail
     const personRow = page.locator("tbody tr[hx-get]").first();
     if (await personRow.isVisible()) {
@@ -41,7 +41,7 @@ test.describe("People Directory", () => {
   });
 
   test("people list route loads", async ({ page }) => {
-    await navigateTo(page, "/demo/people/list");
+    await navigateTo(page, "/apps/people/list");
     await expect(page.locator("#people-table-container")).toBeVisible();
   });
 });

--- a/e2e/repository.spec.ts
+++ b/e2e/repository.spec.ts
@@ -7,7 +7,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("renders page with title and table", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     await expect(page.locator("h1")).toContainText("Repository Pattern Demo");
     await expect(page.locator("#repo-table-container")).toBeVisible();
     // Should have seeded task rows
@@ -19,7 +19,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("table has expected columns", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     for (const col of [
       "Title",
       "Description",
@@ -35,7 +35,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("status badges render for seeded data", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const badges = page.locator(".badge");
     const count = await badges.count();
     expect(count).toBeGreaterThan(0);
@@ -51,14 +51,14 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("version badges show v1+ for seeded data", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const versionBadges = page.locator('.badge:has-text("v")');
     const count = await versionBadges.count();
     expect(count).toBeGreaterThan(0);
   });
 
   test("filter by search narrows results", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const searchInput = page.locator('input[name="q"]');
     await expect(searchInput).toBeVisible();
     await searchInput.fill("schema");
@@ -70,7 +70,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("filter by status dropdown", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const statusSelect = page.locator('select[name="status"]');
     if (await statusSelect.isVisible()) {
       await statusSelect.selectOption("active");
@@ -80,7 +80,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("sorting by column header", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const titleHeader = page.locator("th >> text=Title");
     if (await titleHeader.isVisible()) {
       const sortLink = titleHeader.locator("a").first();
@@ -93,7 +93,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("add new task form appears and cancel works", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const addBtn = page.locator('button:has-text("+ New Task")');
     await expect(addBtn).toBeVisible();
     await addBtn.click();
@@ -110,7 +110,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("create new task via inline form", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const addBtn = page.locator('button:has-text("+ New Task")');
     await addBtn.click();
     await waitForHtmx(page);
@@ -131,7 +131,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("inline edit shows form and saves", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const editBtn = page.locator('button:has-text("Edit")').first();
     await editBtn.click();
     await waitForHtmx(page);
@@ -143,7 +143,7 @@ test.describe("Repository Demo Page", () => {
   test("soft delete shows deleted badge when show deleted is on", async ({
     page,
   }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     // Handle confirmation dialog before triggering it
     page.on("dialog", (dialog) => dialog.accept());
     // Delete the first task
@@ -166,7 +166,7 @@ test.describe("Repository Demo Page", () => {
   test("archive task shows archived badge when show archived is on", async ({
     page,
   }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     // Archive the first task
     const archiveBtn = page.locator('button:has-text("Archive")').first();
     await archiveBtn.click();
@@ -185,7 +185,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("restore deleted task brings it back", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     // Handle confirmation dialog before triggering it
     page.on("dialog", (dialog) => dialog.accept());
     // Count initial visible rows
@@ -215,7 +215,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("info cards show repository pattern features", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     await expect(page.locator('text="Schema"')).toBeVisible();
     await expect(page.locator('text="Query"')).toBeVisible();
     await expect(page.locator('text="Filters"')).toBeVisible();
@@ -223,7 +223,7 @@ test.describe("Repository Demo Page", () => {
   });
 
   test("navigation includes Demo link", async ({ page }) => {
-    await navigateTo(page, "/demo/repository");
+    await navigateTo(page, "/platform/repository");
     const navLink = page.locator('nav a:has-text("Demo")');
     await expect(navLink).toBeVisible();
   });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -7,17 +7,17 @@ test.describe("Settings Page", () => {
   });
 
   test("renders page with title", async ({ page }) => {
-    await navigateTo(page, "/demo/settings");
+    await navigateTo(page, "/platform/settings");
     await expect(page.locator("h1")).toContainText("Settings");
   });
 
   test("settings content loads", async ({ page }) => {
-    await navigateTo(page, "/demo/settings");
+    await navigateTo(page, "/platform/settings");
     await expect(page.locator("#settings-content")).toBeVisible();
   });
 
   test("settings tabs are present", async ({ page }) => {
-    await navigateTo(page, "/demo/settings");
+    await navigateTo(page, "/platform/settings");
     for (const tab of ["General", "Notifications", "Security", "Appearance"]) {
       await expect(
         page.locator(`.settings-tab:has-text("${tab}"), [role="tab"]:has-text("${tab}"), button:has-text("${tab}")`).first(),
@@ -26,7 +26,7 @@ test.describe("Settings Page", () => {
   });
 
   test("switching tabs updates content", async ({ page }) => {
-    await navigateTo(page, "/demo/settings");
+    await navigateTo(page, "/platform/settings");
     const notifTab = page.locator(
       '.settings-tab:has-text("Notifications"), [role="tab"]:has-text("Notifications"), button:has-text("Notifications")',
     ).first();
@@ -38,7 +38,7 @@ test.describe("Settings Page", () => {
   });
 
   test("save button exists", async ({ page }) => {
-    await navigateTo(page, "/demo/settings");
+    await navigateTo(page, "/platform/settings");
     const saveBtn = page.locator('button:has-text("Save")').first();
     await expect(saveBtn).toBeVisible();
   });

--- a/e2e/vendors.spec.ts
+++ b/e2e/vendors.spec.ts
@@ -7,17 +7,17 @@ test.describe("Vendor Contacts", () => {
   });
 
   test("renders page with title", async ({ page }) => {
-    await navigateTo(page, "/demo/vendors");
+    await navigateTo(page, "/apps/vendors");
     await expect(page.locator("h1")).toContainText("Vendor Contacts");
   });
 
   test("vendor list is visible", async ({ page }) => {
-    await navigateTo(page, "/demo/vendors");
+    await navigateTo(page, "/apps/vendors");
     await expect(page.locator("#vendor-list")).toBeVisible();
   });
 
   test("clicking a vendor shows contacts", async ({ page }) => {
-    await navigateTo(page, "/demo/vendors");
+    await navigateTo(page, "/apps/vendors");
     const vendorLink = page
       .locator("#vendor-list a, #vendor-list button, #vendor-list [hx-get]")
       .first();


### PR DESCRIPTION
## Summary
- Updates all 17 e2e test files to use new route paths after the nav reorganization in #490
- `/demo/*` routes → `/apps/*`, `/platform/*`, `/realtime/*`
- `/hypermedia/*` routes → `/patterns/*`, `/components/*`, `/realtime/*`
- All 183 failing tests should now pass with correct route paths

## Test plan
- [ ] Pipeline workflow passes (all 206 e2e tests green)