### PR TITLE
refactor: adopt tavern.SubscribeFromIDWith resume helper (closes #602)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/catgoose/dorman v0.1.15
 	github.com/catgoose/linkwell v0.2.29
 	github.com/catgoose/promolog/sqlite v0.0.0-20260409215859-0fc0b83ab989
-	github.com/catgoose/tavern v0.4.74
+	github.com/catgoose/tavern v0.4.76
 	github.com/charmbracelet/huh v1.0.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/jmoiron/sqlx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/catgoose/promolog v0.2.27 h1:nzvumQ2FO/N8BKpbSz5ZT7RI8d8VSquGHN6hrzuQ
 github.com/catgoose/promolog v0.2.27/go.mod h1:ml44Fkt/KONxjTO6yL+3EQDSuv3+KdVJQOjM5pPnCKk=
 github.com/catgoose/promolog/sqlite v0.0.0-20260409215859-0fc0b83ab989 h1:HUgCDs4EgHHLb3bssCWncflb0jsxAoObtKVlfp2w634=
 github.com/catgoose/promolog/sqlite v0.0.0-20260409215859-0fc0b83ab989/go.mod h1:Vo2raEZh+FnB8R3zYAJDS+cFRHsxoOqXvu9H8Ey9fZg=
-github.com/catgoose/tavern v0.4.74 h1:+bgj2BjCAS/N7B8deg/EtAnljjOSiTDHFJXpUGELCIA=
-github.com/catgoose/tavern v0.4.74/go.mod h1:hb8960IWrAZ9hJuknCfMyJVtXOWvLjD+ok/MnD5jEmU=
+github.com/catgoose/tavern v0.4.76 h1:uMhG3RPVLSR/Q7rGeSxrbmmbVWd1EphJwNl0kwvXY2w=
+github.com/catgoose/tavern v0.4.76/go.mod h1:hb8960IWrAZ9hJuknCfMyJVtXOWvLjD+ok/MnD5jEmU=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/internal/routes/routes_notifications.go
+++ b/internal/routes/routes_notifications.go
@@ -171,22 +171,14 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 		return true
 	}
 
-	// Check for Last-Event-ID for replay.
-	// Both paths apply the same filterFn: SubscribeWith uses it natively at
-	// the broker level for live messages; SubscribeFromID doesn't support
-	// filters, so the encode function below re-applies it. Returning an
-	// empty string from the encoder skips a value without terminating the
-	// stream, so category preferences survive SSE reconnections.
+	// SubscribeFromIDWith composes resume with subscription options, so the
+	// category filter applies at the broker layer on both fresh and resumed
+	// connections. Category preferences now survive SSE reconnections from
+	// a single subscription path.
 	lastEventID := c.Request().Header.Get("Last-Event-ID")
-	var msgs <-chan string
-	var unsub func()
-	if lastEventID != "" {
-		msgs, unsub = n.broker.SubscribeFromID(userTopic, lastEventID)
-	} else {
-		msgs, unsub = n.broker.SubscribeWith(userTopic,
-			tavern.SubWithFilter(filterFn),
-		)
-	}
+	msgs, unsub := n.broker.SubscribeFromIDWith(userTopic, lastEventID,
+		tavern.SubWithFilter(filterFn),
+	)
 	defer unsub()
 
 	// Presence bookkeeping: refresh the tracker entry every 10s so the user
@@ -211,12 +203,7 @@ func (n *notificationRoutes) handleSSE(c echo.Context) error {
 		ctx,
 		c.Response(),
 		msgs,
-		func(msg string) string {
-			if !filterFn(msg) {
-				return ""
-			}
-			return msg
-		},
+		func(msg string) string { return msg },
 		tavern.WithStreamHeartbeat(10*time.Second),
 	)
 }

--- a/internal/routes/routes_people.go
+++ b/internal/routes/routes_people.go
@@ -159,15 +159,11 @@ func (p *peopleRoutes) handlePersonSSE(c echo.Context) error {
 	p.broker.SetReplayPolicy(topic, 5)
 	p.broker.SetReplayGapPolicy(topic, tavern.GapFallbackToSnapshot, nil)
 
-	// Check for Last-Event-ID for replay on reconnect.
+	// SubscribeFromIDWith is resume-aware on both paths: a fresh connection
+	// (empty Last-Event-ID) behaves like SubscribeWith, and a non-empty
+	// Last-Event-ID replays from the ID-backed replay log after that ID.
 	lastEventID := c.Request().Header.Get("Last-Event-ID")
-	var ch <-chan string
-	var unsub func()
-	if lastEventID != "" {
-		ch, unsub = p.broker.SubscribeFromID(topic, lastEventID)
-	} else {
-		ch, unsub = p.broker.Subscribe(topic)
-	}
+	ch, unsub := p.broker.SubscribeFromIDWith(topic, lastEventID)
 	defer unsub()
 
 	return tavern.StreamSSE(

--- a/internal/routes/routes_tavern_failures.go
+++ b/internal/routes/routes_tavern_failures.go
@@ -63,21 +63,19 @@ func (r *failuresRoutes) handleSSE(c echo.Context) error {
 		lastEventID = c.QueryParam("resume")
 	}
 
-	var msgs <-chan string
-	var unsub func()
+	// SubscribeFromIDWith collapses the fresh-vs-resume branch into a
+	// single subscription path. The conditional snapshot frame describing
+	// the resume attempt only fires on the resume path, since fresh
+	// connections have nothing to explain.
+	msgs, unsub := r.broker.SubscribeFromIDWith(topicFailuresLive, lastEventID)
+	defer unsub()
+
 	var opts []tavern.StreamSSEOption
 	if lastEventID != "" {
-		msgs, unsub = r.broker.SubscribeFromID(topicFailuresLive, lastEventID)
-		// Tell the client how we interpreted the resume hint so the result
-		// panel can render it. WithStreamSnapshot writes this once before
-		// any channel values are streamed.
 		opts = append(opts, tavern.WithStreamSnapshot(func() string {
 			return resumeDescriptionFrame(lastEventID)
 		}))
-	} else {
-		msgs, unsub = r.broker.Subscribe(topicFailuresLive)
 	}
-	defer unsub()
 
 	return tavern.StreamSSE(
 		c.Request().Context(),

--- a/internal/routes/routes_tavern_recovery.go
+++ b/internal/routes/routes_tavern_recovery.go
@@ -84,15 +84,11 @@ func (r *recoveryRoutes) handleSSE(c echo.Context) error {
 	lastEventID := c.Request().Header.Get("Last-Event-ID")
 	reconnect := lastEventID != ""
 
-	// Replay subscription: SubscribeFromID for reconnects, Subscribe otherwise.
-	// SubscribeFromID delivers any events newer than lastEventID.
-	var replayCh <-chan string
-	var replayUnsub func()
-	if reconnect {
-		replayCh, replayUnsub = r.broker.SubscribeFromID(topicRecoveryReplay, lastEventID)
-	} else {
-		replayCh, replayUnsub = r.broker.Subscribe(topicRecoveryReplay)
-	}
+	// Replay subscription: SubscribeFromIDWith handles both fresh and
+	// resumed connections in a single call. The snapshot and live legs
+	// below intentionally use different APIs because they exercise
+	// different recovery strategies on this multi-region demo.
+	replayCh, replayUnsub := r.broker.SubscribeFromIDWith(topicRecoveryReplay, lastEventID)
 	defer replayUnsub()
 
 	// Snapshot subscription: deliver the current snapshot atomically before


### PR DESCRIPTION
Adopts the new resume-aware subscription helpers from upstream Tavern:

- \`SubscribeFromIDWith\` from \`v0.4.75\` (composes resume with \`SubscribeOption\`s)
- \`SubscribeMultiFromID\` from \`v0.4.76\` (intentionally not adopted yet — see below)

## Tavern bump

\`go get github.com/catgoose/tavern@v0.4.76\` — covers both new APIs.

## Routes converted

| Route | Before | After |
| --- | --- | --- |
| \`routes_people.go\` | \`Subscribe\` / \`SubscribeFromID\` branch | single \`SubscribeFromIDWith\` |
| \`routes_tavern_failures.go\` | \`Subscribe\` / \`SubscribeFromID\` branch | single \`SubscribeFromIDWith\`; resume-explanation \`WithStreamSnapshot\` still only fires when a \`Last-Event-ID\` hint is present |
| \`routes_notifications.go\` | \`SubscribeWith(SubWithFilter)\` for fresh, \`SubscribeFromID\` for resume | single \`SubscribeFromIDWith(..., SubWithFilter)\`; encoder drops the duplicate filter check and collapses to a passthrough |
| \`routes_tavern_recovery.go\` | replay leg branched between \`Subscribe\` and \`SubscribeFromID\` | replay leg uses \`SubscribeFromIDWith\`. The snapshot and live legs are intentionally untouched — each region demos a different recovery strategy and the fan-in/multi-channel structure stays explicit |

## SubscribeMultiFromID

Not adopted in this PR. Per the plan, no current \`dothog\` route truly wants merged-replay across multiple replay-backed topics. \`SubscribeMulti\` call sites in hooks/subs/backpressure are not replay handlers, and converting them speculatively would obscure the demo intent.

## Grep checklist

\`\`\`
internal/routes/routes_tavern_replay.go:48:    // find Last-Event-ID in the replay log...
internal/routes/routes_people.go:166:           p.broker.SubscribeFromIDWith(topic, lastEventID)
internal/routes/routes_tavern_recovery.go:91:  r.broker.SubscribeFromIDWith(topicRecoveryReplay, lastEventID)
internal/routes/routes_tavern_failures.go:70:  r.broker.SubscribeFromIDWith(topicFailuresLive, lastEventID)
internal/routes/routes_notifications.go:179:   n.broker.SubscribeFromIDWith(userTopic, lastEventID, tavern.SubWithFilter(filterFn))
\`\`\`

Zero remaining \`SubscribeFromID(\` (narrow API) calls in \`internal/routes/\`. The \`Last-Event-ID\` matches that remain are header reads, demo strings, and explanatory comments — all legitimate per the plan.

## Behavior preserved

- People profile: replay on reconnect.
- Failures lab: malformed-resume snapshot frame, gap fallback, burst publishing.
- Notifications: per-user replay scoping, category filtering on both fresh and resumed connections, presence bookkeeping, 10s heartbeat.
- Recovery lab: replay region resumes from \`Last-Event-ID\`, snapshot region delivers current snapshot, live region remains live-only.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [x] \`mage lint\`
- [ ] Manual smoke: notifications reconnect + filter persistence; people profile reconnect; failures lab malformed/expired resume scenarios; recovery lab three-region disconnect

Closes #602