### PR TITLE
fix: raise sim speed floor from 1ms to 10ms

### DIFF
--- a/internal/demo/calendar_lab.go
+++ b/internal/demo/calendar_lab.go
@@ -17,7 +17,7 @@ type CalendarLabSettings struct {
 	VisibleCategories map[CalendarEventCategory]bool
 	Assignee          string // "" = all
 	Density           int    // max events shown per day cell (1–12)
-	SimSpeed          int    // ms between ticks (1–5000)
+	SimSpeed          int    // ms between ticks (10–5000)
 	BurstSize         int    // synthetic events per tick (1–8)
 	CompactMode       bool
 	HighlightWeekends bool

--- a/internal/routes/routes_tavern_calendar.go
+++ b/internal/routes/routes_tavern_calendar.go
@@ -241,7 +241,7 @@ func (r *tavernCalendarRoutes) handleControls(c echo.Context) error {
 		if v, err := strconv.Atoi(c.FormValue("density")); err == nil && v >= 1 && v <= 12 {
 			s.Density = v
 		}
-		if v, err := strconv.Atoi(c.FormValue("sim_speed")); err == nil && v >= 1 && v <= 5000 {
+		if v, err := strconv.Atoi(c.FormValue("sim_speed")); err == nil && v >= 10 && v <= 5000 {
 			s.SimSpeed = v
 		}
 		if v, err := strconv.Atoi(c.FormValue("burst_size")); err == nil && v >= 1 && v <= 8 {

--- a/web/views/tavern_calendar.templ
+++ b/web/views/tavern_calendar.templ
@@ -512,7 +512,7 @@ templ calendarLabControls(settings demo.CalendarLabSettings, paused bool) {
 					<span class="label-text-alt text-xs font-mono" id="cal-speed-val">{ fmt.Sprintf("%dms", settings.SimSpeed) }</span>
 				</label>
 				<input
-					type="range" min="1" max="5000" step="1"
+					type="range" min="10" max="5000" step="1"
 					value={ fmt.Sprintf("%d", settings.SimSpeed) }
 					class="range range-xs range-secondary"
 					name="sim_speed"

--- a/web/views/tavern_calendar_templ.go
+++ b/web/views/tavern_calendar_templ.go
@@ -1406,7 +1406,7 @@ func calendarLabControls(settings demo.CalendarLabSettings, paused bool) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</span></label> <input type=\"range\" min=\"1\" max=\"5000\" step=\"1\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "</span></label> <input type=\"range\" min=\"10\" max=\"5000\" step=\"1\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Raise sim speed floor from 1ms to 10ms — 1ms causes slow subscriber eviction
- Server validation, slider min, and comment all updated to 10ms

## Test plan

- [ ] Slider stops at 10ms, cannot go lower
- [ ] 10ms is aggressive but doesn't evict subscribers