### PR TITLE
feat: add Hell preset, raise density/burst/speed limits

### DIFF
--- a/internal/demo/calendar_lab.go
+++ b/internal/demo/calendar_lab.go
@@ -16,9 +16,9 @@ import (
 type CalendarLabSettings struct {
 	VisibleCategories map[CalendarEventCategory]bool
 	Assignee          string // "" = all
-	Density           int    // max events shown per day cell (1–8)
+	Density           int    // max events shown per day cell (1–12)
 	SimSpeed          int    // ms between ticks (100–5000)
-	BurstSize         int    // synthetic events per tick (1–5)
+	BurstSize         int    // synthetic events per tick (1–8)
 	CompactMode       bool
 	HighlightWeekends bool
 }
@@ -37,6 +37,7 @@ var CalendarLabPresets = []CalendarLabPreset{
 	{Name: "Steady", Density: 4, SimSpeed: 2000, BurstSize: 2},
 	{Name: "Busy", Density: 6, SimSpeed: 800, BurstSize: 3},
 	{Name: "Chaos", Density: 8, SimSpeed: 200, BurstSize: 5},
+	{Name: "Hell", Density: 12, SimSpeed: 100, BurstSize: 8},
 }
 
 // CalendarLabActivity records one simulator or user action for the activity log.

--- a/internal/routes/routes_tavern_calendar.go
+++ b/internal/routes/routes_tavern_calendar.go
@@ -238,13 +238,13 @@ func (r *tavernCalendarRoutes) handleDeleteEvent(c echo.Context) error {
 // hx-include="closest .card-body".
 func (r *tavernCalendarRoutes) handleControls(c echo.Context) error {
 	r.lab.UpdateSettings(func(s *demo.CalendarLabSettings) {
-		if v, err := strconv.Atoi(c.FormValue("density")); err == nil && v >= 1 && v <= 8 {
+		if v, err := strconv.Atoi(c.FormValue("density")); err == nil && v >= 1 && v <= 12 {
 			s.Density = v
 		}
-		if v, err := strconv.Atoi(c.FormValue("sim_speed")); err == nil && v >= 200 && v <= 5000 {
+		if v, err := strconv.Atoi(c.FormValue("sim_speed")); err == nil && v >= 100 && v <= 5000 {
 			s.SimSpeed = v
 		}
-		if v, err := strconv.Atoi(c.FormValue("burst_size")); err == nil && v >= 1 && v <= 5 {
+		if v, err := strconv.Atoi(c.FormValue("burst_size")); err == nil && v >= 1 && v <= 8 {
 			s.BurstSize = v
 		}
 		s.Assignee = c.FormValue("assignee")

--- a/web/views/tavern_calendar.templ
+++ b/web/views/tavern_calendar.templ
@@ -493,7 +493,7 @@ templ calendarLabControls(settings demo.CalendarLabSettings, paused bool) {
 					<span class="label-text-alt text-xs font-mono" id="cal-density-val">{ fmt.Sprintf("%d", settings.Density) }</span>
 				</label>
 				<input
-					type="range" min="1" max="8"
+					type="range" min="1" max="12"
 					value={ fmt.Sprintf("%d", settings.Density) }
 					class="range range-xs range-primary"
 					name="density"
@@ -512,7 +512,7 @@ templ calendarLabControls(settings demo.CalendarLabSettings, paused bool) {
 					<span class="label-text-alt text-xs font-mono" id="cal-speed-val">{ fmt.Sprintf("%dms", settings.SimSpeed) }</span>
 				</label>
 				<input
-					type="range" min="200" max="5000" step="200"
+					type="range" min="100" max="5000" step="100"
 					value={ fmt.Sprintf("%d", settings.SimSpeed) }
 					class="range range-xs range-secondary"
 					name="sim_speed"
@@ -531,7 +531,7 @@ templ calendarLabControls(settings demo.CalendarLabSettings, paused bool) {
 					<span class="label-text-alt text-xs font-mono" id="cal-burst-val">{ fmt.Sprintf("%d", settings.BurstSize) }</span>
 				</label>
 				<input
-					type="range" min="1" max="5"
+					type="range" min="1" max="8"
 					value={ fmt.Sprintf("%d", settings.BurstSize) }
 					class="range range-xs range-accent"
 					name="burst_size"

--- a/web/views/tavern_calendar_templ.go
+++ b/web/views/tavern_calendar_templ.go
@@ -1380,7 +1380,7 @@ func calendarLabControls(settings demo.CalendarLabSettings, paused bool) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "</span></label> <input type=\"range\" min=\"1\" max=\"8\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "</span></label> <input type=\"range\" min=\"1\" max=\"12\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1406,7 +1406,7 @@ func calendarLabControls(settings demo.CalendarLabSettings, paused bool) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</span></label> <input type=\"range\" min=\"200\" max=\"5000\" step=\"200\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</span></label> <input type=\"range\" min=\"100\" max=\"5000\" step=\"100\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1432,7 +1432,7 @@ func calendarLabControls(settings demo.CalendarLabSettings, paused bool) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "</span></label> <input type=\"range\" min=\"1\" max=\"5\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "</span></label> <input type=\"range\" min=\"1\" max=\"8\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Add `Hell` preset: density 12, speed 100ms, burst 8
- Raise server-side validation limits: density 1-12, sim speed 100-5000ms, burst 1-8
- Update UI sliders to match: density max=12, speed min=100 step=100, burst max=8
- Preset sequence: Calm → Steady → Busy → Chaos → Hell

## Test plan

- [ ] Apply Hell preset — sliders update to density 12, speed 100ms, burst 8
- [ ] Let simulator run at Hell — no swap errors, page remains interactive
- [ ] Day selection works under extreme churn
- [ ] Month nav works under extreme churn
- [ ] Compare Chaos vs Hell — Hell is materially more intense
- [ ] Density 12 renders sensibly in day cells (+N more overflow)