### PR TITLE
fix: remove noisy Azure credentials log from demo startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -214,8 +214,6 @@ func main() {
 		if err := graph.InitAndSyncUserCache(appCtx, userCache, cfg.GraphUserCacheRefreshHour, graphClient.FetchAllEnabledUsers, afterSync); err != nil {
 			logger.Fatal("Failed to initialize user cache", "error", err)
 		}
-	} else {
-		logger.Debug("Azure credentials not configured; skipping user and photo sync")
 	}
 	// setup:feature:avatar:end
 


### PR DESCRIPTION
The else branch logged an INFO message on every startup when Azure credentials aren't configured — which is always in demo mode. The block is already gated by \`setup:feature:avatar\` so it gets stripped in derived apps that don't select avatar. In the source repo, just silently skip when credentials are absent.