### PR TITLE
fix: unwrap compression writer in error handler and update e2e tests

### DIFF
--- a/e2e/bugs.spec.ts
+++ b/e2e/bugs.spec.ts
@@ -844,7 +844,7 @@ test.describe("Navigation: all pages load without 500 errors", () => {
     "/components/widgets",
     "/components/cards",
     "/components/advanced",
-    "/realtime/dashboard",
+    "/realtime",
   ];
 
   for (const path of pages) {

--- a/e2e/repository.spec.ts
+++ b/e2e/repository.spec.ts
@@ -222,9 +222,9 @@ test.describe("Repository Demo Page", () => {
     await expect(page.locator('text="Audit"')).toBeVisible();
   });
 
-  test("navigation includes Demo link", async ({ page }) => {
+  test("navigation includes Platform link", async ({ page }) => {
     await navigateTo(page, "/platform/repository");
-    const navLink = page.locator('nav a:has-text("Demo")');
+    const navLink = page.locator('nav a:has-text("Platform")');
     await expect(navLink).toBeVisible();
   });
 });

--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -112,16 +112,17 @@ func handleErrorWithContext(c echo.Context, ec linkwell.ErrorContext) error {
 // shared store on error so it can be retrieved for issue reports.
 func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Context) {
 	return func(err error, c echo.Context) {
-		// The error handler runs after the middleware chain returns. If the
-		// httpcompression middleware has already finalized its writer, rendering
-		// the error page can panic (nil pointer in compressWriter.Write).
-		// Recover here so the connection isn't killed outright.
-		defer func() {
-			if r := recover(); r != nil {
-				logger.WithContext(c.Request().Context()).Error("Panic in error handler (response writer likely finalized)",
-					"panic", r, "route", c.Request().URL.Path)
+		// Bypass finalized compression writer by unwrapping to the raw
+		// http.ResponseWriter. The httpcompression middleware may have
+		// closed its writer by the time the error handler runs, so we
+		// write directly to the underlying writer.
+		for {
+			if u, ok := c.Response().Writer.(interface{ Unwrap() http.ResponseWriter }); ok {
+				c.Response().Writer = u.Unwrap()
+			} else {
+				break
 			}
-		}()
+		}
 		// Determine status code from error type before promoting.
 		statusCode := http.StatusInternalServerError
 		var hhe *linkwell.HTTPError


### PR DESCRIPTION
## Summary
- Fixes the error handler panic caused by the `httpcompression` middleware finalizing its writer before the error handler runs
- Replaces `defer recover()` workaround with proper writer unwrapping using Go 1.20+ `Unwrap()` convention
- Updates `repository.spec.ts` nav link assertion from "Demo" to "Platform"
- Fixes `/realtime/dashboard` → `/realtime` in `bugs.spec.ts` navigation smoke test

## Root cause
When a handler returns an error (e.g., `linkwell.NewHTTPError`), the middleware chain unwinds and the compression middleware closes its writer. Echo's error handler then tries to render through the closed writer, causing a nil pointer panic. The `defer recover()` caught the panic silently, producing empty 200 responses instead of proper error responses with correct status codes and OOB-swapped error banners.

## Test plan
- [ ] All 206 e2e tests pass (21 currently failing should be fixed)
- [ ] Error banner renders correctly on `/patterns/errors` trigger buttons
- [ ] API endpoints return proper error status codes (400, 404) for invalid input