### PR TITLE
fix: remove double SSE framing in document and auction demos

### DIFF
--- a/internal/routes/routes_auction.go
+++ b/internal/routes/routes_auction.go
@@ -85,8 +85,7 @@ func (a *auctionRoutes) handleBid(c echo.Context) error {
 
 	topic := a.house.Topic(itemID)
 	html := renderAuctionCardUpdateHTML(item)
-	sseMsg := tavern.NewSSEMessage(topic, html).String()
-	a.broker.PublishWithReplay(topic, sseMsg)
+	a.broker.PublishWithReplay(topic, html)
 
 	return c.HTML(http.StatusOK, html)
 }
@@ -158,8 +157,7 @@ func (a *auctionRoutes) startBotBidder(ctx context.Context) {
 			}
 
 			html := renderAuctionCardUpdateHTML(item)
-			sseMsg := tavern.NewSSEMessage(topic, html).String()
-			a.broker.PublishWithReplay(topic, sseMsg)
+			a.broker.PublishWithReplay(topic, html)
 		}
 	}
 }

--- a/internal/routes/routes_doc.go
+++ b/internal/routes/routes_doc.go
@@ -58,13 +58,13 @@ func (ar *appRoutes) initDocRoutes(broker *tavern.SSEBroker) {
 	// After hooks: content changes trigger stats + sentiment + history recalculation.
 	broker.After(topicDocContent, func() {
 		statsHTML := renderDocStats(doc)
-		broker.Publish(topicDocStats, tavern.NewSSEMessage("stats", statsHTML).String())
+		broker.Publish(topicDocStats, statsHTML)
 
 		sentimentHTML := renderDocSentiment(doc)
-		broker.Publish(topicDocSentiment, tavern.NewSSEMessage("sentiment", sentimentHTML).String())
+		broker.Publish(topicDocSentiment, sentimentHTML)
 
 		historyHTML := renderDocHistory(doc)
-		broker.Publish(topicDocHistory, tavern.NewSSEMessage("history", historyHTML).String())
+		broker.Publish(topicDocHistory, historyHTML)
 	})
 
 	// OnMutate: edit POSTs trigger content publish via mutation signal.
@@ -72,7 +72,7 @@ func (ar *appRoutes) initDocRoutes(broker *tavern.SSEBroker) {
 		content := evt.Data.(string)
 		doc.Update(content)
 		html := renderDocContent(doc)
-		broker.Publish(topicDocContent, tavern.NewSSEMessage("content", html).String())
+		broker.Publish(topicDocContent, html)
 	})
 
 	// Define topic group for a single SSE endpoint.
@@ -108,10 +108,10 @@ func (d *docRoutes) handleBatchEdit(c echo.Context) error {
 	newContent := d.doc.BatchEdit(action)
 
 	batch := d.broker.Batch()
-	batch.Publish(topicDocContent, tavern.NewSSEMessage("content", renderDocContent(d.doc)).String())
-	batch.Publish(topicDocStats, tavern.NewSSEMessage("stats", renderDocStats(d.doc)).String())
-	batch.Publish(topicDocSentiment, tavern.NewSSEMessage("sentiment", renderDocSentiment(d.doc)).String())
-	batch.Publish(topicDocHistory, tavern.NewSSEMessage("history", renderDocHistory(d.doc)).String())
+	batch.Publish(topicDocContent, renderDocContent(d.doc))
+	batch.Publish(topicDocStats, renderDocStats(d.doc))
+	batch.Publish(topicDocSentiment, renderDocSentiment(d.doc))
+	batch.Publish(topicDocHistory, renderDocHistory(d.doc))
 	batch.Flush()
 
 	_ = newContent


### PR DESCRIPTION
Closes #532

## Summary

- Document and auction demos were wrapping payloads with `tavern.NewSSEMessage(...).String()` before publishing to `GroupHandler`/`DynamicGroupHandler` topics
- The grouped handlers already add SSE framing per topic, so clients received nested SSE text instead of HTML fragments
- Changed all publish calls in both demos to pass raw HTML payloads, letting the grouped handler provide the outer SSE framing

## Test plan

- [ ] Open the collaborative document demo, edit content, and verify SSE updates render correctly (content, stats, sentiment, history panels)
- [ ] Test batch edit actions and confirm all panels update without nested SSE artifacts
- [ ] Open the auction demo, place bids, and verify card updates render as HTML (not raw SSE text)
- [ ] Verify bot bidder updates also render correctly
- [ ] Confirm SSE reconnect + replay works for auction (replay policy is set to 5)