### PR TITLE
fix: preserve notification category filters across SSE reconnect

### DIFF
--- a/internal/routes/routes_notifications.go
+++ b/internal/routes/routes_notifications.go
@@ -110,7 +110,11 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 		return true
 	}
 
-	// Check for Last-Event-ID for replay
+	// Check for Last-Event-ID for replay.
+	// Both paths apply the same filterFn: SubscribeWith uses it natively for
+	// live messages, while SubscribeFromID doesn't support filters so we apply
+	// the filter in the write loop below. This ensures category preferences
+	// survive SSE reconnections.
 	lastEventID := c.Request().Header.Get("Last-Event-ID")
 	var msgs <-chan string
 	var unsub func()
@@ -134,6 +138,9 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 		case msg, ok := <-msgs:
 			if !ok {
 				return nil
+			}
+			if !filterFn(msg) {
+				continue
 			}
 			_, _ = fmt.Fprint(c.Response(), msg)
 			flusher.Flush()


### PR DESCRIPTION
## Summary
- The reconnect path (`SubscribeFromID`) bypassed category filters, causing disabled notification categories to reappear after browser reconnection
- Applied the same `filterFn` in the write loop so both initial connect and reconnect paths respect the user's category preferences

Closes #538

## Test plan
- [ ] Open notifications demo, disable a category (e.g. alerts)
- [ ] Trigger a reconnect (disconnect/reconnect SSE or refresh with Last-Event-ID)
- [ ] Verify disabled categories remain filtered after reconnect
- [ ] Verify enabled categories still appear normally