### PR TITLE
fix: calendar lab category dropdown clipping

### DIFF
--- a/web/views/tavern_calendar.templ
+++ b/web/views/tavern_calendar.templ
@@ -206,7 +206,7 @@ templ CalendarLabDay(day time.Time, events []demo.CalendarEvent, settings demo.C
 			<h2 class="text-sm font-semibold uppercase tracking-wider text-base-content/50">{ day.Format("Mon Jan 2, 2006") }</h2>
 			<p class="text-xs text-base-content/40">{ fmt.Sprintf("%d event(s)", len(events)) }</p>
 		</div>
-		<div class="space-y-1 max-h-64 overflow-y-auto" style="contain:paint">
+		<div class="space-y-1 max-h-64 overflow-y-auto">
 			if len(events) == 0 {
 				<p class="text-xs text-base-content/30 py-2">No events on this day.</p>
 			} else {
@@ -258,8 +258,8 @@ templ calLabAddEventForm(day time.Time) {
 				required
 			/>
 		</div>
-		<div class="flex items-center gap-2">
-			<select name="category" class="select select-xs select-bordered flex-1">
+		<div class="grid grid-cols-[1fr_auto] gap-2">
+			<select name="category" class="select select-xs select-bordered w-full">
 				for _, cat := range demo.AllCalendarCategories {
 					<option value={ string(cat) }>{ string(cat) }</option>
 				}

--- a/web/views/tavern_calendar_templ.go
+++ b/web/views/tavern_calendar_templ.go
@@ -482,7 +482,7 @@ func CalendarLabDay(day time.Time, events []demo.CalendarEvent, settings demo.Ca
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</p></div><div class=\"space-y-1 max-h-64 overflow-y-auto\" style=\"contain:paint\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</p></div><div class=\"space-y-1 max-h-64 overflow-y-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -664,7 +664,7 @@ func calLabAddEventForm(day time.Time) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\"><div class=\"form-control\"><input type=\"text\" name=\"title\" placeholder=\"Event title\" class=\"input input-xs input-bordered w-full\" required></div><div class=\"flex items-center gap-2\"><select name=\"category\" class=\"select select-xs select-bordered flex-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\"><div class=\"form-control\"><input type=\"text\" name=\"title\" placeholder=\"Event title\" class=\"input input-xs input-bordered w-full\" required></div><div class=\"grid grid-cols-[1fr_auto] gap-2\"><select name=\"category\" class=\"select select-xs select-bordered w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
The category \`<select>\` in the Calendar Lab day inspector was visually clipped by a nearby \`contain:paint\` on the scrollable event list.

## Changes

1. **Removed \`contain:paint\`** from the day-events scroll wrapper — it was creating a stacking context that clipped the native select popup in the add-event form below.
2. **Switched the select/button row from \`flex\` to \`grid grid-cols-[1fr_auto]\`** so the select gets stable width instead of being packed into a tight inline slot.

No custom dropdown, no JS, no z-index layering — just fixing the layout conflict.