### PR TITLE
fix: use full path for oxlint in CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -142,10 +142,9 @@ jobs:
       - name: Install oxlint
         run: |
           curl -sSf https://oxc.rs/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Lint JavaScript
-        run: oxlint web/assets/public/js/
+        run: $HOME/.local/bin/oxlint web/assets/public/js/
 
   e2e-test:
     needs: [update-deps]


### PR DESCRIPTION
## Summary

- Use `$HOME/.local/bin/oxlint` directly instead of relying on GITHUB_PATH
- The install script puts the binary in ~/.local/bin but PATH updates weren't resolving reliably