### PR TITLE
refactor: migrate sensors and notifications to tavern.StreamSSE (#620)

### DIFF
--- a/internal/routes/routes_notifications.go
+++ b/internal/routes/routes_notifications.go
@@ -137,11 +137,6 @@ func (n *notificationRoutes) handleSimulatorSpeed(c echo.Context) error {
 func (n *notificationRoutes) handleSSE(c echo.Context) error {
 	identity := resolveNotifIdentity(c.QueryParam("identity"))
 
-	flusher, err := startSSEResponse(c)
-	if err != nil {
-		return err
-	}
-
 	// Each SSE connection gets a unique presence key so that multiple tabs
 	// sharing the same identity cookie track independently. The real identity
 	// ID is stored in metadata for notification routing and deduplication.
@@ -177,10 +172,11 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 	}
 
 	// Check for Last-Event-ID for replay.
-	// Both paths apply the same filterFn: SubscribeWith uses it natively for
-	// live messages, while SubscribeFromID doesn't support filters so we apply
-	// the filter in the write loop below. This ensures category preferences
-	// survive SSE reconnections.
+	// Both paths apply the same filterFn: SubscribeWith uses it natively at
+	// the broker level for live messages; SubscribeFromID doesn't support
+	// filters, so the encode function below re-applies it. Returning an
+	// empty string from the encoder skips a value without terminating the
+	// stream, so category preferences survive SSE reconnections.
 	lastEventID := c.Request().Header.Get("Last-Event-ID")
 	var msgs <-chan string
 	var unsub func()
@@ -193,29 +189,36 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 	}
 	defer unsub()
 
-	heartbeat := time.NewTicker(10 * time.Second)
-	defer heartbeat.Stop()
-
+	// Presence bookkeeping: refresh the tracker entry every 10s so the user
+	// stays in the online list. This is independent of the SSE keepalive
+	// (which is handled below by WithStreamHeartbeat) — it just happens to
+	// share the same cadence the original loop used.
 	ctx := c.Request().Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case msg, ok := <-msgs:
-			if !ok {
-				return nil
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				n.tracker.Heartbeat(TopicNotifications, connID)
 			}
-			if !filterFn(msg) {
-				continue
-			}
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
-		case <-heartbeat.C:
-			n.tracker.Heartbeat(TopicNotifications, connID)
-			_, _ = fmt.Fprintf(c.Response(), ": heartbeat\n\n")
-			flusher.Flush()
 		}
-	}
+	}()
+
+	return tavern.StreamSSE(
+		ctx,
+		c.Response(),
+		msgs,
+		func(msg string) string {
+			if !filterFn(msg) {
+				return ""
+			}
+			return msg
+		},
+		tavern.WithStreamHeartbeat(10*time.Second),
+	)
 }
 
 func (n *notificationRoutes) handleFilterUpdate(c echo.Context) error {

--- a/internal/routes/routes_sensors.go
+++ b/internal/routes/routes_sensors.go
@@ -5,7 +5,6 @@ package routes
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"time"
 
 	"catgoose/dothog/internal/demo"
@@ -43,12 +42,8 @@ func (s *sensorRoutes) handleSSE(c echo.Context) error {
 		pattern = "sensors/**"
 	}
 
-	flusher, err := startSSEResponse(c)
-	if err != nil {
-		return err
-	}
-
-	// Build snapshot function for initial state delivery
+	// Snapshot is delivered at the broker layer via SubWithSnapshot, so the
+	// initial frame still arrives atomically with the subscription.
 	snapshotFn := func() string {
 		snap := s.grid.Snapshot(pattern)
 		var buf bytes.Buffer
@@ -72,26 +67,15 @@ func (s *sensorRoutes) handleSSE(c echo.Context) error {
 	)
 	defer unsub()
 
-	heartbeat := time.NewTicker(10 * time.Second)
-	defer heartbeat.Stop()
-
-	ctx := c.Request().Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case tm, ok := <-msgs:
-			if !ok {
-				return nil
-			}
-			msg := tavern.NewSSEMessage("sensor-update", tm.Data).String()
-			_, _ = fmt.Fprint(c.Response(), msg)
-			flusher.Flush()
-		case <-heartbeat.C:
-			_, _ = fmt.Fprintf(c.Response(), ": heartbeat\n\n")
-			flusher.Flush()
-		}
-	}
+	return tavern.StreamSSE(
+		c.Request().Context(),
+		c.Response(),
+		msgs,
+		func(tm tavern.TopicMessage) string {
+			return tavern.NewSSEMessage("sensor-update", tm.Data).String()
+		},
+		tavern.WithStreamHeartbeat(10*time.Second),
+	)
 }
 
 func (s *sensorRoutes) handleFloodToggle(c echo.Context) error {


### PR DESCRIPTION
Third batch of #620 — the two stateful routes with existing heartbeats and side-effects.

## routes_sensors.go

- Snapshot still flows through \`SubWithSnapshot\` at the broker layer (atomic with subscription). \`StreamSSE\` has no role in initial state delivery here.
- \`TopicMessage\` encoder wraps each tick as a \`sensor-update\` frame.
- 10s SSE keepalive via \`WithStreamHeartbeat\`.

## routes_notifications.go

This is the most behavior-sensitive route migrated so far. Care taken:

- **Filter on both paths.** \`SubWithFilter\` continues to handle the fresh path at the broker layer; the \`StreamSSE\` encoder re-applies \`filterFn\` for the \`SubscribeFromID\` resume path. Returning an empty string from \`encode\` skips a value without terminating the stream, so category preferences survive reconnects exactly as before.
- **Last-Event-ID resume, per-user replay buffer, and presence tracking** are untouched.
- **Presence \`Heartbeat\` is bookkeeping, not an SSE keepalive.** It moves to a sibling goroutine bound to the request context. The SSE keepalive itself goes through \`WithStreamHeartbeat(10*time.Second)\`.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [x] \`mage lint\`
- [ ] Manual smoke: sensors page connects + snapshot + tick updates + flood mode; notifications page identity switch + category filter + reconnect (Last-Event-ID) + presence list

Refs #620