### PR TITLE
chore: update dorman, tavern, and linkwell deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/a-h/templ v0.3.1001
 	github.com/angelofallars/htmx-go v0.5.0
 	github.com/catgoose/crooner v1.4.15
-	github.com/catgoose/dorman v0.0.1
-	github.com/catgoose/linkwell v0.2.21
+	github.com/catgoose/dorman v0.1.7
+	github.com/catgoose/linkwell v0.2.24
 	github.com/catgoose/promolog/sqlite v0.0.0-20260404160355-64d49720300a
 	github.com/catgoose/tavern v0.4.62
 	github.com/charmbracelet/huh v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -75,10 +75,10 @@ github.com/catgoose/chuck v0.1.10 h1:jNt5tO8Ta4syt7IZFIkf8DkcVcfDZsA+/YdXp4f2EMk
 github.com/catgoose/chuck v0.1.10/go.mod h1:e1b0XhhinnPELFxeF6I9G0/7mBXBqm7Mc7T4tzNnPSY=
 github.com/catgoose/crooner v1.4.15 h1:jjbRCFqDzx6B507B6yZ/9ZjlaYN5X1NFbM8dIDUSwvE=
 github.com/catgoose/crooner v1.4.15/go.mod h1:D1o/6PwAmHNA/pi1fiCGCBBL2PhFlQwxBaLqvuZl9qM=
-github.com/catgoose/dorman v0.0.1 h1:mP2ZlGzoVkdRlGg7O3KO9J2Ho+pWRfV1MZKu7O1k5rY=
-github.com/catgoose/dorman v0.0.1/go.mod h1:Ts07t5ssefILdbgavmabSJIIh6Npbdh8VO4r1iYXhxQ=
-github.com/catgoose/linkwell v0.2.21 h1:pLHdVN9c0CmTt8VJRNSLMeGYm1l6KUrkwlcWp0L0gy4=
-github.com/catgoose/linkwell v0.2.21/go.mod h1:bhkgK3y/d2LgAjoP3d2uVpvjuB8ufKPaqxQOv5krGbo=
+github.com/catgoose/dorman v0.1.7 h1:IAyAj5XFXEcbnaXCv6+S+MZd5t0amciue/yS/pcWkyY=
+github.com/catgoose/dorman v0.1.7/go.mod h1:Ts07t5ssefILdbgavmabSJIIh6Npbdh8VO4r1iYXhxQ=
+github.com/catgoose/linkwell v0.2.24 h1:EKB5hEJm6t2wSVp2YgLL2w7KYILRcaFN45uH8/K83zs=
+github.com/catgoose/linkwell v0.2.24/go.mod h1:bhkgK3y/d2LgAjoP3d2uVpvjuB8ufKPaqxQOv5krGbo=
 github.com/catgoose/promolog v0.2.25 h1:PaLEHWrM6Equ34sCCsc9UHzBKXH2PCgC0LAgq7rxiqQ=
 github.com/catgoose/promolog v0.2.25/go.mod h1:jEsBpxvJjXW8FTaCBi+vXaIwN5ISr3ylR6Z5AId+Yb4=
 github.com/catgoose/promolog/sqlite v0.0.0-20260404160355-64d49720300a h1:uEw2/bcmYMTAOAAMBRJWPvMLZYzMSJaq+IrnCs3oOSc=


### PR DESCRIPTION
## Summary

- **dorman** v0.0.1 → v0.1.7: major version bump (renamed from porter); no API changes needed since PR #527 already migrated to dorman
- **tavern** v0.4.59 → v0.4.62: bug fixes for grouped SSE resumption, SSE id field emission, and Batch.Flush routing
- **linkwell** v0.2.21 → v0.2.24: bug fixes for sitemap target-only pages, breadcrumb title preservation, and ValidateAgainstRoutes

All three updates are backwards-compatible with the current codebase. Build, vet, and lint pass cleanly.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `mage lint` passes
- [ ] Verify realtime SSE demos still work correctly (tavern fixes)
- [ ] Verify breadcrumb rendering on nested pages (linkwell fixes)
- [ ] Verify CSRF and security header middleware (dorman)