### PR TITLE
fix: restore raw response writer in error handler

### DIFF
--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -112,16 +112,12 @@ func handleErrorWithContext(c echo.Context, ec linkwell.ErrorContext) error {
 // shared store on error so it can be retrieved for issue reports.
 func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Context) {
 	return func(err error, c echo.Context) {
-		// Bypass finalized compression writer by unwrapping to the raw
-		// http.ResponseWriter. The httpcompression middleware may have
-		// closed its writer by the time the error handler runs, so we
-		// write directly to the underlying writer.
-		for {
-			if u, ok := c.Response().Writer.(interface{ Unwrap() http.ResponseWriter }); ok {
-				c.Response().Writer = u.Unwrap()
-			} else {
-				break
-			}
+		// Restore the raw response writer saved before the compression
+		// middleware wrapped it. The httpcompression writer is finalized
+		// (closed) by the time the error handler runs, so writing through
+		// it panics. Using the raw writer bypasses the closed compressor.
+		if rw, ok := c.Get(rawWriterKey).(http.ResponseWriter); ok {
+			c.Response().Writer = rw
 		}
 		// Determine status code from error type before promoting.
 		statusCode := http.StatusInternalServerError

--- a/internal/routes/middleware/raw_writer.go
+++ b/internal/routes/middleware/raw_writer.go
@@ -1,0 +1,20 @@
+package middleware
+
+import "github.com/labstack/echo/v4"
+
+// rawWriterKey is the echo context key used to store the original
+// http.ResponseWriter before the compression middleware wraps it.
+const rawWriterKey = "raw_response_writer"
+
+// RawWriterMiddleware saves the original http.ResponseWriter in the echo
+// context so the error handler can bypass the httpcompression writer after
+// it has been finalized (closed). Register this middleware immediately
+// before the compression middleware.
+func RawWriterMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Set(rawWriterKey, c.Response().Writer)
+			return next(c)
+		}
+	}
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -301,6 +301,11 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 		PermissionsPolicy:       "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
 		CrossOriginOpenerPolicy: "same-origin",
 	})))
+	// Save the raw response writer before the compression middleware wraps it.
+	// The error handler needs the unwrapped writer because httpcompression
+	// finalizes (closes) its writer when the middleware chain unwinds, making
+	// it unusable by the time Echo's HTTPErrorHandler runs.
+	e.Use(middleware.RawWriterMiddleware())
 	// Skip compression when running behind the templ proxy (mage watch).
 	// Chunked compressed responses cause h2 framing errors through
 	// the templ-proxy → Caddy chain. Caddy handles compression instead.


### PR DESCRIPTION
## Summary
- Saves the raw `http.ResponseWriter` in echo context before httpcompression wraps it
- Error handler restores the raw writer, bypassing the finalized compressor
- Replaces the non-functional `Unwrap()` loop from #501 (httpcompression doesn't implement `Unwrap`)

## Root cause
The `httpcompression` middleware closes its writer when the middleware chain unwinds. Echo's error handler runs after that, so writing through the closed compressor panics (nil pointer in `compressWriter.Write`). The `defer recover()` silently caught this, producing empty 200 responses instead of proper error banners.

## Test plan
- [ ] All 206 e2e tests pass (20 currently failing should be fixed)
- [ ] Error banners render on `/patterns/errors` trigger buttons
- [ ] API endpoints return proper error status codes (400, 404)