### PR TITLE
docs: move screenshot above TOC in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/catgoose/dothog.svg)](https://pkg.go.dev/github.com/catgoose/dothog)
 [![Pipeline](https://github.com/catgoose/dothog/actions/workflows/pipeline.yml/badge.svg?branch=main)](https://github.com/catgoose/dothog/actions/workflows/pipeline.yml)
 
+![image](https://github.com/catgoose/screenshots/blob/main/dothog/dashboard.png)
+
 ## Or, How I Learned to Stop Worrying and Trust the Server
 
 **Being a Account of the Rediscovery of the ORIGINAL WEB by the HYPERMEDIA NOVICES, Hidden Disciples of the Honorable ROY T. FIELDING (Whose Dissertation We Have Read, Unlike You)**


### PR DESCRIPTION
## Summary

- Adds dashboard screenshot from the screenshots repo directly after title and badges, before intro text
- Follows the same layout pattern used in dorman: title -> badges -> screenshot -> prose -> TOC