### PR TITLE
fix: correct feature marker in routes_theme.go

### DIFF
--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -1,4 +1,4 @@
-// setup:feature:sse
+// setup:feature:session_settings
 
 package routes
 


### PR DESCRIPTION
## Summary

- Changed file-level feature marker in `internal/routes/routes_theme.go` from `// setup:feature:sse` to `// setup:feature:session_settings`
- The file's entire functionality (theme/layout handlers) depends on `session_settings`, not just `sse`. When the SSE+Caddy test ran without `session_settings`, the file was kept but its block-gated content was stripped, leaving unused `tavern` and `echo` imports that broke the build.

Fixes #207

## Test plan

- [x] `go test ./tests/ -run TestSetup_FeaturesSSECaddy -v` passes
- [x] `mage lint` passes with 0 issues