### PR TITLE
fix: enable slow-subscriber eviction on main broker

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -183,6 +183,7 @@ func (ar *appRoutes) InitRoutes() error {
 	// setup:feature:sse:start
 	ar.broker = tavern.NewSSEBroker(
 		tavern.WithKeepalive(30*time.Second),
+		tavern.WithSlowSubscriberEviction(100),
 		tavern.WithSlowSubscriberCallback(func(topic string) {
 			logger.Warn("Slow subscriber evicted", "topic", topic)
 		}),


### PR DESCRIPTION
## Summary

- The main SSE broker was configured with `WithSlowSubscriberCallback` but not `WithSlowSubscriberEviction`, making the callback dead code that could never fire
- Added `WithSlowSubscriberEviction(100)` so subscribers that drop 100 consecutive messages are evicted and the callback fires as intended

## Test plan

- [ ] Verify the app compiles and starts without errors
- [ ] Confirm slow subscribers are evicted after 100 consecutive dropped messages
- [ ] Confirm the "Slow subscriber evicted" warning log fires on eviction

Closes #531