### PR TITLE
fix: CSRF key derivation for dorman v0.1.7

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -23,6 +23,7 @@ import (
 	"catgoose/dothog/internal/session"
 	// setup:feature:session_settings:end
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"github.com/catgoose/dorman"
 	"io"
@@ -369,10 +370,8 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 		e.GET(cfg.CroonerConfig.AuthRoutes.Callback, echo.WrapHandler(authCfg.CallbackHandler()))
 		// setup:feature:csrf:start
 		if cfg.SessionSecret != "" {
-			csrfKey := []byte(cfg.SessionSecret)
-			if len(csrfKey) > 32 {
-				csrfKey = csrfKey[:32]
-			}
+			hash := sha256.Sum256([]byte(cfg.SessionSecret))
+			csrfKey := hash[:]
 			csrfMw := dorman.CSRFProtect(dorman.CSRFConfig{
 				Key:              csrfKey,
 				CookiePath:       "/",


### PR DESCRIPTION
Closes #530

## Summary

- Replace naive CSRF key truncation with SHA-256 derivation so any length `SessionSecret` always produces a valid 32-byte key, preventing panics with dorman v0.1.7's minimum length requirement
- linkwell was already at v0.2.25 on main after PR #528

## Test plan

- [ ] Verify app starts without panic using a short session secret (< 32 bytes)
- [ ] Verify app starts with a long session secret (> 32 bytes)
- [ ] Verify CSRF protection still works end-to-end on forms
- [ ] Run `go build ./...` and `mage lint` — both pass