### PR TITLE
feat: lower sim speed floor to raw (1ms), step 50ms

### DIFF
--- a/internal/demo/calendar_lab.go
+++ b/internal/demo/calendar_lab.go
@@ -17,7 +17,7 @@ type CalendarLabSettings struct {
 	VisibleCategories map[CalendarEventCategory]bool
 	Assignee          string // "" = all
 	Density           int    // max events shown per day cell (1–12)
-	SimSpeed          int    // ms between ticks (100–5000)
+	SimSpeed          int    // ms between ticks (1–5000)
 	BurstSize         int    // synthetic events per tick (1–8)
 	CompactMode       bool
 	HighlightWeekends bool
@@ -37,7 +37,7 @@ var CalendarLabPresets = []CalendarLabPreset{
 	{Name: "Steady", Density: 4, SimSpeed: 2000, BurstSize: 2},
 	{Name: "Busy", Density: 6, SimSpeed: 800, BurstSize: 3},
 	{Name: "Chaos", Density: 8, SimSpeed: 200, BurstSize: 5},
-	{Name: "Hell", Density: 12, SimSpeed: 100, BurstSize: 8},
+	{Name: "Hell", Density: 12, SimSpeed: 50, BurstSize: 8},
 }
 
 // CalendarLabActivity records one simulator or user action for the activity log.

--- a/internal/routes/routes_tavern_calendar.go
+++ b/internal/routes/routes_tavern_calendar.go
@@ -241,7 +241,7 @@ func (r *tavernCalendarRoutes) handleControls(c echo.Context) error {
 		if v, err := strconv.Atoi(c.FormValue("density")); err == nil && v >= 1 && v <= 12 {
 			s.Density = v
 		}
-		if v, err := strconv.Atoi(c.FormValue("sim_speed")); err == nil && v >= 100 && v <= 5000 {
+		if v, err := strconv.Atoi(c.FormValue("sim_speed")); err == nil && v >= 1 && v <= 5000 {
 			s.SimSpeed = v
 		}
 		if v, err := strconv.Atoi(c.FormValue("burst_size")); err == nil && v >= 1 && v <= 8 {

--- a/web/views/tavern_calendar.templ
+++ b/web/views/tavern_calendar.templ
@@ -512,7 +512,7 @@ templ calendarLabControls(settings demo.CalendarLabSettings, paused bool) {
 					<span class="label-text-alt text-xs font-mono" id="cal-speed-val">{ fmt.Sprintf("%dms", settings.SimSpeed) }</span>
 				</label>
 				<input
-					type="range" min="100" max="5000" step="100"
+					type="range" min="1" max="5000" step="50"
 					value={ fmt.Sprintf("%d", settings.SimSpeed) }
 					class="range range-xs range-secondary"
 					name="sim_speed"

--- a/web/views/tavern_calendar_templ.go
+++ b/web/views/tavern_calendar_templ.go
@@ -1406,7 +1406,7 @@ func calendarLabControls(settings demo.CalendarLabSettings, paused bool) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</span></label> <input type=\"range\" min=\"100\" max=\"5000\" step=\"100\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</span></label> <input type=\"range\" min=\"1\" max=\"5000\" step=\"50\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Drop sim speed validation floor from 100ms to 1ms (raw)
- Slider: min=1, step=50 for practical increments
- Hell preset: 100ms → 50ms

## Test plan

- [ ] Slider reaches 1ms at the low end
- [ ] Hell preset sets speed to 50ms
- [ ] Page remains functional at extreme speeds