### PR TITLE
fix: resolve all lint warnings and clean up mage output

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,5 +7,8 @@
     "web/assets/public/js/alpine.min.js",
     "web/assets/public/js/alpine.morph.min.js",
     "web/assets/public/js/_hyperscript.min.js"
-  ]
+  ],
+  "rules": {
+    "no-unused-vars": ["warn", { "caughtErrors": "none" }]
+  }
 }

--- a/internal/database/schema/tables.go
+++ b/internal/database/schema/tables.go
@@ -4,14 +4,17 @@ import (
 	s "github.com/catgoose/chuck/schema"
 )
 
-// Re-export chuck/schema types so consumers can continue to import
-// this package for both table definitions and schema types.
 type (
-	TableDef  = s.TableDef
+	// TableDef is a re-exported chuck/schema table definition.
+	TableDef = s.TableDef
+	// ColumnDef is a re-exported chuck/schema column definition.
 	ColumnDef = s.ColumnDef
-	IndexDef  = s.IndexDef
-	SeedRow   = s.SeedRow
-	TypeFunc  = s.TypeFunc
+	// IndexDef is a re-exported chuck/schema index definition.
+	IndexDef = s.IndexDef
+	// SeedRow is a re-exported chuck/schema seed row.
+	SeedRow = s.SeedRow
+	// TypeFunc is a re-exported chuck/schema type constructor.
+	TypeFunc = s.TypeFunc
 )
 
 // Re-export chuck/schema constructors.
@@ -40,6 +43,7 @@ var (
 
 // setup:feature:session_settings:start
 
+// SessionSettingsTable defines the session_settings schema.
 var SessionSettingsTable = NewTable("SessionSettings").
 	Columns(
 		AutoIncrCol("Id"),
@@ -53,6 +57,7 @@ var SessionSettingsTable = NewTable("SessionSettings").
 
 // setup:feature:graph:start
 
+// UsersTable defines the users schema.
 var UsersTable = NewTable("Users").
 	Columns(
 		AutoIncrCol("ID"),

--- a/internal/demo/link_relations.go
+++ b/internal/demo/link_relations.go
@@ -1,4 +1,5 @@
 // setup:feature:demo
+
 package demo
 
 import "fmt"

--- a/internal/demo/memory.go
+++ b/internal/demo/memory.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	_ "github.com/catgoose/chuck/driver/sqlite"
+	_ "github.com/catgoose/chuck/driver/sqlite" // register SQLite driver
 )
 
 // OpenMemoryDB opens a new in-memory SQLite database for admin/seed operations.

--- a/internal/demo/people.go
+++ b/internal/demo/people.go
@@ -40,6 +40,7 @@ var allowedPeopleSort = map[string]string{
 	"title":      "job_title",
 }
 
+// ListPeople returns a paginated list of people matching optional search and department filters.
 func (d *DB) ListPeople(ctx context.Context, search, department, sortBy, sortDir string, page, perPage int) ([]Person, int, error) {
 	col, ok := allowedPeopleSort[sortBy]
 	if !ok {
@@ -98,6 +99,7 @@ func (d *DB) ListPeople(ctx context.Context, search, department, sortBy, sortDir
 	return people, total, rows.Err()
 }
 
+// GetPerson returns a single person by ID.
 func (d *DB) GetPerson(ctx context.Context, id int) (Person, error) {
 	var p Person
 	err := d.db.QueryRowContext(ctx,
@@ -109,6 +111,7 @@ func (d *DB) GetPerson(ctx context.Context, id int) (Person, error) {
 	return p, nil
 }
 
+// UpdatePerson updates a person row.
 func (d *DB) UpdatePerson(ctx context.Context, p Person) error {
 	res, err := d.db.ExecContext(ctx,
 		"UPDATE people SET first_name=@FirstName, last_name=@LastName, email=@Email, phone=@Phone, city=@City, state=@State, department=@Department, job_title=@JobTitle, bio=@Bio WHERE id=@ID",

--- a/internal/demo/vendor_contact.go
+++ b/internal/demo/vendor_contact.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 )
 
+// Vendor represents a vendor in the demo dataset.
 type Vendor struct {
 	Name     string
 	Category string
 	ID       int
 }
 
+// Contact represents a vendor contact in the demo dataset.
 type Contact struct {
 	Name     string
 	Email    string
@@ -24,6 +26,7 @@ type Contact struct {
 	VendorID int
 }
 
+// ListVendors returns vendors matching the optional search and category filters.
 func (d *DB) ListVendors(ctx context.Context, search, category string) ([]Vendor, error) {
 	var conds []string
 	var args []any
@@ -55,12 +58,14 @@ func (d *DB) ListVendors(ctx context.Context, search, category string) ([]Vendor
 	return vendors, rows.Err()
 }
 
+// GetVendor returns a single vendor by ID.
 func (d *DB) GetVendor(ctx context.Context, id int) (Vendor, error) {
 	var v Vendor
 	err := d.db.QueryRowContext(ctx, "SELECT id,name,category FROM vendors WHERE id = @ID", sql.Named("ID", id)).Scan(&v.ID, &v.Name, &v.Category)
 	return v, err
 }
 
+// ListContacts returns all contacts for a vendor.
 func (d *DB) ListContacts(ctx context.Context, vendorID int) ([]Contact, error) {
 	rows, err := d.db.QueryContext(ctx, "SELECT id,vendor_id,name,email,phone,role FROM contacts WHERE vendor_id = @VendorID ORDER BY name", sql.Named("VendorID", vendorID))
 	if err != nil {
@@ -78,12 +83,14 @@ func (d *DB) ListContacts(ctx context.Context, vendorID int) ([]Contact, error) 
 	return contacts, rows.Err()
 }
 
+// GetContact returns a single contact by ID.
 func (d *DB) GetContact(ctx context.Context, id int) (Contact, error) {
 	var c Contact
 	err := d.db.QueryRowContext(ctx, "SELECT id,vendor_id,name,email,phone,role FROM contacts WHERE id = @ID", sql.Named("ID", id)).Scan(&c.ID, &c.VendorID, &c.Name, &c.Email, &c.Phone, &c.Role)
 	return c, err
 }
 
+// UpdateContact updates a contact row.
 func (d *DB) UpdateContact(ctx context.Context, c Contact) error {
 	res, err := d.db.ExecContext(ctx, "UPDATE contacts SET name=@Name, email=@Email, phone=@Phone, role=@Role WHERE id=@ID",
 		sql.Named("Name", c.Name), sql.Named("Email", c.Email), sql.Named("Phone", c.Phone), sql.Named("Role", c.Role), sql.Named("ID", c.ID))

--- a/internal/repository/session_settings_repository.go
+++ b/internal/repository/session_settings_repository.go
@@ -15,19 +15,19 @@ import (
 	"catgoose/dothog/internal/session"
 )
 
-// sessionSettingsRepository provides session settings data access.
-type sessionSettingsRepository struct {
+// SessionSettingsRepository provides session settings data access.
+type SessionSettingsRepository struct {
 	repo *dbrepoManager.RepoManager
 }
 
 // NewSessionSettingsRepository creates a new session settings repository.
-// The returned value satisfies both session.SessionSettingsProvider and
+// The returned value satisfies both session.SettingsProvider and
 // routes.SessionSettingsStore via Go's implicit interface satisfaction.
-func NewSessionSettingsRepository(repo *dbrepoManager.RepoManager) *sessionSettingsRepository {
-	return &sessionSettingsRepository{repo: repo}
+func NewSessionSettingsRepository(repo *dbrepoManager.RepoManager) *SessionSettingsRepository {
+	return &SessionSettingsRepository{repo: repo}
 }
 
-// selectCols lists the columns matching the session.SessionSettings struct.
+// selectCols lists the columns matching the session.Settings struct.
 // SessionSettingsTable.SelectColumns() includes CreatedAt which the domain
 // struct omits, so we list them explicitly.
 var selectCols = dbrepo.Columns("Id", "SessionUUID", "Theme", "Layout", "UpdatedAt")
@@ -35,11 +35,11 @@ var selectCols = dbrepo.Columns("Id", "SessionUUID", "Theme", "Layout", "Updated
 var tableName = schema.SessionSettingsTable.Name
 
 // GetByUUID returns settings for the given session UUID, or nil if not found.
-func (r *sessionSettingsRepository) GetByUUID(ctx context.Context, uuid string) (*session.SessionSettings, error) {
+func (r *SessionSettingsRepository) GetByUUID(ctx context.Context, uuid string) (*session.Settings, error) {
 	w := dbrepo.NewWhere().And("SessionUUID = @SessionUUID", sql.Named("SessionUUID", uuid))
 	query, args := dbrepo.NewSelect(tableName, selectCols).Where(w).Build()
 
-	var s session.SessionSettings
+	var s session.Settings
 	err := r.repo.GetDB().GetContext(ctx, &s, query, args...)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -51,7 +51,7 @@ func (r *sessionSettingsRepository) GetByUUID(ctx context.Context, uuid string) 
 }
 
 // Upsert inserts or updates session settings by SessionUUID.
-func (r *sessionSettingsRepository) Upsert(ctx context.Context, s *session.SessionSettings) error {
+func (r *SessionSettingsRepository) Upsert(ctx context.Context, s *session.Settings) error {
 	existing, err := r.GetByUUID(ctx, s.SessionUUID)
 	if err != nil {
 		return fmt.Errorf("lookup existing session settings: %w", err)
@@ -92,7 +92,7 @@ func (r *sessionSettingsRepository) Upsert(ctx context.Context, s *session.Sessi
 }
 
 // Touch updates UpdatedAt for the given session UUID.
-func (r *sessionSettingsRepository) Touch(ctx context.Context, uuid string) error {
+func (r *SessionSettingsRepository) Touch(ctx context.Context, uuid string) error {
 	query := fmt.Sprintf("UPDATE %s SET %s WHERE SessionUUID = @SessionUUID",
 		tableName,
 		dbrepo.SetClause("UpdatedAt"),
@@ -109,9 +109,9 @@ func (r *sessionSettingsRepository) Touch(ctx context.Context, uuid string) erro
 }
 
 // ListAll returns all session settings rows ordered by most recently updated.
-func (r *sessionSettingsRepository) ListAll(ctx context.Context) ([]session.SessionSettings, error) {
+func (r *SessionSettingsRepository) ListAll(ctx context.Context) ([]session.Settings, error) {
 	query, args := dbrepo.NewSelect(tableName, selectCols).OrderBy("UpdatedAt DESC").Build()
-	var rows []session.SessionSettings
+	var rows []session.Settings
 	err := r.repo.GetDB().SelectContext(ctx, &rows, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list session settings: %w", err)

--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -71,7 +71,7 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 		csrfToken = t
 	}
 	// setup:feature:csrf:end
-	var theme string //nolint:gosimple // declared before setup:feature gate
+	var theme string //nolint:staticcheck // declared before setup:feature gate
 	// setup:feature:session_settings:start
 	theme = session.GetSettings(c.Request()).Theme
 	// setup:feature:session_settings:end

--- a/internal/routes/middleware/links.go
+++ b/internal/routes/middleware/links.go
@@ -1,4 +1,5 @@
 // setup:feature:demo
+
 package middleware
 
 import (

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -56,8 +56,8 @@ type AppRoutes interface {
 // SessionSettingsStore is the subset of session-settings operations that route
 // handlers need: listing all rows and upserting a single row.
 type SessionSettingsStore interface {
-	ListAll(ctx context.Context) ([]session.SessionSettings, error)
-	Upsert(ctx context.Context, s *session.SessionSettings) error
+	ListAll(ctx context.Context) ([]session.Settings, error)
+	Upsert(ctx context.Context, s *session.Settings) error
 }
 
 // setup:feature:session_settings:end
@@ -370,7 +370,7 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 
 	// setup:feature:session_settings:start
 	if settingsRepo != nil {
-		var sessCfg session.SessionConfig
+		var sessCfg session.Config
 		if cfg != nil && cfg.AppName != "" {
 			sessCfg.CookieName = cfg.AppName + "_session_id"
 		}

--- a/internal/routes/routes_admin_settings.go
+++ b/internal/routes/routes_admin_settings.go
@@ -101,7 +101,7 @@ func handleSSEAdmin(broker *tavern.SSEBroker) echo.HandlerFunc {
 				if !ok {
 					return nil
 				}
-				fmt.Fprint(c.Response(), msg)
+				fmt.Fprint(c.Response(), msg) //nolint:errcheck // SSE stream; client disconnect handled by context
 				flusher.Flush()
 			}
 		}

--- a/internal/routes/routes_numerical.go
+++ b/internal/routes/routes_numerical.go
@@ -444,7 +444,7 @@ func handleSSENumerical(broker *tavern.SSEBroker) echo.HandlerFunc {
 				if !ok {
 					return nil
 				}
-				fmt.Fprint(c.Response(), msg)
+				fmt.Fprint(c.Response(), msg) //nolint:errcheck // SSE stream; client disconnect handled by context
 				flusher.Flush()
 			}
 		}

--- a/internal/routes/routes_sync.go
+++ b/internal/routes/routes_sync.go
@@ -1,4 +1,5 @@
 // setup:feature:sync
+
 package routes
 
 import (

--- a/internal/routes/routes_tables.go
+++ b/internal/routes/routes_tables.go
@@ -1,4 +1,5 @@
 // setup:feature:demo
+
 package routes
 
 import (

--- a/internal/routes/sync_types.go
+++ b/internal/routes/sync_types.go
@@ -1,4 +1,5 @@
 // setup:feature:sync
+
 package routes
 
 import "time"
@@ -22,6 +23,7 @@ type SyncRequest struct {
 // SyncResultStatus represents the outcome of a sync operation.
 type SyncResultStatus string
 
+// Sync result statuses.
 const (
 	SyncApplied  SyncResultStatus = "applied"
 	SyncConflict SyncResultStatus = "conflict"

--- a/internal/routes/sync_version.go
+++ b/internal/routes/sync_version.go
@@ -1,4 +1,5 @@
 // setup:feature:sync
+
 package routes
 
 import (

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,4 +1,5 @@
 // setup:feature:session_settings
+
 package session
 
 import (
@@ -17,10 +18,10 @@ type settingsKeyType struct{}
 
 var settingsCtxKey settingsKeyType
 
-// SessionSettings holds per-session user preferences keyed by a browser UUID
+// Settings holds per-session user preferences keyed by a browser UUID
 // cookie. The struct is designed to be stored in a database row; the db tags
 // match the expected column names.
-type SessionSettings struct {
+type Settings struct {
 	UpdatedAt   time.Time         `db:"UpdatedAt"`
 	Extra       map[string]string `db:"Extra" json:"extra,omitempty"`
 	SessionUUID string            `db:"SessionUUID"`
@@ -30,7 +31,7 @@ type SessionSettings struct {
 }
 
 // GetExtra returns the value for key, or empty string if not set.
-func (s *SessionSettings) GetExtra(key string) string {
+func (s *Settings) GetExtra(key string) string {
 	if s.Extra == nil {
 		return ""
 	}
@@ -38,7 +39,7 @@ func (s *SessionSettings) GetExtra(key string) string {
 }
 
 // SetExtra sets a key-value pair in Extra, initializing the map if nil.
-func (s *SessionSettings) SetExtra(key, value string) {
+func (s *Settings) SetExtra(key, value string) {
 	if s.Extra == nil {
 		s.Extra = make(map[string]string)
 	}
@@ -46,7 +47,7 @@ func (s *SessionSettings) SetExtra(key, value string) {
 }
 
 // MarshalExtra returns the Extra map serialized as a JSON string.
-func (s *SessionSettings) MarshalExtra() (string, error) {
+func (s *Settings) MarshalExtra() (string, error) {
 	if s.Extra == nil {
 		return "{}", nil
 	}
@@ -58,7 +59,7 @@ func (s *SessionSettings) MarshalExtra() (string, error) {
 }
 
 // UnmarshalExtra populates the Extra map from a JSON string.
-func (s *SessionSettings) UnmarshalExtra(data string) error {
+func (s *Settings) UnmarshalExtra(data string) error {
 	if data == "" {
 		s.Extra = make(map[string]string)
 		return nil
@@ -71,15 +72,16 @@ func (s *SessionSettings) UnmarshalExtra(data string) error {
 	return nil
 }
 
+// Session settings defaults.
 const (
 	DefaultTheme  = "light"
 	DefaultLayout = "classic"
 	LayoutApp     = "app"
 )
 
-// NewDefaultSettings returns a SessionSettings with defaults for the given UUID.
-func NewDefaultSettings(uuid string) *SessionSettings {
-	return &SessionSettings{
+// NewDefaultSettings returns a Settings with defaults for the given UUID.
+func NewDefaultSettings(uuid string) *Settings {
+	return &Settings{
 		SessionUUID: uuid,
 		Theme:       DefaultTheme,
 		Layout:      DefaultLayout,
@@ -87,20 +89,20 @@ func NewDefaultSettings(uuid string) *SessionSettings {
 	}
 }
 
-// SessionConfig holds session middleware configuration.
-type SessionConfig struct {
+// Config holds session middleware configuration.
+type Config struct {
 	Logger     *slog.Logger
 	CookieName string
 }
 
-func (cfg SessionConfig) cookieName() string {
+func (cfg Config) cookieName() string {
 	if cfg.CookieName != "" {
 		return cfg.CookieName
 	}
 	return "session_id"
 }
 
-func (cfg SessionConfig) logger() *slog.Logger {
+func (cfg Config) logger() *slog.Logger {
 	if cfg.Logger != nil {
 		return cfg.Logger
 	}
@@ -109,8 +111,8 @@ func (cfg SessionConfig) logger() *slog.Logger {
 
 // Provider is the interface for session-settings persistence.
 type Provider interface {
-	GetByUUID(ctx context.Context, uuid string) (*SessionSettings, error)
-	Upsert(ctx context.Context, s *SessionSettings) error
+	GetByUUID(ctx context.Context, uuid string) (*Settings, error)
+	Upsert(ctx context.Context, s *Settings) error
 	Touch(ctx context.Context, uuid string) error
 }
 
@@ -119,8 +121,8 @@ type IDFunc func(r *http.Request) string
 
 // Middleware returns middleware that loads per-session settings and stores
 // them on the request context for downstream handlers.
-func Middleware(repo Provider, idFunc IDFunc, cfgs ...SessionConfig) func(http.Handler) http.Handler {
-	var cfg SessionConfig
+func Middleware(repo Provider, idFunc IDFunc, cfgs ...Config) func(http.Handler) http.Handler {
+	var cfg Config
 	if len(cfgs) > 0 {
 		cfg = cfgs[0]
 	}
@@ -165,8 +167,8 @@ func Middleware(repo Provider, idFunc IDFunc, cfgs ...SessionConfig) func(http.H
 }
 
 // GetSettings returns the session settings from the request context.
-func GetSettings(r *http.Request) *SessionSettings {
-	if s, ok := r.Context().Value(settingsCtxKey).(*SessionSettings); ok {
+func GetSettings(r *http.Request) *Settings {
+	if s, ok := r.Context().Value(settingsCtxKey).(*Settings); ok {
 		return s
 	}
 	return NewDefaultSettings("")

--- a/magefile.go
+++ b/magefile.go
@@ -738,41 +738,46 @@ func parseFeatureFlag(val string) []string {
 
 // setup:feature:demo:end
 
+// runQuiet runs a command with stdout/stderr piped through without the verbose exec: prefix.
+func runQuiet(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 // Lint runs static analysis and style checks on the codebase.
 func Lint() error {
-	// Check if golangci-lint is available
-	if _, err := sh.Exec(nil, nil, nil, "which", "golangci-lint"); err != nil {
+	if _, err := exec.LookPath("golangci-lint"); err != nil {
 		return errors.New("golangci-lint not found. Please install it: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest")
 	}
 	fmt.Println("Running golangci-lint...")
-	if err := sh.RunV("golangci-lint", "run"); err != nil {
+	if err := runQuiet("golangci-lint", "run"); err != nil {
 		return err
 	}
 
-	// Check if golint is available
-	if _, err := sh.Exec(nil, nil, nil, "which", "golint"); err != nil {
+	if _, err := exec.LookPath("golint"); err != nil {
 		return errors.New("golint not found. Please install it: go install golang.org/x/lint/golint@latest")
 	}
 	fmt.Println("Running golint...")
-	if err := sh.RunV("golint", "./..."); err != nil {
+	if err := runQuiet("golint", "./..."); err != nil {
 		return err
 	}
 
-	// Check if fieldalignment is available
-	if _, err := sh.Exec(nil, nil, nil, "which", "fieldalignment"); err != nil {
+	if _, err := exec.LookPath("fieldalignment"); err != nil {
 		return errors.New("fieldalignment not found. Please install it: go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest")
 	}
 	fmt.Println("Running fieldalignment...")
-	if err := sh.RunV("fieldalignment", "./..."); err != nil {
+	if err := runFilteredFieldAlignment(); err != nil {
 		return err
 	}
 
 	// oxlint is optional — warn if not installed
-	if _, err := sh.Exec(nil, nil, nil, "which", "oxlint"); err != nil {
+	if _, err := exec.LookPath("oxlint"); err != nil {
 		fmt.Println("Warning: oxlint not found, skipping JS lint. Install: curl -sSf https://oxc.rs/install.sh | sh")
 	} else {
 		fmt.Println("Running oxlint...")
-		if err := sh.RunV("oxlint", "web/assets/public/js/"); err != nil {
+		if err := runQuiet("oxlint", "web/assets/public/js/"); err != nil {
 			return err
 		}
 	}
@@ -780,14 +785,33 @@ func Lint() error {
 	return nil
 }
 
+// runFilteredFieldAlignment runs fieldalignment and filters out _templ.go generated files.
+func runFilteredFieldAlignment() error {
+	out, err := exec.Command("fieldalignment", "./...").CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	var lines []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line == "" || strings.Contains(line, "_templ.go") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	fmt.Println(strings.Join(lines, "\n"))
+	return errors.New("fieldalignment issues found")
+}
+
 // FixFieldAlignment runs fieldalignment with the -fix flag to automatically fix field alignment issues
 func FixFieldAlignment() error {
-	// Check if fieldalignment is available
-	if _, err := sh.Exec(nil, nil, nil, "which", "fieldalignment"); err != nil {
+	if _, err := exec.LookPath("fieldalignment"); err != nil {
 		return errors.New("fieldalignment not found. Please install it: go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest")
 	}
 	fmt.Println("Running fieldalignment with -fix...")
-	return sh.RunV("fieldalignment", "-fix", "./...")
+	return runQuiet("fieldalignment", "-fix", "./...")
 }
 
 // LintWatch runs Air with lint configuration for automatic linting on file changes

--- a/web/components/core/csrf_templ.go
+++ b/web/components/core/csrf_templ.go
@@ -8,9 +8,11 @@ package components
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-// CsrfMeta renders the CSRF meta tag and the HTMX configRequest listener
-// that attaches the token to every outgoing request. Include this in any
-// custom layout that handles authenticated mutations.
+import "catgoose/dothog/internal/version"
+
+// CsrfMeta renders the CSRF meta tag and loads the external configRequest
+// listener that attaches the token to every outgoing HTMX request. Include
+// this in any custom layout that handles authenticated mutations.
 func CsrfMeta(token string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -40,13 +42,26 @@ func CsrfMeta(token string) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(token)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/csrf.templ`, Line: 8, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/csrf.templ`, Line: 10, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><script>\n\t\t\t/**\n\t\t\t * Attach the CSRF token to every outgoing HTMX request.\n\t\t\t * Reads the token from the <meta name=\"csrf-token\"> tag injected\n\t\t\t * by the server and sets the X-CSRF-Token header.\n\t\t\t * @listens htmx:configRequest\n\t\t\t */\n\t\t\tdocument.addEventListener(\"htmx:configRequest\", function(evt) {\n\t\t\t\t/** @type {HTMLMetaElement|null} */\n\t\t\t\tvar t = document.querySelector(\"meta[name=\\\"csrf-token\\\"]\");\n\t\t\t\tif (t) evt.detail.headers[\"X-CSRF-Token\"] = t.getAttribute(\"content\");\n\t\t\t});\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><script src=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var3 string
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(version.Asset("/public/js/csrf-header.js"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/csrf.templ`, Line: 11, Col: 58}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"></script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/web/views/admin_sessions.templ
+++ b/web/views/admin_sessions.templ
@@ -10,7 +10,7 @@ import (
 )
 
 // AdminSessionsPage displays all session settings rows with live SSE updates.
-templ AdminSessionsPage(sessions []session.SessionSettings) {
+templ AdminSessionsPage(sessions []session.Settings) {
 	<div class="p-4 space-y-6 max-w-4xl mx-auto">
 		<h1 class="text-2xl font-bold">Session Settings</h1>
 		<p class="text-sm text-base-content/60">
@@ -27,7 +27,7 @@ templ AdminSessionsPage(sessions []session.SessionSettings) {
 }
 
 // AdminSessionsTable renders just the sessions table for HTMX fragment swaps.
-templ AdminSessionsTable(sessions []session.SessionSettings) {
+templ AdminSessionsTable(sessions []session.Settings) {
 	<div class="card bg-base-100 shadow border border-base-300">
 		<div class="card-body p-4">
 			<div class="overflow-x-auto">

--- a/web/views/admin_sessions_templ.go
+++ b/web/views/admin_sessions_templ.go
@@ -18,7 +18,7 @@ import (
 )
 
 // AdminSessionsPage displays all session settings rows with live SSE updates.
-func AdminSessionsPage(sessions []session.SessionSettings) templ.Component {
+func AdminSessionsPage(sessions []session.Settings) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -56,7 +56,7 @@ func AdminSessionsPage(sessions []session.SessionSettings) templ.Component {
 }
 
 // AdminSessionsTable renders just the sessions table for HTMX fragment swaps.
-func AdminSessionsTable(sessions []session.SessionSettings) templ.Component {
+func AdminSessionsTable(sessions []session.Settings) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {

--- a/web/views/hypermedia_links.go
+++ b/web/views/hypermedia_links.go
@@ -1,4 +1,5 @@
 // setup:feature:demo
+
 package views
 
 import (


### PR DESCRIPTION
## Summary

- Fix golangci-lint errcheck warnings on SSE `fmt.Fprint` calls and update stale `gosimple` nolint directive to `staticcheck`
- Fix all golint warnings: missing comments on exported symbols, package comments on feature-gated files, blank import justification
- Fix golint stutter: `session.SessionSettings` → `session.Settings`, `session.SessionConfig` → `session.Config`, export `SessionSettingsRepository`
- Filter `_templ.go` generated files from fieldalignment output
- Configure oxlint `caughtErrors: none` for intentional catch swallows
- Replace `sh.Exec`/`sh.RunV` with `exec.LookPath`/`runQuiet` in mage lint to suppress verbose `exec:` noise

## Test plan
- [x] `mage lint` passes with zero warnings across all four linters
- [x] `go build ./...` passes
- [x] `go tool templ generate` passes