### PR TITLE
fix: workflow-specific CI failure notifier

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -147,35 +147,55 @@ jobs:
     steps:
       - name: Notify CI failure
         run: |
+          TITLE="CI: ${{ github.workflow }} failure"
           BODY="**Workflow:** \`${{ github.workflow }}\`
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Branch:** \`${{ github.ref_name }}\`
           **Commit:** \`${{ github.sha }}\`
           **Triggered by:** ${{ github.actor }}"
 
-          EXISTING=$(gh issue list \
+          ISSUE=$(gh issue list \
             --repo "${{ github.repository }}" \
             --label "ci" \
-            --state all \
-            --limit 1 \
-            --json number,state \
-            --jq '.[0]')
+            --state open \
+            --search "in:title $TITLE" \
+            --json number \
+            --jq '.[0].number // empty')
 
-          if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+          if [ -z "$ISSUE" ]; then
             gh issue create \
               --repo "${{ github.repository }}" \
-              --title "Pipeline failure: ${{ github.workflow }}" \
+              --title "$TITLE" \
               --label "ci" \
               --body "$BODY"
           else
-            NUMBER=$(echo "$EXISTING" | jq -r '.number')
-            STATE=$(echo "$EXISTING" | jq -r '.state')
-            if [ "$STATE" = "CLOSED" ]; then
-              gh issue reopen "$NUMBER" --repo "${{ github.repository }}"
-            fi
-            gh issue comment "$NUMBER" \
+            gh issue comment "$ISSUE" \
               --repo "${{ github.repository }}" \
               --body "$BODY"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  notify-success:
+    if: ${{ success() }}
+    needs: [build-simulator]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close CI issue on success
+        run: |
+          TITLE="CI: ${{ github.workflow }} failure"
+          ISSUE=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "ci" \
+            --state open \
+            --search "in:title $TITLE" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$ISSUE" ]; then
+            gh issue close "$ISSUE" \
+              --repo "${{ github.repository }}" \
+              --comment "${{ github.workflow }} is green again. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -304,35 +304,56 @@ jobs:
     steps:
       - name: Notify CI failure
         run: |
+          TITLE="CI: ${{ github.workflow }} failure"
           BODY="**Workflow:** \`${{ github.workflow }}\`
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Branch:** \`${{ github.ref_name }}\`
           **Commit:** \`${{ github.sha }}\`
           **Triggered by:** ${{ github.actor }}"
 
-          EXISTING=$(gh issue list \
+          ISSUE=$(gh issue list \
             --repo "${{ github.repository }}" \
             --label "ci" \
-            --state all \
-            --limit 1 \
-            --json number,state \
-            --jq '.[0]')
+            --state open \
+            --search "in:title $TITLE" \
+            --json number \
+            --jq '.[0].number // empty')
 
-          if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+          if [ -z "$ISSUE" ]; then
             gh issue create \
               --repo "${{ github.repository }}" \
-              --title "Pipeline failure: ${{ github.workflow }}" \
+              --title "$TITLE" \
               --label "ci" \
               --body "$BODY"
           else
-            NUMBER=$(echo "$EXISTING" | jq -r '.number')
-            STATE=$(echo "$EXISTING" | jq -r '.state')
-            if [ "$STATE" = "CLOSED" ]; then
-              gh issue reopen "$NUMBER" --repo "${{ github.repository }}"
-            fi
-            gh issue comment "$NUMBER" \
+            gh issue comment "$ISSUE" \
               --repo "${{ github.repository }}" \
               --body "$BODY"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  # ── Close CI issue on success ──────────────────────────────────────────────
+  notify-success:
+    if: ${{ success() }}
+    needs: [update-deps, go-test, e2e-test, js-lint, docs, sync-harmony]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close CI issue on success
+        run: |
+          TITLE="CI: ${{ github.workflow }} failure"
+          ISSUE=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "ci" \
+            --state open \
+            --search "in:title $TITLE" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$ISSUE" ]; then
+            gh issue close "$ISSUE" \
+              --repo "${{ github.repository }}" \
+              --comment "${{ github.workflow }} is green again. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,35 +225,55 @@ jobs:
     steps:
       - name: Notify CI failure
         run: |
+          TITLE="CI: ${{ github.workflow }} failure"
           BODY="**Workflow:** \`${{ github.workflow }}\`
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Branch:** \`${{ github.ref_name }}\`
           **Commit:** \`${{ github.sha }}\`
           **Triggered by:** ${{ github.actor }}"
 
-          EXISTING=$(gh issue list \
+          ISSUE=$(gh issue list \
             --repo "${{ github.repository }}" \
             --label "ci" \
-            --state all \
-            --limit 1 \
-            --json number,state \
-            --jq '.[0]')
+            --state open \
+            --search "in:title $TITLE" \
+            --json number \
+            --jq '.[0].number // empty')
 
-          if [ -z "$EXISTING" ] || [ "$EXISTING" = "null" ]; then
+          if [ -z "$ISSUE" ]; then
             gh issue create \
               --repo "${{ github.repository }}" \
-              --title "Pipeline failure: ${{ github.workflow }}" \
+              --title "$TITLE" \
               --label "ci" \
               --body "$BODY"
           else
-            NUMBER=$(echo "$EXISTING" | jq -r '.number')
-            STATE=$(echo "$EXISTING" | jq -r '.state')
-            if [ "$STATE" = "CLOSED" ]; then
-              gh issue reopen "$NUMBER" --repo "${{ github.repository }}"
-            fi
-            gh issue comment "$NUMBER" \
+            gh issue comment "$ISSUE" \
               --repo "${{ github.repository }}" \
               --body "$BODY"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  notify-success:
+    if: ${{ success() }}
+    needs: [check, release, docker]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close CI issue on success
+        run: |
+          TITLE="CI: ${{ github.workflow }} failure"
+          ISSUE=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "ci" \
+            --state open \
+            --search "in:title $TITLE" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$ISSUE" ]; then
+            gh issue close "$ISSUE" \
+              --repo "${{ github.repository }}" \
+              --comment "${{ github.workflow }} is green again. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Each workflow now keys its CI issue by title (e.g. "CI: Pipeline failure", "CI: Release failure") instead of grabbing an arbitrary `ci`-labeled issue
- On failure: finds or creates an open issue specific to that workflow, comments with run details
- On success: closes the workflow-specific CI issue with a "green again" comment
- Closes stale issue #207 which was being reused by all workflows

Closes #563