### PR TITLE
fix: check field alignment without mutating checkout in CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -113,8 +113,8 @@ jobs:
       - name: Generate templ files
         run: go tool templ generate
 
-      - name: Fix field alignment
-        run: go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest && fieldalignment -fix ./...
+      - name: Check field alignment
+        run: go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest && fieldalignment ./...
 
       - name: Lint
         run: golangci-lint run


### PR DESCRIPTION
## Summary

- Replaces `fieldalignment -fix ./...` with `fieldalignment ./...` in the `go-test` pipeline job
- CI now validates the committed tree instead of auto-rewriting struct field alignment before lint/build/vet/tests
- `fieldalignment` without `-fix` exits non-zero if alignment issues exist, failing the build appropriately

Closes #564