### PR TITLE
fix: render numerical tile pin buttons from server state

### DIFF
--- a/internal/routes/routes_numerical.go
+++ b/internal/routes/routes_numerical.go
@@ -113,6 +113,7 @@ func (s *numSim) buildTiles() []views.NumTile {
 		t.ID = id
 		t.IntervalMs = getTileInterval(id)
 		t.Scale = getTileScale(id)
+		t.Pinned = getTilePinned(id)
 		return t
 	}
 
@@ -359,6 +360,12 @@ func getTileScale(id string) string {
 		return u
 	}
 	return components.AutoScale(getTileInterval(id))
+}
+
+func getTilePinned(id string) bool {
+	numTileIntervals.mu.RLock()
+	defer numTileIntervals.mu.RUnlock()
+	return numTileIntervals.pinned[id]
 }
 
 // ── Routes ──────────────────────────────────────────────────────────────────

--- a/web/views/numerical.go
+++ b/web/views/numerical.go
@@ -14,4 +14,5 @@ type NumTile struct {
 	IntervalMs int    // update interval in milliseconds (canonical)
 	DeltaUp    bool   // true = positive direction
 	Neutral    bool   // delta is informational, not good/bad
+	Pinned     bool   // tile is pinned (excluded from master override)
 }

--- a/web/views/numerical.templ
+++ b/web/views/numerical.templ
@@ -12,7 +12,7 @@ import (
 templ numTileWrapper(t NumTile) {
 	<div class="bg-base-200 rounded-lg p-4 relative">
 		<div class="absolute top-2 right-2">
-			@components.PinButton(t.ID, "/realtime/dashboard/pin", false, false)
+			@components.PinButton(t.ID, "/realtime/dashboard/pin", t.Pinned, false)
 		</div>
 		@numTileData(t)
 		@components.IntervalSlider(components.IntervalSliderCfg{

--- a/web/views/numerical_templ.go
+++ b/web/views/numerical_templ.go
@@ -42,7 +42,7 @@ func numTileWrapper(t NumTile) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = components.PinButton(t.ID, "/realtime/dashboard/pin", false, false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = components.PinButton(t.ID, "/realtime/dashboard/pin", t.Pinned, false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- Adds `Pinned` field to `NumTile` struct to carry server-side pin state
- `buildTiles()` now reads `numTileIntervals.pinned` via new `getTilePinned()` helper
- `numerical.templ` renders `PinButton` with `t.Pinned` instead of hardcoded `false`

Follows the same pattern as the chart card fix in #558.

Closes #559