### PR TITLE
refactor: replace SSE handler boilerplate with tavern SSEHandler

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -181,7 +181,7 @@ func (ar *appRoutes) InitRoutes() error {
 	// setup:feature:demo:end
 
 	// setup:feature:sse:start
-	ar.broker = tavern.NewSSEBroker()
+	ar.broker = tavern.NewSSEBroker(tavern.WithKeepalive(30 * time.Second))
 	// setup:feature:sse:end
 	// setup:feature:session_settings:start
 	ar.initThemeRoutes(ar.broker)

--- a/internal/routes/routes_admin_settings.go
+++ b/internal/routes/routes_admin_settings.go
@@ -5,7 +5,6 @@ package routes
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
@@ -51,7 +50,7 @@ func (ar *appRoutes) initAdminSettingsRoutes(broker *tavern.SSEBroker) {
 	initAdminIntervals()
 	ar.e.GET("/admin/settings", ar.handleAdminSettings(broker))
 	ar.e.POST("/admin/settings/interval", handleAdminInterval)
-	ar.e.GET("/sse/admin", handleSSEAdmin(broker))
+	ar.e.GET("/sse/admin", echo.WrapHandler(broker.SSEHandler(TopicAdminPanel)))
 
 	go ar.publishAdminPanel(broker)
 }
@@ -75,37 +74,6 @@ func handleAdminInterval(c echo.Context) error {
 	adminIntervals.intervals[section] = ms
 	adminIntervals.mu.Unlock()
 	return c.NoContent(http.StatusNoContent)
-}
-
-func handleSSEAdmin(broker *tavern.SSEBroker) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		c.Response().Header().Set("Content-Type", "text/event-stream")
-		c.Response().Header().Set("Cache-Control", "no-cache")
-		c.Response().Header().Set("Connection", "keep-alive")
-		c.Response().WriteHeader(http.StatusOK)
-		flusher, ok := c.Response().Writer.(http.Flusher)
-		if !ok {
-			return fmt.Errorf("streaming not supported")
-		}
-		flusher.Flush()
-
-		ch, unsub := broker.Subscribe(TopicAdminPanel)
-		defer unsub()
-
-		ctx := c.Request().Context()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case msg, ok := <-ch:
-				if !ok {
-					return nil
-				}
-				fmt.Fprint(c.Response(), msg) //nolint:errcheck // SSE stream; client disconnect handled by context
-				flusher.Flush()
-			}
-		}
-	}
 }
 
 // ── Publisher ────────────────────────────────────────────────────────────────

--- a/internal/routes/routes_feed.go
+++ b/internal/routes/routes_feed.go
@@ -5,9 +5,7 @@ package routes
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math/rand/v2"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -22,14 +20,13 @@ import (
 
 type feedRoutes struct {
 	actLog *demo.ActivityLog
-	broker *tavern.SSEBroker
 }
 
 func (ar *appRoutes) initFeedRoutes(actLog *demo.ActivityLog, broker *tavern.SSEBroker) {
-	f := &feedRoutes{actLog: actLog, broker: broker}
+	f := &feedRoutes{actLog: actLog}
 	ar.e.GET("/realtime/feed", f.handleFeedPage)
 	ar.e.GET("/realtime/feed/more", f.handleFeedMore)
-	ar.e.GET("/sse/activity", f.handleActivitySSE)
+	ar.e.GET("/sse/activity", echo.WrapHandler(broker.SSEHandler(TopicActivityFeed)))
 
 	// Seed some initial events so the feed isn't empty on first load.
 	seedFeedEvents(actLog)
@@ -66,35 +63,6 @@ func (f *feedRoutes) handleFeedMore(c echo.Context) error {
 	}
 	hasMore := len(filtered) == 20
 	return handler.RenderComponent(c, views.FeedMoreItems(filtered, lastID, hasMore))
-}
-
-func (f *feedRoutes) handleActivitySSE(c echo.Context) error {
-	c.Response().Header().Set("Content-Type", "text/event-stream")
-	c.Response().Header().Set("Cache-Control", "no-cache")
-	c.Response().Header().Set("Connection", "keep-alive")
-	c.Response().WriteHeader(http.StatusOK)
-
-	flusher, ok := c.Response().Writer.(http.Flusher)
-	if !ok {
-		return fmt.Errorf("streaming unsupported")
-	}
-
-	ch, unsub := f.broker.Subscribe(TopicActivityFeed)
-	defer unsub()
-
-	ctx := c.Request().Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case msg, ok := <-ch:
-			if !ok {
-				return nil
-			}
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
-		}
-	}
 }
 
 // BroadcastActivity publishes an activity event to the SSE feed.

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -31,7 +31,7 @@ func (ar *appRoutes) initLoggingRoutes(broker *tavern.SSEBroker) {
 		})
 	}
 
-	ar.e.GET("/sse/error-traces", handleErrorTracesSSE(broker))
+	ar.e.GET("/sse/error-traces", echo.WrapHandler(broker.SSEHandler(TopicErrorTraces)))
 	// setup:feature:sse:end
 
 	ar.e.GET(loggingBase, handler.HandleComponent(views.LoggingPage()))
@@ -133,36 +133,6 @@ func (ar *appRoutes) initLoggingRoutes(broker *tavern.SSEBroker) {
 }
 
 // setup:feature:sse:start
-
-func handleErrorTracesSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		c.Response().Header().Set("Content-Type", "text/event-stream")
-		c.Response().Header().Set("Cache-Control", "no-cache")
-		c.Response().Header().Set("Connection", "keep-alive")
-		c.Response().WriteHeader(http.StatusOK)
-
-		flusher, ok := c.Response().Writer.(http.Flusher)
-		if !ok {
-			return fmt.Errorf("streaming unsupported")
-		}
-		ch, unsub := broker.Subscribe(TopicErrorTraces)
-		defer unsub()
-
-		ctx := c.Request().Context()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case msg, ok := <-ch:
-				if !ok {
-					return nil
-				}
-				_, _ = fmt.Fprint(c.Response(), msg)
-				flusher.Flush()
-			}
-		}
-	}
-}
 
 func broadcastErrorTrace(broker *tavern.SSEBroker, summary promolog.TraceSummary) {
 	if !broker.HasSubscribers(TopicErrorTraces) {

--- a/internal/routes/routes_numerical.go
+++ b/internal/routes/routes_numerical.go
@@ -420,37 +420,6 @@ func broadcastTileSlider(tileID string, ms int, unit string) {
 	numBroker.Publish(TopicNumericalDash, msg)
 }
 
-func handleSSENumerical(broker *tavern.SSEBroker) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		c.Response().Header().Set("Content-Type", "text/event-stream")
-		c.Response().Header().Set("Cache-Control", "no-cache")
-		c.Response().Header().Set("Connection", "keep-alive")
-		c.Response().WriteHeader(200)
-		flusher, ok := c.Response().Writer.(http.Flusher)
-		if !ok {
-			return fmt.Errorf("streaming not supported")
-		}
-		flusher.Flush()
-
-		ch, unsub := broker.Subscribe(TopicNumericalDash)
-		defer unsub()
-
-		ctx := c.Request().Context()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case msg, ok := <-ch:
-				if !ok {
-					return nil
-				}
-				fmt.Fprint(c.Response(), msg) //nolint:errcheck // SSE stream; client disconnect handled by context
-				flusher.Flush()
-			}
-		}
-	}
-}
-
 // ── Publisher ────────────────────────────────────────────────────────────────
 
 func (ar *appRoutes) publishNumerical(broker *tavern.SSEBroker) {

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -89,13 +89,13 @@ func (ar *appRoutes) initRealtimeRoutes(broker *tavern.SSEBroker) {
 	ar.e.POST("/realtime/dashboard/interval-all", handleRTIntervalAll)
 	ar.e.POST("/realtime/dashboard/interval-restore", handleRTIntervalRestore)
 	ar.e.POST("/realtime/dashboard/pin", handleRTPin)
-	ar.e.GET("/sse/system", handleSSESystem(broker))
-	ar.e.GET("/sse/dashboard", handleSSEDashboard(broker))
+	ar.e.GET("/sse/system", echo.WrapHandler(broker.SSEHandler(TopicSystemStats)))
+	ar.e.GET("/sse/dashboard", echo.WrapHandler(broker.SSEHandler(TopicDashMetrics)))
 
 	// Numerical tile publisher (shares the page, separate SSE stream)
 	initTileIntervals()
 	ar.e.POST("/realtime/dashboard/tile-interval", handleNumericalInterval)
-	ar.e.GET("/sse/numerical", handleSSENumerical(broker))
+	ar.e.GET("/sse/numerical", echo.WrapHandler(broker.SSEHandler(TopicNumericalDash)))
 
 	go ar.publishSystemStats(broker)
 	go ar.publishRealtimeDashboard(broker)
@@ -274,69 +274,6 @@ func (ar *appRoutes) handleRealtimePage() echo.HandlerFunc {
 		}
 
 		return handler.RenderBaseLayout(c, views.RealtimePage(stats, snap, services, svcLatencies, tiles, masterEnabled, masterMs))
-	}
-}
-
-func handleSSESystem(broker *tavern.SSEBroker) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		c.Response().Header().Set("Content-Type", "text/event-stream")
-		c.Response().Header().Set("Cache-Control", "no-cache")
-		c.Response().Header().Set("Connection", "keep-alive")
-		c.Response().WriteHeader(http.StatusOK)
-
-		flusher, ok := c.Response().Writer.(http.Flusher)
-		if !ok {
-			return fmt.Errorf("streaming unsupported")
-		}
-
-		ch, unsub := broker.Subscribe(TopicSystemStats)
-		defer unsub()
-
-		ctx := c.Request().Context()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case msg, ok := <-ch:
-				if !ok {
-					return nil
-				}
-				_, _ = fmt.Fprint(c.Response(), msg)
-				flusher.Flush()
-			}
-		}
-	}
-}
-
-// handleSSEDashboard streams dashboard card updates from the unified publisher.
-func handleSSEDashboard(broker *tavern.SSEBroker) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		c.Response().Header().Set("Content-Type", "text/event-stream")
-		c.Response().Header().Set("Cache-Control", "no-cache")
-		c.Response().Header().Set("Connection", "keep-alive")
-		c.Response().WriteHeader(http.StatusOK)
-
-		flusher, ok := c.Response().Writer.(http.Flusher)
-		if !ok {
-			return fmt.Errorf("streaming unsupported")
-		}
-
-		ch, unsub := broker.Subscribe(TopicDashMetrics)
-		defer unsub()
-
-		ctx := c.Request().Context()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case msg, ok := <-ch:
-				if !ok {
-					return nil
-				}
-				_, _ = fmt.Fprint(c.Response(), msg)
-				flusher.Flush()
-			}
-		}
 	}
 }
 

--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -3,7 +3,6 @@
 package routes
 
 import (
-	"fmt"
 	"net/http"
 
 	"catgoose/dothog/internal/logger"
@@ -24,7 +23,7 @@ import (
 func (ar *appRoutes) initThemeRoutes(broker *tavern.SSEBroker) {
 	ar.e.POST("/settings/theme", ar.handleTheme(broker))
 	ar.e.POST("/settings/layout", ar.handleLayout())
-	ar.e.GET("/sse/theme", handleSSETheme(broker))
+	ar.e.GET("/sse/theme", echo.WrapHandler(broker.SSEHandler(TopicThemeChange)))
 }
 
 // handleTheme updates the shared theme setting and broadcasts to all browsers.
@@ -83,35 +82,3 @@ func (ar *appRoutes) handleLayout() echo.HandlerFunc {
 }
 
 // setup:feature:session_settings:end
-
-// handleSSETheme streams theme-change events to all connected browsers.
-func handleSSETheme(broker *tavern.SSEBroker) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		c.Response().Header().Set("Content-Type", "text/event-stream")
-		c.Response().Header().Set("Cache-Control", "no-cache")
-		c.Response().Header().Set("Connection", "keep-alive")
-		c.Response().WriteHeader(http.StatusOK)
-
-		flusher, ok := c.Response().Writer.(http.Flusher)
-		if !ok {
-			return fmt.Errorf("streaming unsupported")
-		}
-
-		ch, unsub := broker.Subscribe(TopicThemeChange)
-		defer unsub()
-
-		ctx := c.Request().Context()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case msg, ok := <-ch:
-				if !ok {
-					return nil
-				}
-				_, _ = fmt.Fprint(c.Response(), msg)
-				flusher.Flush()
-			}
-		}
-	}
-}


### PR DESCRIPTION
## Summary

- Replace 7 hand-rolled SSE handler functions with `echo.WrapHandler(broker.SSEHandler(topic))` using tavern v0.4.53's built-in `SSEHandler`, removing ~230 lines of duplicated boilerplate
- Enable broker-level keepalive (30s) via `WithKeepalive` to keep connections alive through proxies
- Canvas SSE handler intentionally kept as-is due to custom client-tracking heartbeat logic

Affected handlers:
- `handleSSETheme` (routes_theme.go)
- `handleSSESystem`, `handleSSEDashboard` (routes_realtime.go)
- `handleSSENumerical` (routes_numerical.go)
- `handleSSEAdmin` (routes_admin_settings.go)
- `handleErrorTracesSSE` (routes_logging.go)
- `handleActivitySSE` (routes_feed.go)

## Test plan

- [ ] Verify theme SSE stream works (change theme in one tab, observe in another)
- [ ] Verify realtime dashboard charts update via SSE
- [ ] Verify numerical tiles update via SSE
- [ ] Verify admin settings panel updates via SSE
- [ ] Verify error traces stream to logging page
- [ ] Verify activity feed receives live events
- [ ] Verify canvas SSE still works (unchanged)
- [ ] Confirm keepalive comments appear in SSE streams after 30s idle