### PR TITLE
refactor: migrate 5 SSE routes to tavern.StreamSSE (#620)

### DIFF
--- a/internal/routes/routes_canvas.go
+++ b/internal/routes/routes_canvas.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"math/big"
 	"net/http"
@@ -108,32 +107,31 @@ func (cr *canvasRoutes) handleCanvasSSE(c echo.Context) error {
 	cr.canvas.TouchClient(connID, color)
 	defer cr.canvas.RemoveClient(connID)
 
-	flusher, err := startSSEResponse(c)
-	if err != nil {
-		return err
-	}
-
 	ch, unsub := cr.broker.Subscribe(TopicCanvasUpdate)
 	defer unsub()
 
-	heartbeat := time.NewTicker(10 * time.Second)
-	defer heartbeat.Stop()
-
+	// Periodically refresh this client's presence so the prune-stale tick
+	// keeps it visible. This is presence bookkeeping, not an SSE heartbeat.
 	ctx := c.Request().Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-heartbeat.C:
-			cr.canvas.TouchClient(connID, color)
-		case msg, ok := <-ch:
-			if !ok {
-				return nil
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cr.canvas.TouchClient(connID, color)
 			}
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
 		}
-	}
+	}()
+
+	return tavern.StreamSSE(
+		ctx,
+		c.Response(),
+		ch,
+		func(s string) string { return s },
+	)
 }
 
 // runTicker periodically broadcasts active client info and prunes stale clients.

--- a/internal/routes/routes_lifeline.go
+++ b/internal/routes/routes_lifeline.go
@@ -1,7 +1,6 @@
 package routes
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/catgoose/tavern"
@@ -14,32 +13,15 @@ func (ar *appRoutes) initLifelineRoutes(broker *tavern.SSEBroker) {
 
 func handleLifelineSSE(broker *tavern.SSEBroker) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		flusher, err := startSSEResponse(c)
-		if err != nil {
-			return err
-		}
-
 		msgs, unsub := broker.Subscribe(TopicAppLifeline)
 		defer unsub()
 
-		heartbeat := time.NewTicker(30 * time.Second)
-		defer heartbeat.Stop()
-
-		ctx := c.Request().Context()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case msg, ok := <-msgs:
-				if !ok {
-					return nil
-				}
-				_, _ = fmt.Fprint(c.Response(), msg)
-				flusher.Flush()
-			case <-heartbeat.C:
-				_, _ = fmt.Fprintf(c.Response(), ": heartbeat\n\n")
-				flusher.Flush()
-			}
-		}
+		return tavern.StreamSSE(
+			c.Request().Context(),
+			c.Response(),
+			msgs,
+			func(s string) string { return s },
+			tavern.WithStreamHeartbeat(30*time.Second),
+		)
 	}
 }

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -159,11 +159,6 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 	p.broker.SetReplayPolicy(topic, 5)
 	p.broker.SetReplayGapPolicy(topic, tavern.GapFallbackToSnapshot, nil)
 
-	flusher, err := startSSEResponse(c)
-	if err != nil {
-		return err
-	}
-
 	// Check for Last-Event-ID for replay on reconnect.
 	lastEventID := c.Request().Header.Get("Last-Event-ID")
 	var ch <-chan string
@@ -175,19 +170,12 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 	}
 	defer unsub()
 
-	ctx := c.Request().Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case msg, ok := <-ch:
-			if !ok {
-				return nil
-			}
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
-		}
-	}
+	return tavern.StreamSSE(
+		c.Request().Context(),
+		c.Response(),
+		ch,
+		func(s string) string { return s },
+	)
 }
 
 func (p *peopleRoutes) buildPeopleContent(c echo.Context) ([]demo.Person, int, linkwell.FilterBar, []linkwell.TableCol, linkwell.PageInfo, error) {

--- a/internal/routes/routes_tavern_failures.go
+++ b/internal/routes/routes_tavern_failures.go
@@ -58,11 +58,6 @@ func (r *failuresRoutes) handlePage(c echo.Context) error {
 // parameter — the latter lets the in-page scenario buttons trigger a
 // resume without browser support for setting EventSource headers.
 func (r *failuresRoutes) handleSSE(c echo.Context) error {
-	flusher, err := startSSEResponse(c)
-	if err != nil {
-		return err
-	}
-
 	lastEventID := c.Request().Header.Get("Last-Event-ID")
 	if lastEventID == "" {
 		lastEventID = c.QueryParam("resume")
@@ -70,29 +65,27 @@ func (r *failuresRoutes) handleSSE(c echo.Context) error {
 
 	var msgs <-chan string
 	var unsub func()
+	var opts []tavern.StreamSSEOption
 	if lastEventID != "" {
 		msgs, unsub = r.broker.SubscribeFromID(topicFailuresLive, lastEventID)
-		// Tell the client what we got back so the result panel can show it.
-		describeResume(c.Response(), lastEventID)
-		flusher.Flush()
+		// Tell the client how we interpreted the resume hint so the result
+		// panel can render it. WithStreamSnapshot writes this once before
+		// any channel values are streamed.
+		opts = append(opts, tavern.WithStreamSnapshot(func() string {
+			return resumeDescriptionFrame(lastEventID)
+		}))
 	} else {
 		msgs, unsub = r.broker.Subscribe(topicFailuresLive)
 	}
 	defer unsub()
 
-	ctx := c.Request().Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case msg, ok := <-msgs:
-			if !ok {
-				return nil
-			}
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
-		}
-	}
+	return tavern.StreamSSE(
+		c.Request().Context(),
+		c.Response(),
+		msgs,
+		func(s string) string { return s },
+		opts...,
+	)
 }
 
 // handleBurst publishes a few events with sequential IDs so the replay
@@ -137,9 +130,10 @@ func (r *failuresRoutes) startBackgroundTrickle(ctx context.Context) {
 	}
 }
 
-// describeResume writes a one-shot SSE result message describing how the
-// resume attempt was interpreted. The client renders this in the result panel.
-func describeResume(w http.ResponseWriter, lastEventID string) {
+// resumeDescriptionFrame returns a one-shot SSE result frame describing how
+// the resume attempt was interpreted. The client renders this in the result
+// panel. It is delivered via tavern.WithStreamSnapshot before any live events.
+func resumeDescriptionFrame(lastEventID string) string {
 	var title, detail, level string
 	if !looksLikeFailuresEventID(lastEventID) {
 		title = "malformed Last-Event-ID"
@@ -151,7 +145,7 @@ func describeResume(w http.ResponseWriter, lastEventID string) {
 		level = "info"
 	}
 	html := renderFailuresResult(title, detail, level)
-	_, _ = fmt.Fprint(w, tavern.NewSSEMessage("failures-result", html).String())
+	return tavern.NewSSEMessage("failures-result", html).String()
 }
 
 // looksLikeFailuresEventID is a tiny shape check matching IDs this lab emits.

--- a/internal/routes/routes_tavern_recovery.go
+++ b/internal/routes/routes_tavern_recovery.go
@@ -76,17 +76,16 @@ func (r *recoveryRoutes) handleReset(c echo.Context) error {
 // handleSSE multiplexes all three recovery topics into one SSE response.
 // On reconnect, the replay region uses Last-Event-ID, the snapshot region
 // gets the current snapshot value, and the live region just resumes streaming.
+//
+// StreamSSE takes a single channel, so the three topic channels are fanned
+// in to one stream channel. The fan-in goroutine exits when ctx is cancelled
+// or any source channel is closed; closing fanIn signals StreamSSE to return.
 func (r *recoveryRoutes) handleSSE(c echo.Context) error {
-	flusher, err := startSSEResponse(c)
-	if err != nil {
-		return err
-	}
-
 	lastEventID := c.Request().Header.Get("Last-Event-ID")
 	reconnect := lastEventID != ""
 
-	// Replay subscription: SubscribeFromID for reconnects, SubscribeMulti
-	// otherwise. SubscribeFromID delivers any events newer than lastEventID.
+	// Replay subscription: SubscribeFromID for reconnects, Subscribe otherwise.
+	// SubscribeFromID delivers any events newer than lastEventID.
 	var replayCh <-chan string
 	var replayUnsub func()
 	if reconnect {
@@ -109,48 +108,62 @@ func (r *recoveryRoutes) handleSSE(c echo.Context) error {
 	liveCh, liveUnsub := r.broker.Subscribe(topicRecoveryLive)
 	defer liveUnsub()
 
+	ctx := c.Request().Context()
+	fanIn := make(chan string, 16)
+	go func() {
+		defer close(fanIn)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-replayCh:
+				if !ok {
+					return
+				}
+				select {
+				case fanIn <- msg:
+				case <-ctx.Done():
+					return
+				}
+			case msg, ok := <-snapCh:
+				if !ok {
+					return
+				}
+				select {
+				case fanIn <- msg:
+				case <-ctx.Done():
+					return
+				}
+			case msg, ok := <-liveCh:
+				if !ok {
+					return
+				}
+				select {
+				case fanIn <- msg:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
 	// Tell the client whether this was a fresh connect or a reconnect, so
-	// the regions can show the right "first delivery" badges.
+	// the regions can show the right "first delivery" badges. Delivered as
+	// a one-shot snapshot before any channel values are streamed.
 	mode := "fresh"
 	if reconnect {
 		mode = "reconnect"
 	}
-	if _, werr := fmt.Fprintf(c.Response(), "event: recovery-mode\ndata: %s\n\n", mode); werr != nil {
-		return nil
-	}
-	flusher.Flush()
+	modeFrame := fmt.Sprintf("event: recovery-mode\ndata: %s\n\n", mode)
 
-	ctx := c.Request().Context()
-	heartbeat := time.NewTicker(15 * time.Second)
-	defer heartbeat.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case msg, ok := <-replayCh:
-			if !ok {
-				return nil
-			}
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
-		case msg, ok := <-snapCh:
-			if !ok {
-				return nil
-			}
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
-		case msg, ok := <-liveCh:
-			if !ok {
-				return nil
-			}
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
-		case <-heartbeat.C:
-			_, _ = fmt.Fprintf(c.Response(), ": heartbeat\n\n")
-			flusher.Flush()
-		}
-	}
+	return tavern.StreamSSE(
+		ctx,
+		c.Response(),
+		fanIn,
+		func(s string) string { return s },
+		tavern.WithStreamSnapshot(func() string { return modeFrame }),
+		tavern.WithStreamHeartbeat(15*time.Second),
+	)
 }
 
 // startPublisher emits replay and live events on a slow timer so the demo


### PR DESCRIPTION
First batch of the `tavern.StreamSSE` migration tracked in #620 — the routes that map almost directly to the helper.

## Routes migrated

| Route | Notes |
| --- | --- |
| \`routes_lifeline.go\` | 30s heartbeat → \`WithStreamHeartbeat(30s)\` |
| \`routes_people.go\` | Last-Event-ID resume preserved at the call site |
| \`routes_canvas.go\` | 10s tick is presence bookkeeping, not an SSE keepalive — moved to a sibling goroutine that exits with the request context |
| \`routes_tavern_failures.go\` | \`describeResume\` folded into a one-shot \`WithStreamSnapshot\` frame; \`resumeDescriptionFrame\` returns the SSE string instead of writing to the response |
| \`routes_tavern_recovery.go\` | Three topic channels (replay/snapshot/live) fanned in to a single stream channel; mode frame delivered via \`WithStreamSnapshot\`; 15s heartbeat via \`WithStreamHeartbeat\` |

## Behavior preserved

- Heartbeat cadences match the originals (lifeline 30s, recovery 15s, canvas 10s)
- Last-Event-ID resume in people and failures
- Snapshot ordering in recovery (mode frame first, then snapshot/live deliveries)
- Canvas presence touch loop stops with the request context

## Not yet touched

\`startSSEResponse\` still has callers in subs, sensors, notifications, hooks, and backpressure. The final cleanup PR for #620 will remove the helper once those routes are migrated.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [x] \`mage lint\`
- [ ] Manual smoke: lifeline keepalive, people profile SSE, canvas presence, failures lab resume scenarios, recovery lab disconnect/reconnect

Refs #620