### PR TITLE
fix: use PublishWithID for people profile replay

### DIFF
--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strconv"
 	"sync/atomic"
-	"time"
 
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
@@ -150,7 +149,7 @@ func (p *peopleRoutes) broadcastPersonUpdate(person demo.Person) {
 		WithID(eventID).
 		String()
 	statsBufPool.Put(buf)
-	p.broker.PublishWithTTL(topic, msg, 60*time.Second)
+	p.broker.PublishWithID(topic, eventID, msg)
 }
 
 func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {


### PR DESCRIPTION
## Summary

- Switch `broadcastPersonUpdate` from `PublishWithTTL` to `PublishWithID` so replay entries include the event ID
- This enables `SubscribeFromID` (used on SSE reconnect via `Last-Event-ID`) to match stored entries and replay missed updates
- Removes unused `time` import

Closes #541