### PR TITLE
fix: enable replay gap policies for all SSE demos

### DIFF
--- a/internal/routes/routes_admin_settings.go
+++ b/internal/routes/routes_admin_settings.go
@@ -49,6 +49,7 @@ func (ar *appRoutes) initAdminSettingsRoutes(broker *tavern.SSEBroker) {
 	initAdminIntervals()
 	ar.e.GET("/admin/settings", ar.handleAdminSettings(broker))
 	ar.e.POST("/admin/settings/interval", handleAdminInterval)
+	broker.SetReplayGapPolicy(TopicAdminPanel, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/admin", echo.WrapHandler(broker.SSEHandler(TopicAdminPanel)))
 
 	adminPub = ar.newAdminPublisher(broker)

--- a/internal/routes/routes_doc.go
+++ b/internal/routes/routes_doc.go
@@ -75,6 +75,11 @@ func (ar *appRoutes) initDocRoutes(broker *tavern.SSEBroker) {
 		broker.Publish(topicDocContent, html)
 	})
 
+	// Set gap policy so reconnecting clients see the gap UX.
+	for _, t := range []string{topicDocContent, topicDocStats, topicDocSentiment, topicDocHistory} {
+		broker.SetReplayGapPolicy(t, tavern.GapFallbackToSnapshot, nil)
+	}
+
 	// Define topic group for a single SSE endpoint.
 	broker.DefineGroup("doc-all", []string{topicDocContent, topicDocStats, topicDocSentiment, topicDocHistory})
 

--- a/internal/routes/routes_feed.go
+++ b/internal/routes/routes_feed.go
@@ -27,6 +27,7 @@ func (ar *appRoutes) initFeedRoutes(actLog *demo.ActivityLog, broker *tavern.SSE
 	f := &feedRoutes{actLog: actLog, broker: broker}
 	ar.e.GET("/realtime/feed", f.handleFeedPage)
 	ar.e.GET("/realtime/feed/more", f.handleFeedMore)
+	broker.SetReplayGapPolicy(TopicActivityFeed, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/activity", echo.WrapHandler(broker.SSEHandler(TopicActivityFeed)))
 
 	// Seed some initial events so the feed isn't empty on first load.

--- a/internal/routes/routes_logging.go
+++ b/internal/routes/routes_logging.go
@@ -31,6 +31,7 @@ func (ar *appRoutes) initLoggingRoutes(broker *tavern.SSEBroker) {
 		})
 	}
 
+	broker.SetReplayGapPolicy(TopicErrorTraces, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/error-traces", echo.WrapHandler(broker.SSEHandler(TopicErrorTraces)))
 	// setup:feature:sse:end
 

--- a/internal/routes/routes_notifications.go
+++ b/internal/routes/routes_notifications.go
@@ -98,6 +98,7 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 	// inherently scoped — no risk of leaking another user's notifications.
 	userTopic := notifUserTopic(identity.ID)
 	n.broker.SetReplayPolicy(userTopic, 50)
+	n.broker.SetReplayGapPolicy(userTopic, tavern.GapFallbackToSnapshot, nil)
 
 	// Build a filter that checks the user's current category preferences.
 	// The rendered HTML includes data-cat="<category>" so we can detect it.

--- a/internal/routes/routes_observatory.go
+++ b/internal/routes/routes_observatory.go
@@ -74,6 +74,7 @@ func (ar *appRoutes) initObservatoryRoutes(mainBroker *tavern.SSEBroker) {
 	mainBroker.RunPublisher(ar.ctx, o.startMetricsPublisher)
 
 	ar.e.GET("/realtime/observatory", o.handlePage)
+	mainBroker.SetReplayGapPolicy(TopicObservatory, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/observatory", echo.WrapHandler(mainBroker.SSEHandler(TopicObservatory)))
 	ar.e.POST("/realtime/observatory/stress", o.handleStressToggle)
 	ar.e.POST("/realtime/observatory/max-subscribers", o.handleMaxSubscribers)

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -161,6 +161,7 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 
 	// Set replay policy so reconnecting clients receive missed updates.
 	p.broker.SetReplayPolicy(topic, 5)
+	p.broker.SetReplayGapPolicy(topic, tavern.GapFallbackToSnapshot, nil)
 
 	c.Response().Header().Set("Content-Type", "text/event-stream")
 	c.Response().Header().Set("Cache-Control", "no-cache")

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -77,12 +77,14 @@ func (ar *appRoutes) initRealtimeRoutes(broker *tavern.SSEBroker) {
 	ar.e.POST("/realtime/dashboard/interval-all", handleRTIntervalAll)
 	ar.e.POST("/realtime/dashboard/interval-restore", handleRTIntervalRestore)
 	ar.e.POST("/realtime/dashboard/pin", handleRTPin)
+	broker.SetReplayGapPolicy(TopicDashMetrics, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/system", echo.WrapHandler(broker.SSEHandler(TopicSystemStats)))
 	ar.e.GET("/sse/dashboard", echo.WrapHandler(broker.SSEHandler(TopicDashMetrics)))
 
 	// Numerical tile publisher (shares the page, separate SSE stream)
 	initTileIntervals()
 	ar.e.POST("/realtime/dashboard/tile-interval", handleNumericalInterval)
+	broker.SetReplayGapPolicy(TopicNumericalDash, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/numerical", echo.WrapHandler(broker.SSEHandler(TopicNumericalDash)))
 
 	sysPub := ar.newSystemStatsPublisher(broker)

--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -23,6 +23,7 @@ import (
 func (ar *appRoutes) initThemeRoutes(broker *tavern.SSEBroker) {
 	ar.e.POST("/settings/theme", ar.handleTheme(broker))
 	ar.e.POST("/settings/layout", ar.handleLayout())
+	broker.SetReplayGapPolicy(TopicThemeChange, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/theme", echo.WrapHandler(broker.SSEHandler(TopicThemeChange)))
 }
 


### PR DESCRIPTION
## Summary

- Add `SetReplayGapPolicy(topic, GapFallbackToSnapshot, nil)` for all SSE topics whose templates declare `data-tavern-gap-action`
- Covers: notifications (per-user topics), error traces, activity feed, observatory, theme, admin panel, people profiles, dashboard metrics, numerical dashboard, and document topics

Closes #542