### PR TITLE
fix: remove stale DATABASE_URL from .env.development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,9 +6,8 @@ SERVER_LISTEN_PORT=5124
 LOG_LEVEL=INFO
 SESSION_SECRET=change-me-in-production
 
-# Database
-ENABLE_DATABASE=false
-DATABASE_URL=sqlite:///db/app.db
+# Database (set DATABASE_URL to enable)
+# DATABASE_URL=sqlite:///db/app.db
 
 # OIDC Authentication (disabled by default)
 # OIDC_ISSUER_URL=https://login.microsoftonline.com/{tenant-id}/v2.0


### PR DESCRIPTION
\#579 removed \`ENABLE_DATABASE\` from the codebase but \`.env.development\` still had both \`ENABLE_DATABASE=false\` and \`DATABASE_URL=sqlite:///db/app.db\`.

Since the config now gates on \`DatabaseURL != ""\`, the stale URL caused the app to try opening \`/db/app.db\` (absolute path from the triple-slash URI) on startup.

Comments out \`DATABASE_URL\` to match \`.env.sample\` and restore the expected no-database default for local development.