### PR TITLE
fix: demote Azure credentials log to Debug level

### DIFF
--- a/main.go
+++ b/main.go
@@ -215,7 +215,7 @@ func main() {
 			logger.Fatal("Failed to initialize user cache", "error", err)
 		}
 	} else {
-		logger.Info("Azure credentials not configured; skipping user and photo sync")
+		logger.Debug("Azure credentials not configured; skipping user and photo sync")
 	}
 	// setup:feature:avatar:end
 


### PR DESCRIPTION
The 'Azure credentials not configured' message fires on every startup in demo mode since Azure is never configured. Demoting from Info to Debug keeps the startup log clean.