### PR TITLE
fix: sim speed slider step=1 for full granularity

### DIFF
--- a/web/views/tavern_calendar.templ
+++ b/web/views/tavern_calendar.templ
@@ -512,7 +512,7 @@ templ calendarLabControls(settings demo.CalendarLabSettings, paused bool) {
 					<span class="label-text-alt text-xs font-mono" id="cal-speed-val">{ fmt.Sprintf("%dms", settings.SimSpeed) }</span>
 				</label>
 				<input
-					type="range" min="1" max="5000" step="50"
+					type="range" min="1" max="5000" step="1"
 					value={ fmt.Sprintf("%d", settings.SimSpeed) }
 					class="range range-xs range-secondary"
 					name="sim_speed"

--- a/web/views/tavern_calendar_templ.go
+++ b/web/views/tavern_calendar_templ.go
@@ -1406,7 +1406,7 @@ func calendarLabControls(settings demo.CalendarLabSettings, paused bool) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</span></label> <input type=\"range\" min=\"1\" max=\"5000\" step=\"50\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</span></label> <input type=\"range\" min=\"1\" max=\"5000\" step=\"1\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Change sim speed slider from step=50 to step=1
- Step=50 with min=1 meant you could only hit 1, 51, 101... — values like 10 or 25 were unreachable

## Test plan

- [ ] Slider smoothly reaches any value from 1ms to 5000ms