### PR TITLE
fix: use npx oxlint instead of broken install script

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -139,12 +139,8 @@ jobs:
         with:
           ref: ${{ needs.update-deps.outputs.sha }}
 
-      - name: Install oxlint
-        run: |
-          curl -sSf https://oxc.rs/install.sh | sh
-
       - name: Lint JavaScript
-        run: $HOME/.local/bin/oxlint web/assets/public/js/
+        run: npx oxlint web/assets/public/js/
 
   e2e-test:
     needs: [update-deps]


### PR DESCRIPTION
## Summary

- The oxc.rs install script returns 404 — it no longer exists
- Use `npx oxlint` instead, which downloads and runs the binary via npm (Node is already on the runner)
- Simplifies the job to a single step