### PR TITLE
fix: enable replay-gap policies for demos advertising gap UX

### DIFF
--- a/internal/routes/routes_admin_settings.go
+++ b/internal/routes/routes_admin_settings.go
@@ -49,6 +49,7 @@ func (ar *appRoutes) initAdminSettingsRoutes(broker *tavern.SSEBroker) {
 	initAdminIntervals()
 	ar.e.GET("/admin/settings", ar.handleAdminSettings(broker))
 	ar.e.POST("/admin/settings/interval", handleAdminInterval)
+	broker.SetReplayGapPolicy(TopicAdminPanel, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/admin", echo.WrapHandler(broker.SSEHandler(TopicAdminPanel)))
 
 	adminPub = ar.newAdminPublisher(broker)

--- a/internal/routes/routes_doc.go
+++ b/internal/routes/routes_doc.go
@@ -77,6 +77,9 @@ func (ar *appRoutes) initDocRoutes(broker *tavern.SSEBroker) {
 
 	// Define topic group for a single SSE endpoint.
 	broker.DefineGroup("doc-all", []string{topicDocContent, topicDocStats, topicDocSentiment, topicDocHistory})
+	for _, t := range []string{topicDocContent, topicDocStats, topicDocSentiment, topicDocHistory} {
+		broker.SetReplayGapPolicy(t, tavern.GapFallbackToSnapshot, nil)
+	}
 
 	ar.e.GET("/realtime/document", d.handlePage)
 	ar.e.GET("/sse/document", echo.WrapHandler(broker.GroupHandler("doc-all")))

--- a/internal/routes/routes_feed.go
+++ b/internal/routes/routes_feed.go
@@ -27,6 +27,7 @@ func (ar *appRoutes) initFeedRoutes(actLog *demo.ActivityLog, broker *tavern.SSE
 	f := &feedRoutes{actLog: actLog, broker: broker}
 	ar.e.GET("/realtime/feed", f.handleFeedPage)
 	ar.e.GET("/realtime/feed/more", f.handleFeedMore)
+	broker.SetReplayGapPolicy(TopicActivityFeed, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/activity", echo.WrapHandler(broker.SSEHandler(TopicActivityFeed)))
 
 	// Seed some initial events so the feed isn't empty on first load.

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -31,6 +31,7 @@ func (ar *appRoutes) initLoggingRoutes(broker *tavern.SSEBroker) {
 		})
 	}
 
+	broker.SetReplayGapPolicy(TopicErrorTraces, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/error-traces", echo.WrapHandler(broker.SSEHandler(TopicErrorTraces)))
 	// setup:feature:sse:end
 

--- a/internal/routes/routes_notifications.go
+++ b/internal/routes/routes_notifications.go
@@ -98,6 +98,7 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 	// inherently scoped — no risk of leaking another user's notifications.
 	userTopic := notifUserTopic(identity.ID)
 	n.broker.SetReplayPolicy(userTopic, 20)
+	n.broker.SetReplayGapPolicy(userTopic, tavern.GapFallbackToSnapshot, nil)
 
 	// Build a filter that checks the user's current category preferences.
 	// The rendered HTML includes data-cat="<category>" so we can detect it.

--- a/internal/routes/routes_observatory.go
+++ b/internal/routes/routes_observatory.go
@@ -74,6 +74,7 @@ func (ar *appRoutes) initObservatoryRoutes(mainBroker *tavern.SSEBroker) {
 	mainBroker.RunPublisher(ar.ctx, o.startMetricsPublisher)
 
 	ar.e.GET("/realtime/observatory", o.handlePage)
+	mainBroker.SetReplayGapPolicy(TopicObservatory, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/observatory", echo.WrapHandler(mainBroker.SSEHandler(TopicObservatory)))
 	ar.e.POST("/realtime/observatory/stress", o.handleStressToggle)
 	ar.e.POST("/realtime/observatory/max-subscribers", o.handleMaxSubscribers)

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -162,6 +162,7 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 
 	// Set replay policy so reconnecting clients receive missed updates.
 	p.broker.SetReplayPolicy(topic, 5)
+	p.broker.SetReplayGapPolicy(topic, tavern.GapFallbackToSnapshot, nil)
 
 	c.Response().Header().Set("Content-Type", "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "no-cache")

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -78,11 +78,13 @@ func (ar *appRoutes) initRealtimeRoutes(broker *tavern.SSEBroker) {
 	ar.e.POST("/realtime/dashboard/interval-restore", handleRTIntervalRestore)
 	ar.e.POST("/realtime/dashboard/pin", handleRTPin)
 	ar.e.GET("/sse/system", echo.WrapHandler(broker.SSEHandler(TopicSystemStats)))
+	broker.SetReplayGapPolicy(TopicDashMetrics, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/dashboard", echo.WrapHandler(broker.SSEHandler(TopicDashMetrics)))
 
 	// Numerical tile publisher (shares the page, separate SSE stream)
 	initTileIntervals()
 	ar.e.POST("/realtime/dashboard/tile-interval", handleNumericalInterval)
+	broker.SetReplayGapPolicy(TopicNumericalDash, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/numerical", echo.WrapHandler(broker.SSEHandler(TopicNumericalDash)))
 
 	sysPub := ar.newSystemStatsPublisher(broker)

--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -23,6 +23,7 @@ import (
 func (ar *appRoutes) initThemeRoutes(broker *tavern.SSEBroker) {
 	ar.e.POST("/settings/theme", ar.handleTheme(broker))
 	ar.e.POST("/settings/layout", ar.handleLayout())
+	broker.SetReplayGapPolicy(TopicThemeChange, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/theme", echo.WrapHandler(broker.SSEHandler(TopicThemeChange)))
 }
 


### PR DESCRIPTION
## Summary
- Multiple demo pages include `data-tavern-gap-action` attributes ("reload" or "banner") but the server routes never called `SetReplayGapPolicy(...)`, leaving the default `GapSilent` strategy active and the gap UX inert.
- Added `broker.SetReplayGapPolicy(topic, tavern.GapFallbackToSnapshot, nil)` calls in all 9 affected route files so the broker emits `tavern-replay-gap` control events on reconnection gaps.

## Affected routes
- notifications (per-user topic)
- error-traces
- dashboard + numerical
- activity feed
- people (per-person topic)
- admin panel
- theme
- observatory
- document (all 4 sub-topics in the group)

Closes #542

## Test plan
- [ ] Verify each demo page still loads and SSE streams connect
- [ ] Simulate a replay gap (reconnect with stale Last-Event-ID) and confirm the `tavern-replay-gap` event is emitted
- [ ] Confirm "reload" pages trigger a page reload on gap
- [ ] Confirm "banner" pages show the gap banner on gap