### PR TITLE
fix: override card overflow-hidden on calendar lab day inspector

### DIFF
--- a/web/views/tavern_calendar.templ
+++ b/web/views/tavern_calendar.templ
@@ -72,7 +72,7 @@ templ TavernCalendarPage(data CalendarLabData) {
 
 				<!-- Right rail: day inspector + controls (4 cols) -->
 				<div class="lg:col-span-4 space-y-4">
-					<div id="cal-lab-day" class="card bg-base-200 shadow-sm">
+					<div id="cal-lab-day" class="card bg-base-200 shadow-sm overflow-visible">
 						if !data.MonthData.Selected.IsZero() {
 							@CalendarLabDay(data.MonthData.Selected, data.DayEvents, data.Settings)
 						} else {

--- a/web/views/tavern_calendar_templ.go
+++ b/web/views/tavern_calendar_templ.go
@@ -71,7 +71,7 @@ func TavernCalendarPage(data CalendarLabData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div></div></div></div><!-- Right rail: day inspector + controls (4 cols) --><div class=\"lg:col-span-4 space-y-4\"><div id=\"cal-lab-day\" class=\"card bg-base-200 shadow-sm\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div></div></div></div><!-- Right rail: day inspector + controls (4 cols) --><div class=\"lg:col-span-4 space-y-4\"><div id=\"cal-lab-day\" class=\"card bg-base-200 shadow-sm overflow-visible\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
DaisyUI's \`.card\` sets \`overflow: hidden\` for rounded-corner clipping, which clips the native \`<select>\` dropdown popup in the add-event form. Adding \`overflow-visible\` on the day inspector card lets the popup render outside the card bounds.

Follows up on #631 which fixed the \`contain:paint\` and layout issues but missed the card-level overflow.