### PR TITLE
fix: externalize CSRF script to resolve CSP violation

### DIFF
--- a/web/assets/public/js/csrf-header.js
+++ b/web/assets/public/js/csrf-header.js
@@ -1,0 +1,11 @@
+/**
+ * Attach the CSRF token to every outgoing HTMX request.
+ * Reads the token from the <meta name="csrf-token"> tag injected
+ * by the server and sets the X-CSRF-Token header.
+ * @listens htmx:configRequest
+ */
+document.addEventListener("htmx:configRequest", function(evt) {
+	/** @type {HTMLMetaElement|null} */
+	var t = document.querySelector("meta[name=\"csrf-token\"]");
+	if (t) evt.detail.headers["X-CSRF-Token"] = t.getAttribute("content");
+});

--- a/web/components/core/csrf.templ
+++ b/web/components/core/csrf.templ
@@ -1,23 +1,13 @@
 package components
 
-// CsrfMeta renders the CSRF meta tag and the HTMX configRequest listener
-// that attaches the token to every outgoing request. Include this in any
-// custom layout that handles authenticated mutations.
+import "catgoose/dothog/internal/version"
+
+// CsrfMeta renders the CSRF meta tag and loads the external configRequest
+// listener that attaches the token to every outgoing HTMX request. Include
+// this in any custom layout that handles authenticated mutations.
 templ CsrfMeta(token string) {
 	if token != "" {
 		<meta name="csrf-token" content={ token }/>
-		<script>
-			/**
-			 * Attach the CSRF token to every outgoing HTMX request.
-			 * Reads the token from the <meta name="csrf-token"> tag injected
-			 * by the server and sets the X-CSRF-Token header.
-			 * @listens htmx:configRequest
-			 */
-			document.addEventListener("htmx:configRequest", function(evt) {
-				/** @type {HTMLMetaElement|null} */
-				var t = document.querySelector("meta[name=\"csrf-token\"]");
-				if (t) evt.detail.headers["X-CSRF-Token"] = t.getAttribute("content");
-			});
-		</script>
+		<script src={ version.Asset("/public/js/csrf-header.js") }></script>
 	}
 }


### PR DESCRIPTION
## Summary

- Externalized the inline CSRF `<script>` in `web/components/core/csrf.templ` to a new file `web/assets/public/js/csrf-header.js`
- The inline script was being blocked by the Content-Security-Policy `script-src 'self'` directive
- Moving it to an external `.js` file means it is served from the same origin and covered by `'self'` without needing a hash or `unsafe-inline`

## Notes

The speculation rules inline script (`<script type="speculationrules">`) in `web/views/index.templ` must stay inline per the browser spec. Its hash (`sha256-eOv0TFLNrQcro54QYjf7haCP4wOu3Tn7XpKwJVQ8+qI=`) is already in the Cloudflare CSP in vopts, so after this fix the only remaining inline script (speculation rules) should be covered once the Cloudflare transform rule is deployed.

## Test plan

- [ ] Verify CSRF tokens are still attached to HTMX requests (check `X-CSRF-Token` header in DevTools Network tab)
- [ ] Verify no CSP violations in the browser console for the CSRF script
- [ ] Confirm speculation rules still work (prefetch on link hover)