### PR TITLE
fix: gate snapshotAdminIntervals callsite behind demo feature

### DIFF
--- a/internal/routes/routes_admin_core.go
+++ b/internal/routes/routes_admin_core.go
@@ -181,7 +181,11 @@ func defaultStr(s, fallback string) string {
 
 func (ar *appRoutes) handleAdminHealth(c echo.Context) error {
 	h := health.Check(c.Request().Context(), ar.healthCfg)
-	return handler.RenderBaseLayout(c, views.AdminHealthPage(h, snapshotAdminIntervals()))
+	var intervals map[string]int //nolint:staticcheck // declared before setup:feature gate
+	// setup:feature:demo:start
+	intervals = snapshotAdminIntervals()
+	// setup:feature:demo:end
+	return handler.RenderBaseLayout(c, views.AdminHealthPage(h, intervals))
 }
 
 func (ar *appRoutes) handleAdminHealthCheck(c echo.Context) error {


### PR DESCRIPTION
## Summary

- Wraps the `snapshotAdminIntervals()` call in `handleAdminHealth` with `// setup:feature:demo:start/end` markers so it's stripped alongside the function definition
- Declares `intervals` as `nil` before the gate so feature-stripped builds compile with a nil map fallback (safe because `intervalOr` has defaults and the IntervalSlider is itself demo-gated)
- Follows the existing pattern from `handler.go` for nolint directives on pre-gate variable declarations

## Test plan

- [x] `TestSetup_FeaturesNone` passes
- [x] `TestSetup_PWAWithoutCapacitor` passes
- [x] `TestSetup_FeaturesMSSQL` passes
- [x] `TestSetup_FeaturesSSECaddy` passes
- [x] `TestSetup_FeaturesDatabaseOnly` passes
- [x] `TestSetup_FeaturesAuthOnly` passes
- [x] `mage lint` passes clean

Closes #560