### PR TITLE
fix: add ~/.local/bin to PATH for oxlint in CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -140,7 +140,9 @@ jobs:
           ref: ${{ needs.update-deps.outputs.sha }}
 
       - name: Install oxlint
-        run: curl -sSf https://oxc.rs/install.sh | sh
+        run: |
+          curl -sSf https://oxc.rs/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Lint JavaScript
         run: oxlint web/assets/public/js/


### PR DESCRIPTION
## Summary

- Fixes the `js-lint` CI job failing with `oxlint: command not found`
- The oxlint install script (`https://oxc.rs/install.sh`) places the binary in `~/.local/bin`, which isn't in `PATH` by default on GitHub Actions runners
- Adds `$HOME/.local/bin` to `$GITHUB_PATH` after install so subsequent steps can find the `oxlint` binary

## Note on nolint directive

The `//nolint:staticcheck` directive in `handler.go:74` is already correct — `S1021` is reported by `staticcheck` in golangci-lint v2 (where `gosimple` was merged into `staticcheck`). This was fixed in #505.

## Test plan

- [ ] Verify the `js-lint` job passes in CI after this change