### PR TITLE
fix: use PublishWithID for notifications to enable Last-Event-ID replay

### DIFF
--- a/internal/routes/routes_notifications.go
+++ b/internal/routes/routes_notifications.go
@@ -97,7 +97,7 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 	// Each user gets a dedicated topic so that replay via Last-Event-ID is
 	// inherently scoped — no risk of leaking another user's notifications.
 	userTopic := notifUserTopic(identity.ID)
-	n.broker.SetReplayPolicy(userTopic, 20)
+	n.broker.SetReplayPolicy(userTopic, 50)
 
 	// Build a filter that checks the user's current category preferences.
 	// The rendered HTML includes data-cat="<category>" so we can detect it.
@@ -187,11 +187,10 @@ func (n *notificationRoutes) startSimulator(ctx context.Context) {
 				WithID(notifID).
 				String()
 
-			n.broker.PublishWithTTL(
+			n.broker.PublishWithID(
 				notifUserTopic(target.UserID),
+				notifID,
 				sseMsg,
-				60*time.Second,
-				tavern.WithAutoRemove("notif-"+notifID),
 			)
 		}
 	}


### PR DESCRIPTION
## Summary
- Switch notification publishing from `PublishWithTTL` to `PublishWithID` so that replay entries record the event ID, enabling `SubscribeFromID` to match on `Last-Event-ID` during SSE reconnection
- Bump replay policy from 20 to 50 entries for the per-user notification topic
- Remove `WithAutoRemove` TTL option (incompatible with ID-based publish; old entries are evicted by count-based replay policy instead)

## Test plan
- [ ] Open the notifications demo, trigger some notifications
- [ ] Disconnect/reconnect SSE (e.g., toggle network) and verify missed notifications are replayed via Last-Event-ID
- [ ] Confirm replay log respects the 50-entry cap

Closes #543