### PR TITLE
fix: render interval controls from current server state

### DIFF
--- a/internal/routes/routes_admin_core.go
+++ b/internal/routes/routes_admin_core.go
@@ -181,7 +181,7 @@ func defaultStr(s, fallback string) string {
 
 func (ar *appRoutes) handleAdminHealth(c echo.Context) error {
 	h := health.Check(c.Request().Context(), ar.healthCfg)
-	return handler.RenderBaseLayout(c, views.AdminHealthPage(h))
+	return handler.RenderBaseLayout(c, views.AdminHealthPage(h, snapshotAdminIntervals()))
 }
 
 func (ar *appRoutes) handleAdminHealthCheck(c echo.Context) error {

--- a/internal/routes/routes_admin_settings.go
+++ b/internal/routes/routes_admin_settings.go
@@ -81,6 +81,17 @@ func handleAdminInterval(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// snapshotAdminIntervals returns a copy of the current admin section intervals.
+func snapshotAdminIntervals() map[string]int {
+	adminIntervals.mu.RLock()
+	defer adminIntervals.mu.RUnlock()
+	out := make(map[string]int, len(adminIntervals.intervals))
+	for k, v := range adminIntervals.intervals {
+		out[k] = v
+	}
+	return out
+}
+
 // ── Publisher ────────────────────────────────────────────────────────────────
 
 func (ar *appRoutes) newAdminPublisher(broker *tavern.SSEBroker) *tavern.ScheduledPublisher {
@@ -139,6 +150,7 @@ func (ar *appRoutes) buildAdminPanelData(broker *tavern.SSEBroker, c echo.Contex
 		SSECounts: counts,
 		Features:  features,
 		Routes:    routes,
+		Intervals: snapshotAdminIntervals(),
 	}
 }
 

--- a/internal/routes/routes_realtime.go
+++ b/internal/routes/routes_realtime.go
@@ -284,7 +284,33 @@ func (ar *appRoutes) handleRealtimePage() echo.HandlerFunc {
 			masterMs = 2000 // default
 		}
 
-		return handler.RenderBaseLayout(c, views.RealtimePage(stats, snap, services, svcLatencies, tiles, masterEnabled, masterMs))
+		cards := snapshotDashboardCardState()
+		return handler.RenderBaseLayout(c, views.RealtimePage(stats, snap, services, svcLatencies, tiles, masterEnabled, masterMs, cards))
+	}
+}
+
+// snapshotDashboardCardState reads current per-section intervals, units, and
+// pin state under a single lock and returns a copy for template rendering.
+func snapshotDashboardCardState() views.DashboardCardState {
+	rtIntervals.mu.RLock()
+	defer rtIntervals.mu.RUnlock()
+
+	intervals := make(map[string]int, len(rtIntervals.intervals))
+	for k, v := range rtIntervals.intervals {
+		intervals[k] = v
+	}
+	units := make(map[string]string, len(rtIntervals.units))
+	for k, v := range rtIntervals.units {
+		units[k] = v
+	}
+	pinned := make(map[string]bool, len(rtIntervals.pinned))
+	for k, v := range rtIntervals.pinned {
+		pinned[k] = v
+	}
+	return views.DashboardCardState{
+		Intervals: intervals,
+		Units:     units,
+		Pinned:    pinned,
 	}
 }
 

--- a/web/views/admin_health.go
+++ b/web/views/admin_health.go
@@ -17,3 +17,11 @@ func dbBadgeClass(status string) string {
 	}
 	return "badge-error"
 }
+
+// intervalOr returns the interval from the map, or fallback if missing.
+func intervalOr(m map[string]int, key string, fallback int) int {
+	if v, ok := m[key]; ok {
+		return v
+	}
+	return fallback
+}

--- a/web/views/admin_health.templ
+++ b/web/views/admin_health.templ
@@ -8,7 +8,7 @@ import (
 )
 
 // AdminHealthPage renders the /admin/health page with live health status.
-templ AdminHealthPage(h health.Response) {
+templ AdminHealthPage(h health.Response, intervals map[string]int) {
 	<div class="p-4 space-y-6 max-w-4xl mx-auto">
 		<div class="flex items-center justify-between">
 			<div class="space-y-1">
@@ -19,7 +19,7 @@ templ AdminHealthPage(h health.Response) {
 				// setup:feature:demo:start
 				@components.IntervalSlider(components.IntervalSliderCfg{
 					TargetKey: "section", TargetValue: "health",
-					IntervalMs: 5000, Scale: "s", PostURL: "/admin/settings/interval",
+					IntervalMs: intervalOr(intervals, "health", 5000), Scale: components.AutoScale(intervalOr(intervals, "health", 5000)), PostURL: "/admin/settings/interval",
 				})
 				// setup:feature:demo:end
 				<a href="/health" target="_blank" class="btn btn-sm btn-ghost font-mono">GET /health</a>

--- a/web/views/admin_health_templ.go
+++ b/web/views/admin_health_templ.go
@@ -16,7 +16,7 @@ import (
 )
 
 // AdminHealthPage renders the /admin/health page with live health status.
-func AdminHealthPage(h health.Response) templ.Component {
+func AdminHealthPage(h health.Response, intervals map[string]int) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -43,7 +43,7 @@ func AdminHealthPage(h health.Response) templ.Component {
 		}
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			TargetKey: "section", TargetValue: "health",
-			IntervalMs: 5000, Scale: "s", PostURL: "/admin/settings/interval",
+			IntervalMs: intervalOr(intervals, "health", 5000), Scale: components.AutoScale(intervalOr(intervals, "health", 5000)), PostURL: "/admin/settings/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/web/views/admin_settings.go
+++ b/web/views/admin_settings.go
@@ -39,6 +39,14 @@ func sseCountBadge(count int) string {
 	return "badge-ghost"
 }
 
+// IntervalMs returns the current interval for a section, falling back to fallback.
+func (d AdminPanelData) IntervalMs(section string, fallback int) int {
+	if v, ok := d.Intervals[section]; ok {
+		return v
+	}
+	return fallback
+}
+
 func sortedTopics(counts map[string]int) []string {
 	topics := make([]string, 0, len(counts))
 	for t := range counts {

--- a/web/views/admin_settings.templ
+++ b/web/views/admin_settings.templ
@@ -18,6 +18,7 @@ type AdminPanelData struct {
 	SSECounts map[string]int
 	Features  []FeatureFlag
 	Routes    []RouteInfo
+	Intervals map[string]int // current per-section interval in ms
 }
 
 type FeatureFlag struct {
@@ -55,7 +56,7 @@ templ AdminSettingsPage(data AdminPanelData) {
 					<h2 class="text-xs font-semibold uppercase tracking-wider text-base-content/40">System Metrics</h2>
 					@components.IntervalSlider(components.IntervalSliderCfg{
 						TargetKey: "section", TargetValue: "system-metrics",
-						IntervalMs: 5000, Scale: "s", PostURL: "/admin/settings/interval",
+						IntervalMs: data.IntervalMs("system-metrics", 5000), Scale: components.AutoScale(data.IntervalMs("system-metrics", 5000)), PostURL: "/admin/settings/interval",
 					})
 				</div>
 				<div id="admin-system-metrics">
@@ -71,7 +72,7 @@ templ AdminSettingsPage(data AdminPanelData) {
 					<h2 class="text-xs font-semibold uppercase tracking-wider text-base-content/40">SSE Connections</h2>
 					@components.IntervalSlider(components.IntervalSliderCfg{
 						TargetKey: "section", TargetValue: "sse-counts",
-						IntervalMs: 3000, Scale: "s", PostURL: "/admin/settings/interval",
+						IntervalMs: data.IntervalMs("sse-counts", 3000), Scale: components.AutoScale(data.IntervalMs("sse-counts", 3000)), PostURL: "/admin/settings/interval",
 					})
 				</div>
 				<div id="admin-sse-counts">

--- a/web/views/admin_settings_templ.go
+++ b/web/views/admin_settings_templ.go
@@ -26,6 +26,7 @@ type AdminPanelData struct {
 	SSECounts map[string]int
 	Features  []FeatureFlag
 	Routes    []RouteInfo
+	Intervals map[string]int // current per-section interval in ms
 }
 
 type FeatureFlag struct {
@@ -86,7 +87,7 @@ func AdminSettingsPage(data AdminPanelData) templ.Component {
 		}
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			TargetKey: "section", TargetValue: "system-metrics",
-			IntervalMs: 5000, Scale: "s", PostURL: "/admin/settings/interval",
+			IntervalMs: data.IntervalMs("system-metrics", 5000), Scale: components.AutoScale(data.IntervalMs("system-metrics", 5000)), PostURL: "/admin/settings/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -105,7 +106,7 @@ func AdminSettingsPage(data AdminPanelData) templ.Component {
 		}
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			TargetKey: "section", TargetValue: "sse-counts",
-			IntervalMs: 3000, Scale: "s", PostURL: "/admin/settings/interval",
+			IntervalMs: data.IntervalMs("sse-counts", 3000), Scale: components.AutoScale(data.IntervalMs("sse-counts", 3000)), PostURL: "/admin/settings/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -131,7 +132,7 @@ func AdminSettingsPage(data AdminPanelData) templ.Component {
 				var templ_7745c5c3_Var2 string
 				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(f.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 92, Col: 16}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 93, Col: 16}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 				if templ_7745c5c3_Err != nil {
@@ -149,7 +150,7 @@ func AdminSettingsPage(data AdminPanelData) templ.Component {
 				var templ_7745c5c3_Var3 string
 				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(f.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 96, Col: 16}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 97, Col: 16}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 				if templ_7745c5c3_Err != nil {
@@ -188,7 +189,7 @@ func AdminSettingsPage(data AdminPanelData) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", len(data.Routes)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 131, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 132, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -228,7 +229,7 @@ func AdminSettingsPage(data AdminPanelData) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(r.Method)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 145, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 146, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -241,7 +242,7 @@ func AdminSettingsPage(data AdminPanelData) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(r.Path)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 147, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 148, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -497,7 +498,7 @@ func adminSSECounts(counts map[string]int) templ.Component {
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(topic)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 211, Col: 53}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 212, Col: 53}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -532,7 +533,7 @@ func adminSSECounts(counts map[string]int) templ.Component {
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", counts[topic]))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 212, Col: 112}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 213, Col: 112}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
@@ -580,7 +581,7 @@ func panelStat(label, value string) templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 221, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 222, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -593,7 +594,7 @@ func panelStat(label, value string) templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 222, Col: 54}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 223, Col: 54}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -635,7 +636,7 @@ func metricCard(label, value string) templ.Component {
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 228, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 229, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
@@ -648,7 +649,7 @@ func metricCard(label, value string) templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 229, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/admin_settings.templ`, Line: 230, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {

--- a/web/views/hypermedia_realtime.templ
+++ b/web/views/hypermedia_realtime.templ
@@ -9,7 +9,7 @@ import (
 )
 
 // RealtimePage is the full-page layout for /realtime/dashboard.
-templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []ServiceStatus, svcLatencies []ServiceLatency, tiles []NumTile, masterEnabled bool, masterMs int) {
+templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []ServiceStatus, svcLatencies []ServiceLatency, tiles []NumTile, masterEnabled bool, masterMs int, cards DashboardCardState) {
 	<link rel="stylesheet" href={ version.Asset("/public/css/charts.min.css") }/>
 	<style>
 		/* Charts.css transition smoothing */
@@ -94,9 +94,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-network",
 							TargetKey: "section", TargetValue: "network",
-							IntervalMs: 1000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("network", 1000), Scale: cards.CardScale("network", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("network", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("network", "/realtime/dashboard/pin", cards.CardPinned("network"), false)
 					</div>
 					@networkChart(snap)
 				</div>
@@ -108,9 +108,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-services",
 							TargetKey: "section", TargetValue: "services",
-							IntervalMs: 3000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("services", 3000), Scale: cards.CardScale("services", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("services", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("services", "/realtime/dashboard/pin", cards.CardPinned("services"), false)
 					</div>
 					@servicesChart(services)
 				</div>
@@ -125,9 +125,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-latency",
 							TargetKey: "section", TargetValue: "latency",
-							IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("latency", 2000), Scale: cards.CardScale("latency", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("latency", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("latency", "/realtime/dashboard/pin", cards.CardPinned("latency"), false)
 					</div>
 					@latencyHistChart(snap)
 				</div>
@@ -139,9 +139,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-error-spark",
 							TargetKey: "section", TargetValue: "error-spark",
-							IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("error-spark", 2000), Scale: cards.CardScale("error-spark", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("error-spark", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("error-spark", "/realtime/dashboard/pin", cards.CardPinned("error-spark"), false)
 					</div>
 					@errorSparkline(snap)
 				</div>
@@ -153,9 +153,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-req-dist",
 							TargetKey: "section", TargetValue: "req-dist",
-							IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("req-dist", 2000), Scale: cards.CardScale("req-dist", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("req-dist", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("req-dist", "/realtime/dashboard/pin", cards.CardPinned("req-dist"), false)
 					</div>
 					@requestDistChart(snap)
 				</div>
@@ -170,9 +170,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-throughput",
 							TargetKey: "section", TargetValue: "throughput",
-							IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("throughput", 2000), Scale: cards.CardScale("throughput", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("throughput", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("throughput", "/realtime/dashboard/pin", cards.CardPinned("throughput"), false)
 					</div>
 					@throughputSplitChart(snap)
 				</div>
@@ -184,9 +184,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-svc-latency",
 							TargetKey: "section", TargetValue: "svc-latency",
-							IntervalMs: 3000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("svc-latency", 3000), Scale: cards.CardScale("svc-latency", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("svc-latency", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("svc-latency", "/realtime/dashboard/pin", cards.CardPinned("svc-latency"), false)
 					</div>
 					@serviceLatencyChart(svcLatencies, 150)
 				</div>
@@ -201,9 +201,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-gauges",
 							TargetKey: "section", TargetValue: "gauges",
-							IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("gauges", 2000), Scale: cards.CardScale("gauges", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("gauges", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("gauges", "/realtime/dashboard/pin", cards.CardPinned("gauges"), false)
 					</div>
 					@cpuMemGauges(snap)
 				</div>
@@ -215,9 +215,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-disk-io",
 							TargetKey: "section", TargetValue: "disk-io",
-							IntervalMs: 3000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("disk-io", 3000), Scale: cards.CardScale("disk-io", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("disk-io", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("disk-io", "/realtime/dashboard/pin", cards.CardPinned("disk-io"), false)
 					</div>
 					@diskIOChart(snap)
 				</div>
@@ -229,9 +229,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-conn-pool",
 							TargetKey: "section", TargetValue: "conn-pool",
-							IntervalMs: 3000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("conn-pool", 3000), Scale: cards.CardScale("conn-pool", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("conn-pool", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("conn-pool", "/realtime/dashboard/pin", cards.CardPinned("conn-pool"), false)
 					</div>
 					@connPool(snap)
 				</div>
@@ -246,9 +246,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-sys-stats",
 							TargetKey: "section", TargetValue: "sys-stats",
-							IntervalMs: 5000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("sys-stats", 5000), Scale: cards.CardScale("sys-stats", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("sys-stats", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("sys-stats", "/realtime/dashboard/pin", cards.CardPinned("sys-stats"), false)
 					</div>
 					@dashboardSystemStats(initial)
 				</div>
@@ -260,9 +260,9 @@ templ RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []
 						@components.IntervalSlider(components.IntervalSliderCfg{
 							ID: "iv-events",
 							TargetKey: "section", TargetValue: "events",
-							IntervalMs: 1500, Scale: "s", PostURL: "/realtime/dashboard/interval",
+							IntervalMs: cards.CardMs("events", 1500), Scale: cards.CardScale("events", "s"), PostURL: "/realtime/dashboard/interval",
 						})
-						@components.PinButton("events", "/realtime/dashboard/pin", false, false)
+						@components.PinButton("events", "/realtime/dashboard/pin", cards.CardPinned("events"), false)
 					</div>
 					<div
 						id="event-feed"

--- a/web/views/hypermedia_realtime_templ.go
+++ b/web/views/hypermedia_realtime_templ.go
@@ -18,7 +18,7 @@ import (
 )
 
 // RealtimePage is the full-page layout for /realtime/dashboard.
-func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []ServiceStatus, svcLatencies []ServiceLatency, tiles []NumTile, masterEnabled bool, masterMs int) templ.Component {
+func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []ServiceStatus, svcLatencies []ServiceLatency, tiles []NumTile, masterEnabled bool, masterMs int, cards DashboardCardState) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -92,12 +92,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-network",
 			TargetKey: "section", TargetValue: "network",
-			IntervalMs: 1000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("network", 1000), Scale: cards.CardScale("network", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("network", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("network", "/realtime/dashboard/pin", cards.CardPinned("network"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -116,12 +116,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-services",
 			TargetKey: "section", TargetValue: "services",
-			IntervalMs: 3000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("services", 3000), Scale: cards.CardScale("services", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("services", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("services", "/realtime/dashboard/pin", cards.CardPinned("services"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -140,12 +140,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-latency",
 			TargetKey: "section", TargetValue: "latency",
-			IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("latency", 2000), Scale: cards.CardScale("latency", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("latency", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("latency", "/realtime/dashboard/pin", cards.CardPinned("latency"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -164,12 +164,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-error-spark",
 			TargetKey: "section", TargetValue: "error-spark",
-			IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("error-spark", 2000), Scale: cards.CardScale("error-spark", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("error-spark", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("error-spark", "/realtime/dashboard/pin", cards.CardPinned("error-spark"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -188,12 +188,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-req-dist",
 			TargetKey: "section", TargetValue: "req-dist",
-			IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("req-dist", 2000), Scale: cards.CardScale("req-dist", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("req-dist", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("req-dist", "/realtime/dashboard/pin", cards.CardPinned("req-dist"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -212,12 +212,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-throughput",
 			TargetKey: "section", TargetValue: "throughput",
-			IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("throughput", 2000), Scale: cards.CardScale("throughput", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("throughput", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("throughput", "/realtime/dashboard/pin", cards.CardPinned("throughput"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -236,12 +236,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-svc-latency",
 			TargetKey: "section", TargetValue: "svc-latency",
-			IntervalMs: 3000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("svc-latency", 3000), Scale: cards.CardScale("svc-latency", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("svc-latency", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("svc-latency", "/realtime/dashboard/pin", cards.CardPinned("svc-latency"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -260,12 +260,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-gauges",
 			TargetKey: "section", TargetValue: "gauges",
-			IntervalMs: 2000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("gauges", 2000), Scale: cards.CardScale("gauges", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("gauges", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("gauges", "/realtime/dashboard/pin", cards.CardPinned("gauges"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -284,12 +284,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-disk-io",
 			TargetKey: "section", TargetValue: "disk-io",
-			IntervalMs: 3000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("disk-io", 3000), Scale: cards.CardScale("disk-io", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("disk-io", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("disk-io", "/realtime/dashboard/pin", cards.CardPinned("disk-io"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -308,12 +308,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-conn-pool",
 			TargetKey: "section", TargetValue: "conn-pool",
-			IntervalMs: 3000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("conn-pool", 3000), Scale: cards.CardScale("conn-pool", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("conn-pool", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("conn-pool", "/realtime/dashboard/pin", cards.CardPinned("conn-pool"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -332,12 +332,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-sys-stats",
 			TargetKey: "section", TargetValue: "sys-stats",
-			IntervalMs: 5000, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("sys-stats", 5000), Scale: cards.CardScale("sys-stats", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("sys-stats", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("sys-stats", "/realtime/dashboard/pin", cards.CardPinned("sys-stats"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -356,12 +356,12 @@ func RealtimePage(initial health.SystemStats, snap MetricsSnapshot, services []S
 		templ_7745c5c3_Err = components.IntervalSlider(components.IntervalSliderCfg{
 			ID:        "iv-events",
 			TargetKey: "section", TargetValue: "events",
-			IntervalMs: 1500, Scale: "s", PostURL: "/realtime/dashboard/interval",
+			IntervalMs: cards.CardMs("events", 1500), Scale: cards.CardScale("events", "s"), PostURL: "/realtime/dashboard/interval",
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton("events", "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton("events", "/realtime/dashboard/pin", cards.CardPinned("events"), false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/views/realtime.go
+++ b/web/views/realtime.go
@@ -225,6 +225,35 @@ func fmtRPS(v float64) string {
 	return fmt.Sprintf("%.0f", math.Round(v))
 }
 
+// DashboardCardState carries the current per-section interval and pin state
+// so templates render sliders with live values instead of hardcoded defaults.
+type DashboardCardState struct {
+	Intervals map[string]int    // section -> current ms
+	Units     map[string]string // section -> current scale unit
+	Pinned    map[string]bool   // section -> pinned flag
+}
+
+// CardMs returns the current interval for a section, falling back to fallback.
+func (s DashboardCardState) CardMs(section string, fallback int) int {
+	if v, ok := s.Intervals[section]; ok {
+		return v
+	}
+	return fallback
+}
+
+// CardScale returns the current scale unit for a section, falling back to fallback.
+func (s DashboardCardState) CardScale(section, fallback string) string {
+	if v, ok := s.Units[section]; ok {
+		return v
+	}
+	return fallback
+}
+
+// CardPinned returns whether a section is pinned.
+func (s DashboardCardState) CardPinned(section string) bool {
+	return s.Pinned[section]
+}
+
 type statsEntry struct {
 	ID      string
 	Label   string


### PR DESCRIPTION
## Summary
- Dashboard and admin interval sliders now render from the current in-process state (`rtIntervals`, `adminIntervals`) instead of hardcoded defaults
- Pin button state on the realtime dashboard is also read from server state on page load
- Added `DashboardCardState` struct to carry per-section intervals, units, and pin state to templates
- Added `Intervals` field to `AdminPanelData` and `intervals` parameter to `AdminHealthPage`

Closes #555

## Test plan
- [ ] Load realtime dashboard, change a slider interval, reload page -- slider should retain the changed value
- [ ] Pin a section, reload -- pin state should persist
- [ ] Load admin settings, change system-metrics interval, reload -- slider should retain the changed value
- [ ] Load admin health, change health interval, reload -- slider should retain the changed value
- [ ] Verify master control slider still works and broadcasts to all sections