### PR TITLE
fix: add gosimple to nolint directive for CI compatibility

### DIFF
--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -71,7 +71,7 @@ func getLayoutCtx(c echo.Context) layoutCtx {
 		csrfToken = t
 	}
 	// setup:feature:csrf:end
-	var theme string //nolint:staticcheck // declared before setup:feature gate
+	var theme string //nolint:gosimple,staticcheck // declared before setup:feature gate
 	// setup:feature:session_settings:start
 	theme = session.GetSettings(c.Request()).Theme
 	// setup:feature:session_settings:end


### PR DESCRIPTION
## Summary

- Add `gosimple` alongside `staticcheck` in the nolint directive at handler.go:74
- CI uses golangci-lint v1 where S1021 is reported by `gosimple` (separate linter), local v2 merged them into `staticcheck`

## Test plan

- [ ] CI pipeline passes (golangci-lint lint step)