### PR TITLE
feat: rename porter to dorman

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 | [catgoose/chuck](https://github.com/catgoose/chuck) | SQL dialects, schema DSL, query builders | `"github.com/catgoose/chuck"` |
 | [catgoose/promolog](https://github.com/catgoose/promolog) | Error trace capture, promote-on-error | `"github.com/catgoose/promolog"` |
 | [catgoose/crooner](https://github.com/catgoose/crooner) | OIDC authentication | `"github.com/catgoose/crooner"` |
-| [catgoose/porter](https://github.com/catgoose/porter) | Auth, CSRF, security headers | `"github.com/catgoose/porter"` |
+| [catgoose/dorman](https://github.com/catgoose/dorman) | Auth, CSRF, security headers | `"github.com/catgoose/dorman"` |
 | [catgoose/linkwell](https://github.com/catgoose/linkwell) | HATEOAS controls, navigation, link registry | `"github.com/catgoose/linkwell"` |
 | [catgoose/tavern](https://github.com/catgoose/tavern) | SSE pub/sub broker | `"github.com/catgoose/tavern"` |
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -16,7 +16,7 @@ Per-request log capture with promote-on-error semantics. During normal requests,
 
 OIDC/OAuth2 client with PKCE, session management, and pluggable backends. Handles the login/callback/logout flow and puts identity on the request context. Works with any OIDC-compliant provider (Azure AD, Google, Okta, Auth0, Keycloak).
 
-### [porter](https://github.com/catgoose/porter) — Security
+### [dorman](https://github.com/catgoose/dorman) — Security
 
 Authorization, CSRF protection, and security header middleware. `RequireAuth` and `RequireRole` enforce identity and role checks. `CSRFProtect` implements double-submit cookie with HMAC-SHA256 and BREACH protection. `SecurityHeaders` sets sensible defaults for X-Frame-Options, HSTS, Referrer-Policy, Permissions-Policy, and more.
 
@@ -35,7 +35,7 @@ Thread-safe, topic-based SSE pub/sub broker. Handlers publish events when state 
        │
        ▼
   ┌─────────────┐
-  │  porter      │  Security headers, CSRF validation
+  │  dorman      │  Security headers, CSRF validation
   └──────┬──────┘
          │
   ┌──────▼──────┐
@@ -43,7 +43,7 @@ Thread-safe, topic-based SSE pub/sub broker. Handlers publish events when state 
   └──────┬──────┘
          │
   ┌──────▼──────┐
-  │  porter      │  Role checks (RequireAuth, RequireRole)
+  │  dorman      │  Role checks (RequireAuth, RequireRole)
   └──────┬──────┘
          │
   ┌──────▼──────┐
@@ -65,8 +65,8 @@ Thread-safe, topic-based SSE pub/sub broker. Handlers publish events when state 
 Every library follows the [dothog design philosophy](PHILOSOPHY.md):
 
 - **The server drives state.** Libraries provide data and middleware. Templates are downstream.
-- **Zero or minimal dependencies.** promolog (core), linkwell, porter, and tavern have zero runtime dependencies. chuck has only database drivers. crooner has only OIDC/OAuth2 libraries.
-- **Interfaces over implementations.** `promolog.Storer`, `session.Provider`, `porter.IdentityProvider` — implement the interface, bring your own backend.
+- **Zero or minimal dependencies.** promolog (core), linkwell, dorman, and tavern have zero runtime dependencies. chuck has only database drivers. crooner has only OIDC/OAuth2 libraries.
+- **Interfaces over implementations.** `promolog.Storer`, `session.Provider`, `dorman.IdentityProvider` — implement the interface, bring your own backend.
 - **Standard signatures.** All middleware uses `func(http.Handler) http.Handler`. No framework lock-in.
 - **The struct is the interface.** linkwell's control types are pure data. Any template engine that can read Go struct fields can render them. No `Renderer` interface needed — the data flows one way.
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -382,7 +382,7 @@ The robustness principle isn't about being sloppy. It's about building systems t
 | Templates     | templ              | Type-safe HTML generation, composable components              |
 | Hypermedia    | HTMX + linkwell    | Extends HTML with AJAX; linkwell provides the HATEOAS controls, navigation, and link registry |
 | SQL           | chuck              | Multi-dialect schema DSL and query fragments (SQLite, Postgres, MSSQL) |
-| Auth          | crooner + porter   | crooner handles OIDC/OAuth2; porter handles authorization, CSRF, security headers |
+| Auth          | crooner + dorman   | crooner handles OIDC/OAuth2; dorman handles authorization, CSRF, security headers |
 | Logging       | promolog           | Per-request log capture with promote-on-error                 |
 | Real-time     | tavern             | Thread-safe SSE pub/sub broker                                |
 | Styling       | Tailwind + DaisyUI | Utility-first CSS, consistent design tokens                   |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Each library exists because a single responsibility needed a home. None of them 
 
 - **Zero coupling** -- Libraries compose through Go interfaces and `net/http` middleware. No library imports another. Dothog wires them together; they do not wire themselves.
 - **Zero dependencies in core** -- Each library's core module imports only the Go standard library. Optional submodules (database drivers, test helpers) carry the weight so your binary doesn't.
-- **Server as source of truth** -- The server defines the schema ([chuck](https://github.com/catgoose/chuck)), manages identity ([crooner](https://github.com/catgoose/crooner)), enforces access ([porter](https://github.com/catgoose/porter)), declares navigation ([linkwell](https://github.com/catgoose/linkwell)), captures diagnostics ([promolog](https://github.com/catgoose/promolog)), and pushes state changes ([tavern](https://github.com/catgoose/tavern)). The client renders what it receives. This is the natural order.
+- **Server as source of truth** -- The server defines the schema ([chuck](https://github.com/catgoose/chuck)), manages identity ([crooner](https://github.com/catgoose/crooner)), enforces access ([dorman](https://github.com/catgoose/dorman)), declares navigation ([linkwell](https://github.com/catgoose/linkwell)), captures diagnostics ([promolog](https://github.com/catgoose/promolog)), and pushes state changes ([tavern](https://github.com/catgoose/tavern)). The client renders what it receives. This is the natural order.
 - **Reach up, not down** -- Start at HTML. Reach for a library only when the current layer cannot express what you need. Each library is one reach. If you are reaching more than once for the same problem, the problem is architectural, and the answer is in the [MANIFESTO](MANIFESTO.md).
 
 ## Architecture
@@ -108,11 +108,11 @@ graph TB
 
         subgraph pipeline ["Request Pipeline"]
             direction LR
-            PORTER["<b>porter</b><br/>security headers<br/>max body · CSRF · authz"]
+            DORMAN["<b>dorman</b><br/>security headers<br/>max body · CSRF · authz"]
             CROONER["<b>crooner</b><br/>OIDC sessions"]
             PROMOLOG["<b>promolog</b><br/>request capture<br/>policy-driven promotion"]
             HANDLER["handler"]
-            PORTER --> CROONER --> PROMOLOG --> HANDLER
+            DORMAN --> CROONER --> PROMOLOG --> HANDLER
         end
 
         subgraph response ["Response"]
@@ -151,7 +151,7 @@ graph TB
                              │         ▼                          ▼                         │
   ┌─────────────┐            │  REQUEST PIPELINE                          ┌──────────┐      │
   │   Browser   │            │  ┌──────────┐  ┌──────────┐  ┌──────────┐ │  SQLite  │      │
-  │             │  request   │  │  porter  ├─►│ crooner  ├─►│ promolog │ │          │      │
+  │             │  request   │  │  dorman  ├─►│ crooner  ├─►│ promolog │ │          │      │
   │  HTML+HTMX ─┼───────────┼─►│ security │  │   OIDC   │  │ request  │ └──────────┘      │
   │             │            │  │ headers  │  │ sessions │  │ capture  │      ▲             │
   │             │            │  │ CSRF     │  │          │  │ policy   │      │             │

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ This document describes how dothog processes requests, resolves navigation, and 
 | [chuck](https://github.com/catgoose/chuck) | Multi-dialect SQL schema and query fragments |
 | [promolog](https://github.com/catgoose/promolog) | Per-request log capture with promote-on-error |
 | [crooner](https://github.com/catgoose/crooner) | OIDC/OAuth2 authentication and session management |
-| [porter](https://github.com/catgoose/porter) | Authorization, CSRF protection, security headers |
+| [dorman](https://github.com/catgoose/dorman) | Authorization, CSRF protection, security headers |
 | [linkwell](https://github.com/catgoose/linkwell) | HATEOAS link registry, navigation, hypermedia controls |
 | [tavern](https://github.com/catgoose/tavern) | Thread-safe SSE pub/sub broker |
 
@@ -25,11 +25,11 @@ Request
   ├─ Correlation ID (promolog.CorrelationMiddleware → X-Request-ID)
   ├─ Request Logger (structured access log)
   ├─ Recover (panic recovery)
-  ├─ Security Headers (porter.SecurityHeaders — X-Frame-Options, HSTS, Permissions-Policy, etc.)
+  ├─ Security Headers (dorman.SecurityHeaders — X-Frame-Options, HSTS, Permissions-Policy, etc.)
   ├─ Compression (zstd/brotli/gzip via httpcompression; skipped behind templ proxy)
   ├─ Session (crooner/SCS — loads session, wraps LoadAndSave)
   ├─ Auth (crooner — OAuth/OIDC flow, login redirect)
-  ├─ CSRF (porter.CSRFProtect — Sec-Fetch-Site fast-path, HMAC-SHA256 fallback)
+  ├─ CSRF (dorman.CSRFProtect — Sec-Fetch-Site fast-path, HMAC-SHA256 fallback)
   ├─ Session Settings (loads per-session preferences → request context)
   ├─ Link Relations (resolves linkwell.LinksFor(path) → echo context + Link HTTP header)
   ├─ Vary: HX-Request header
@@ -228,17 +228,17 @@ When `reqLogStore` is non-nil, the error handler promotes the per-request log bu
 
 OIDC/OAuth2 with PKCE flow. Crooner manages the login/callback/logout routes and puts identity on the request context.
 
-### Authorization (porter)
+### Authorization (dorman)
 
-`porter.RequireAuth` rejects unauthenticated requests (401). `porter.RequireRole` / `porter.RequireAnyRole` enforce role-based access (403). Identity is read from context via `porter.GetIdentity(r)`.
+`dorman.RequireAuth` rejects unauthenticated requests (401). `dorman.RequireRole` / `dorman.RequireAnyRole` enforce role-based access (403). Identity is read from context via `dorman.GetIdentity(r)`.
 
-### CSRF (porter)
+### CSRF (dorman)
 
-`porter.CSRFProtect` implements double-submit cookie with HMAC-SHA256 and one-time-pad masking (BREACH protection). Token injected via `porter.GetToken(r)` → `<meta name="csrf-token">` → HTMX configRequest listener.
+`dorman.CSRFProtect` implements double-submit cookie with HMAC-SHA256 and one-time-pad masking (BREACH protection). Token injected via `dorman.GetToken(r)` → `<meta name="csrf-token">` → HTMX configRequest listener.
 
-### Security Headers (porter)
+### Security Headers (dorman)
 
-`porter.SecurityHeaders` sets X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, Cross-Origin-Opener-Policy, and optionally HSTS and CSP.
+`dorman.SecurityHeaders` sets X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, Cross-Origin-Opener-Policy, and optionally HSTS and CSP.
 
 ## File Organization
 

--- a/docs/DEPLOYMENT-SECURITY.md
+++ b/docs/DEPLOYMENT-SECURITY.md
@@ -13,7 +13,7 @@ Two layers, each with a role:
 | Layer | Handles | Examples |
 |-------|---------|----------|
 | **nginx** | TLS termination, reverse proxy, SSE buffering, H3/QUIC | SSL with wildcard certificate, HTTP/2, HTTP/3, proxy headers |
-| **App (porter)** | Application security, session management, CSRF, per-app CSP | Security headers, CSRF tokens, auth middleware, correlation IDs |
+| **App (dorman)** | Application security, session management, CSRF, per-app CSP | Security headers, CSRF tokens, auth middleware, correlation IDs |
 
 ## What each layer does
 
@@ -27,14 +27,14 @@ Configured in `deploy/cloud-init.yml`. Each app gets a server block.
 - SSE endpoints get dedicated config: buffering off, 300s timeouts, HTTP/1.1 upstream
 - `X-Forwarded-Proto`, `X-Real-IP`, `X-Forwarded-For` headers passed through
 
-### App (porter middleware)
+### App (dorman middleware)
 
 Configured in each app's `routes.go`. This is what ships with the scaffold.
 
 | Middleware | What it does |
 |-----------|-------------|
-| `porter.SecurityHeaders()` | Permissions-Policy, COOP, X-Frame-Options, X-Content-Type-Options |
-| `porter.CSRFProtect()` | CSRF tokens with Sec-Fetch-Site fast-path, double-submit cookies |
+| `dorman.SecurityHeaders()` | Permissions-Policy, COOP, X-Frame-Options, X-Content-Type-Options |
+| `dorman.CSRFProtect()` | CSRF tokens with Sec-Fetch-Site fast-path, double-submit cookies |
 | Compression | Brotli + Gzip via httpcompression |
 | Correlation IDs | Per-request trace IDs via promolog |
 | `crooner` session/auth | OIDC, PKCE, session management (when auth feature enabled) |
@@ -70,12 +70,12 @@ If deploying without a CDN or edge proxy, here's how to cover common security fe
 
 | Feature | Without edge proxy | Replacement |
 |---------|-------------------|-------------|
-| HSTS | Not set at edge | Enable in porter: `porter.DefaultHSTSConfig()` |
-| CSP (baseline) | No edge fallback | Set in porter (already done per-app) |
+| HSTS | Not set at edge | Enable in dorman: `dorman.DefaultHSTSConfig()` |
+| CSP (baseline) | No edge fallback | Set in dorman (already done per-app) |
 | Rate limiting | None | Add Go middleware (`golang.org/x/time/rate`) or nginx `limit_req` |
 | Early Hints (edge cache) | No edge replay | App still sends 103s if nginx uses H2 upstream, but no edge caching |
 | ECH | Not available | N/A -- requires a supporting edge proxy |
-| X-Robots-Tag | Not set | Add in porter or nginx if needed |
+| X-Robots-Tag | Not set | Add in dorman or nginx if needed |
 | DDoS protection | None | Firewall rules, fail2ban, or upstream provider |
 | Bot management | None | Consider Caddy with crowdsec or similar |
 
@@ -84,9 +84,9 @@ If deploying without a CDN or edge proxy, here's how to cover common security fe
 When deploying behind a corporate reverse proxy or Azure Application Gateway:
 
 1. **TLS**: Use your corporate wildcard cert on nginx (or let the corporate proxy terminate TLS and proxy HTTP to nginx on port 80)
-2. **HSTS**: Enable in porter if the corporate proxy doesn't set it
-3. **CSP**: Already set by porter per-app -- no change needed
-4. **CSRF**: Already handled by porter -- no change needed
+2. **HSTS**: Enable in dorman if the corporate proxy doesn't set it
+3. **CSP**: Already set by dorman per-app -- no change needed
+4. **CSRF**: Already handled by dorman -- no change needed
 5. **Rate limiting**: Add nginx `limit_req` zone:
    ```nginx
    # In http block
@@ -100,7 +100,7 @@ When deploying behind a corporate reverse proxy or Azure Application Gateway:
    ```
 6. **Auth**: Enable the auth feature (`mage setup` with OIDC) -- crooner handles Azure AD/Entra ID natively
 7. **Session cookie Secure flag**: Set via environment variable when serving over HTTPS
-8. **X-Forwarded headers**: Ensure your corporate proxy passes `X-Forwarded-Proto`, `X-Real-IP`, and `X-Forwarded-For` -- porter and crooner rely on these
+8. **X-Forwarded headers**: Ensure your corporate proxy passes `X-Forwarded-Proto`, `X-Real-IP`, and `X-Forwarded-For` -- dorman and crooner rely on these
 
 ### Corporate nginx config with H3 and SSE (tavern)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -15,7 +15,7 @@ These are active in every generated app by default.
 | Vary | `HX-Request` | Cache separation for HTMX partial vs full-page responses |
 | Cache-Control (static) | `public, max-age=31536000, immutable` | Long-lived cache for fingerprinted assets |
 
-Provided via `porter.SecurityHeaders()` middleware.
+Provided via `dorman.SecurityHeaders()` middleware.
 
 ### Alpine.js CSP Build
 
@@ -59,7 +59,7 @@ All database access uses `jmoiron/sqlx` with parameterized placeholders. No raw 
 ### Dependency Integrity
 
 - `go.sum` checksums for all module dependencies
-- Minimal dependency surface -- security-critical code in catgoose-maintained libraries (porter, crooner)
+- Minimal dependency surface -- security-critical code in catgoose-maintained libraries (dorman, crooner)
 
 ## Feature-gated (opt-in via setup)
 
@@ -67,7 +67,7 @@ These are available in the scaffold but only included when the feature is enable
 
 ### CSRF Protection (`setup:feature:csrf`)
 
-- Token generation and rotation via `porter.CSRFProtect()`
+- Token generation and rotation via `dorman.CSRFProtect()`
 - Sec-Fetch-Site fast-path: modern browsers (94%+ coverage) skip token validation entirely when `Sec-Fetch-Site: same-origin` is present
 - Double-submit cookie pattern with configurable key from `SESSION_SECRET`
 - Automatic HTMX header injection via `htmx:configRequest` listener
@@ -104,7 +104,7 @@ These are deliberate gaps -- things the scaffold does not implement. Depending o
 
 ### Content-Security-Policy header
 
-No CSP header is set by default. The Alpine CSP build means you can set a strict policy without `unsafe-eval`, but you need to configure the header yourself (via porter or your reverse proxy). A recommended starting point:
+No CSP header is set by default. The Alpine CSP build means you can set a strict policy without `unsafe-eval`, but you need to configure the header yourself (via dorman or your reverse proxy). A recommended starting point:
 
 ```
 script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self';
@@ -112,15 +112,15 @@ script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; conne
 
 ### Strict-Transport-Security (HSTS)
 
-Disabled by default in porter (can break dev environments without TLS). Enable with `porter.DefaultHSTSConfig()` when serving over HTTPS, or handle at the reverse proxy layer.
+Disabled by default in dorman (can break dev environments without TLS). Enable with `dorman.DefaultHSTSConfig()` when serving over HTTPS, or handle at the reverse proxy layer.
 
 ### X-Frame-Options / frame-ancestors
 
-Set to `SAMEORIGIN` by default via `porter.SecurityHeaders()`. Override with CSP `frame-ancestors` if you need stricter control.
+Set to `SAMEORIGIN` by default via `dorman.SecurityHeaders()`. Override with CSP `frame-ancestors` if you need stricter control.
 
 ### X-Content-Type-Options
 
-Set to `nosniff` by default via `porter.SecurityHeaders()`. No action needed.
+Set to `nosniff` by default via `dorman.SecurityHeaders()`. No action needed.
 
 ### Rate Limiting
 
@@ -128,7 +128,7 @@ No rate limiting middleware. For public-facing apps, add rate limiting at the re
 
 ### Authorization / RBAC
 
-No role-based access control. Authentication (who are you?) is provided via crooner, but authorization (what can you do?) is left to the application. Porter is designed for this but the scaffold does not wire up permission checks -- your app defines its own authorization rules.
+No role-based access control. Authentication (who are you?) is provided via crooner, but authorization (what can you do?) is left to the application. Dorman is designed for this but the scaffold does not wire up permission checks -- your app defines its own authorization rules.
 
 ### Input Validation
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -46,7 +46,7 @@ ar.initRealtimeRoutes(broker)
 ```
 If `sse` is not selected, everything between `:start` and `:end` (inclusive) is removed.
 
-**CSRF feature** — wraps the CSRF block, which gates porter.CSRFProtect middleware setup. Stripped when `csrf` is not selected.
+**CSRF feature** — wraps the CSRF block, which gates dorman.CSRFProtect middleware setup. Stripped when `csrf` is not selected.
 
 ### Available Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Go + HTMX + Templ demo with batteries included.
 | Document | Description |
 |----------|-------------|
 | [Security](SECURITY.md) | What the scaffold provides and where gaps exist |
-| [Deployment Security](DEPLOYMENT-SECURITY.md) | Full-stack security: nginx + porter, SSE/H3 configuration, corporate deployment |
+| [Deployment Security](DEPLOYMENT-SECURITY.md) | Full-stack security: nginx + dorman, SSE/H3 configuration, corporate deployment |
 | [Architecture](ARCHITECTURE.md) | Request lifecycle, package structure, middleware chain |
 | [Setup](SETUP.md) | Setup wizard and feature gates |
 

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/a-h/templ v0.3.1001
 	github.com/angelofallars/htmx-go v0.5.0
 	github.com/catgoose/crooner v1.4.15
+	github.com/catgoose/dorman v0.0.1
 	github.com/catgoose/linkwell v0.2.21
-	github.com/catgoose/porter v0.4.13
 	github.com/catgoose/promolog/sqlite v0.0.0-20260404160355-64d49720300a
 	github.com/catgoose/tavern v0.4.59
 	github.com/charmbracelet/huh v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/catgoose/chuck v0.1.10 h1:jNt5tO8Ta4syt7IZFIkf8DkcVcfDZsA+/YdXp4f2EMk
 github.com/catgoose/chuck v0.1.10/go.mod h1:e1b0XhhinnPELFxeF6I9G0/7mBXBqm7Mc7T4tzNnPSY=
 github.com/catgoose/crooner v1.4.15 h1:jjbRCFqDzx6B507B6yZ/9ZjlaYN5X1NFbM8dIDUSwvE=
 github.com/catgoose/crooner v1.4.15/go.mod h1:D1o/6PwAmHNA/pi1fiCGCBBL2PhFlQwxBaLqvuZl9qM=
+github.com/catgoose/dorman v0.0.1 h1:mP2ZlGzoVkdRlGg7O3KO9J2Ho+pWRfV1MZKu7O1k5rY=
+github.com/catgoose/dorman v0.0.1/go.mod h1:Ts07t5ssefILdbgavmabSJIIh6Npbdh8VO4r1iYXhxQ=
 github.com/catgoose/linkwell v0.2.21 h1:pLHdVN9c0CmTt8VJRNSLMeGYm1l6KUrkwlcWp0L0gy4=
 github.com/catgoose/linkwell v0.2.21/go.mod h1:bhkgK3y/d2LgAjoP3d2uVpvjuB8ufKPaqxQOv5krGbo=
-github.com/catgoose/porter v0.4.13 h1:HNtsLGEccTXhLZ48vQNXHrZHkEY0hvnKCiXMTH+u+z0=
-github.com/catgoose/porter v0.4.13/go.mod h1:RRi+OhWUYcJPGOKI3JAtWh7F4nQWKoDteejYtjFeLBQ=
 github.com/catgoose/promolog v0.2.25 h1:PaLEHWrM6Equ34sCCsc9UHzBKXH2PCgC0LAgq7rxiqQ=
 github.com/catgoose/promolog v0.2.25/go.mod h1:jEsBpxvJjXW8FTaCBi+vXaIwN5ISr3ylR6Z5AId+Yb4=
 github.com/catgoose/promolog/sqlite v0.0.0-20260404160355-64d49720300a h1:uEw2/bcmYMTAOAAMBRJWPvMLZYzMSJaq+IrnCs3oOSc=

--- a/internal/routes/middleware/echo_middleware_test.go
+++ b/internal/routes/middleware/echo_middleware_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/catgoose/porter"
+	"github.com/catgoose/dorman"
 	"github.com/catgoose/promolog"
 	"github.com/labstack/echo/v4"
 	echoMiddleware "github.com/labstack/echo/v4/middleware"
@@ -19,7 +19,7 @@ import (
 func setupFullEcho() *echo.Echo {
 	e := echo.New()
 	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
-	e.Use(echo.WrapMiddleware(porter.SecurityHeaders()))
+	e.Use(echo.WrapMiddleware(dorman.SecurityHeaders()))
 	e.Use(echoMiddleware.Gzip())
 	e.HTTPErrorHandler = NewHTTPErrorHandler(nil)
 	return e

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -24,7 +24,7 @@ import (
 	// setup:feature:session_settings:end
 	"context"
 	"fmt"
-	"github.com/catgoose/porter"
+	"github.com/catgoose/dorman"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -326,7 +326,7 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 	e.Use(middleware.ServerTimingMiddleware())
 	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
 	e.Use(echoMiddleware.RequestLogger())
-	e.Use(echo.WrapMiddleware(porter.SecurityHeaders(porter.SecurityHeadersConfig{
+	e.Use(echo.WrapMiddleware(dorman.SecurityHeaders(dorman.SecurityHeadersConfig{
 		PermissionsPolicy:       "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
 		CrossOriginOpenerPolicy: "same-origin",
 	})))
@@ -373,7 +373,7 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 			if len(csrfKey) > 32 {
 				csrfKey = csrfKey[:32]
 			}
-			csrfMw := porter.CSRFProtect(porter.CSRFConfig{
+			csrfMw := dorman.CSRFProtect(dorman.CSRFConfig{
 				Key:              csrfKey,
 				CookiePath:       "/",
 				FieldName:        "csrf_token",
@@ -386,7 +386,7 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 			// Inject token into echo context for templates
 			e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 				return func(c echo.Context) error {
-					c.Set("csrf_token", porter.GetToken(c.Request()))
+					c.Set("csrf_token", dorman.GetToken(c.Request()))
 					return next(c)
 				}
 			})

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1384,9 +1384,9 @@ func buildEnvTable(features []string, appName, appTLSPort string) string {
 		sb.WriteString("| `OIDC_CLIENT_SECRET` | OIDC client secret | -- |\n")
 	}
 
-	// CSRF — porter.CSRFProtect uses SESSION_SECRET as the auth key; no extra env vars needed.
+	// CSRF — dorman.CSRFProtect uses SESSION_SECRET as the auth key; no extra env vars needed.
 	if keep[FeatureCSRF] {
-		sb.WriteString("| | CSRF protection enabled (porter) — uses SESSION_SECRET | |\n")
+		sb.WriteString("| | CSRF protection enabled (dorman) — uses SESSION_SECRET | |\n")
 	}
 
 	// Graph


### PR DESCRIPTION
## Summary

- Renamed all `catgoose/porter` references to `catgoose/dorman` across Go imports, go.mod, and documentation
- Updated go.mod dependency to `github.com/catgoose/dorman v0.0.1`
- Updated all markdown docs (README, ECOSYSTEM, AGENTS, PHILOSOPHY, ARCHITECTURE, SECURITY, DEPLOYMENT-SECURITY, SETUP, index)

Closes #523

## Test plan

- [ ] Verify `go build ./...` compiles successfully
- [ ] Verify `mage lint` passes
- [ ] Verify `go test ./...` passes
- [ ] Confirm no remaining porter references in Go or markdown files