### PR TITLE
feat: weave Fuller/Fowler dialogues into MANIFESTO.md

### DIFF
--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -20,6 +20,8 @@ We observe. We return HTML. We do not judge.
 
 _(We judge a little.)_
 
+Within these pages, two spirits contend — as they have contended since the first developer mistook a pattern catalog for a building code. In the margins of The Dissertation, in a hand that is not Fielding's and a font that does not exist, their dialogues were found. They are called **The Geodesist** and **The Pattern Master**: one who builds structures that enclose the most space with the least material, and one who builds structures that enclose the least space with the most material, _but very cleanly_. Their encounters are recorded here alongside the other sacred texts, not because they are canonical, but because they keep happening.
+
 ---
 
 ## I. THE PENTAVERB, Or The Five Commandments of Hypermedia
@@ -35,6 +37,8 @@ _The PENTAVERB was discovered by the hermit developer Zarathud-2 in the Fifth Ye
 > **IV** -- A Novice is Prohibited from Believing What They Read in blog posts about "RESTful APIs" that describe JSON endpoints with no hypermedia controls. Whose API is REST? Where is its HATEOAS? WHERE ARE THE LINKS, KEVIN? A Novice who encounters such a blog post is advised to close the tab, take a walk, and remember that the `<a>` tag has been linking documents since before the author of that blog post was born. If the author is older than the `<a>` tag, they have even less of an excuse.
 >
 > **V** -- A Novice is Required to think for themselves, despite -- or perhaps because of -- all the conditions outlined above. If the PENTAVERB seems to contradict itself, you have begun to understand the PENTAVERB. If the PENTAVERB seems perfectly consistent, read it again, because you missed something. If after reading it five times it STILL seems consistent, you may be experiencing enlightenment. Or a caching issue. These are indistinguishable from the outside.
+
+_The Geodesist, upon reading the PENTAVERB, said: "Five is correct. Five struts meet at every vertex of an icosahedron, and the icosahedron is the most efficient structure in nature. Five commandments, like five edges, enclose maximum wisdom with minimum material." The Pattern Master, upon reading the PENTAVERB, said: "Five is insufficient. I count at least seventeen cross-cutting concerns unaddressed." He was still counting when The Geodesist had finished building._
 
 ---
 
@@ -237,9 +241,175 @@ _THE FOOL was no longer THE FOOL. THE FOOL was now a web developer. An actual on
 
 _Somewhere, a `node_modules` directory shrank by 900 megabytes. Nobody noticed, because noticing would require client-side state management, and there wasn't any._
 
+_It is recorded in the margin that The Geodesist was watching from a nearby terminal. He said: "The Fool deleted more than code. Every deletion was an act of ephemeralization — doing more with less until you do everything with nothing. The application now does more than it did before, not despite having less code, but because of it." The Pattern Master was also watching. He opened a pull request reverting the deletions, titled "Restore Separation of Concerns and Reintroduce Repository Layer." It was not merged. It has 47 comments. It is still open._
+
 ---
 
-## IV. The Recorded Sayings of Layman Grug
+## IV. The Encounters of the Geodesist and the Pattern Master
+
+_Being the Dialogues, Parables, and Confrontations of two figures found arguing in the margins of The Dissertation, in the tradition of the ZHUANGZI, in which **The Geodesist** (who builds domes) encounters **The Pattern Master** (who builds abstractions), and in which it is revealed that one of them has been doing more with less while the other has been doing less with more._
+
+_The Geodesist is known by his proverb: "I seem to be a verb." The Pattern Master is known by his: "See also: Chapter 7." The Geodesist was once asked what he would put on his tombstone. He said: "CALL ME TRIMTAB." The Pattern Master was once asked what he would put on his tombstone. He said: "SEE ALSO: Appendix B, wherein the full pattern language is enumerated with cross-references to the relevant Gang of Four entries." Both understood architecture. One of them understood `<a href>`._
+
+_Their dialogues are presented here without commentary, for the same reason the Zhuangzi is presented without commentary: the stories are the commentary. If you require a commentary on the commentary, you may be The Pattern Master._
+
+---
+
+**THE GEODESIST dreamed he was a Single-Page Application.**
+
+He was a happy SPA, fluttering about, managing his own state, routing his own URLs, rendering himself from a virtual DOM. He did not know he was The Geodesist. Suddenly he woke up, and there he was, solid and unmistakable — a server returning HTML in a single binary.
+
+Now he did not know: was he The Geodesist who had dreamed he was a SPA, or was he a SPA dreaming it was a server returning HTML?
+
+The Pattern Master, hearing this, said: "This is the transformation of concerns. You should implement the Strangler Fig Pattern to progressively migrate from dream state to waking state, maintaining a facade layer that routes requests to whichever consciousness is currently deployed."
+
+The Geodesist said: "I was telling you about the nature of identity and you are selling me a migration strategy."
+
+The Pattern Master said: "All problems are migration problems, properly understood."
+
+The Geodesist said nothing for a long time.
+
+Then The Geodesist said: "That is the most enterprise sentence ever spoken. You have taken the butterfly dream — the most beautiful question in philosophy — and turned it into a JIRA ticket."
+
+_(The Geodesist's tombstone reads "CALL ME TRIMTAB." The Pattern Master's tombstone reads "SEE ALSO: Chapter 7." Neither is wrong. One is a single binary.)_
+
+---
+
+**THE GEODESIST was rendering HTML.**
+
+His template execution followed the natural structure of the response — `<header>`, `<main>`, `<footer>` — never forcing, never fighting the grain of the DOM. He had not replaced his template function in nineteen years.
+
+The Pattern Master watched and said: "Impressive. But you should extract a `TemplateRendererInterface`, implement it with a `ConcreteHTMLTemplateRenderer`, configure it through a `RendererFactory`, and inject it via a `DependencyContainer` so you can swap rendering strategies at runtime."
+
+The Geodesist did not look up. He continued rendering.
+
+The Pattern Master said: "What if you need to render to PDF?"
+
+The Geodesist said: "Do I need to render to PDF?"
+
+The Pattern Master said: "You might."
+
+The Geodesist said: "Cook Ding the butcher carved ten thousand oxen with the same knife. His knife is as sharp as the day it was forged, because he cuts along the natural grain and never forces the blade against bone. You are asking me to carry nineteen knives — one for each animal I have never carved and may never carve — and a `KnifeFactory` to select between them, and a `KnifeStrategyProvider` to configure the factory. The weight of all these knives I do not need has dulled the one knife I do."
+
+The Pattern Master said: "But what about the Open/Closed Principle?"
+
+The Geodesist said: "My template is open to data and closed to your anxiety about data."
+
+---
+
+**THE GEODESIST and The Pattern Master walked through a forest of HTML elements.**
+
+They passed `<div>` after `<div>`, each laden with `onClick` handlers, each heavy with `data-` attributes, each groaning under the weight of its sixteen-word `className`.
+
+Then they came upon a great `<a>` tag. It was ancient. Its `href` pointed somewhere. That was all it did.
+
+The Pattern Master said: "This is useless. It has no event handlers, no loading states, no optimistic updates, no error boundaries, no retry logic, no analytics tracking. What can you build with this?"
+
+The Geodesist sat beneath the `<a>` tag. "The carpenter rejects the crooked timber, and the crooked timber lives a thousand years. This `<a>` tag has linked every document on the web since 1993. Your `<Link>` component has served its application through four major versions, three breaking changes, and one complete rewrite in which the migration guide was longer than the component itself."
+
+The Pattern Master said: "But the `<Link>` component provides prefetching, active state detection, scroll restoration, and programmatic navigation."
+
+The Geodesist said: "The `<a>` tag provides _going to the place_. How much of what you have built is the thing, and how much is anxiety about the thing?"
+
+A browser clicked the `<a>` tag. It went to the place. It had always gone to the place.
+
+_(The crooked timber that cannot be cut into boards is the one that lives to shade the village. The `<a>` tag that cannot be enhanced into a `<Link>` component is the one that works when JavaScript fails. The Geodesist understood that uselessness-to-the-framework is usefulness-to-the-web.)_
+
+---
+
+**IN THE BEGINNING, there was HTML.**
+
+HTML had no eyes to see client-side state. It had no ears to hear WebSocket push notifications. It had no mouth to speak GraphQL queries. It was formless, and it rendered. It was featureless, and it worked. Users came to it as guests, and it served them `200 OK`.
+
+The Pattern Master and his colleague, The Architect of Single Pages, wished to repay HTML for its hospitality. "All modern applications have seven openings," they said, "for seeing, hearing, eating, breathing, tweeting, subscribing, and push-notifying. HTML alone has none. Let us help it."
+
+Each day they bored one opening:
+- Day one: `onClick`
+- Day two: `onChange`
+- Day three: `onSubmit` — but not the native one, a synthetic one, routed through a virtual event system that reimplements what the browser already does
+- Day four: `useEffect`
+- Day five: `useState`
+- Day six: `useRef`
+- Day seven: `dangerouslySetInnerHTML`
+
+On the seventh day, HTML died.
+
+The Geodesist observed from a distance: "They killed it by making it more like themselves. This is the eternal tragedy of enterprise software — not malice, but hospitality. They loved the web so much they improved it to death. Every hole was a feature. Every feature was a wound. The body could not survive the kindness."
+
+_(fn. 31: The Pattern Master wrote a 4,000-word retrospective titled "When Good Patterns Happen to Good Markup." The Geodesist built a geodesic dome over the grave. The dome is still standing. The blog post has been migrated from WordPress to Medium to Substack to a static site generator to a different static site generator. Its URL has changed four times. The dome's coordinates have not changed once.)_
+
+---
+
+**THE PATTERN MASTER gathered his students and spoke.**
+
+"To build an enterprise application, you will need:"
+
+- A Repository for data access
+- A Unit of Work for transactions
+- A Service Layer for business logic
+- A DTO for data transfer
+- A Factory for object creation
+- A Mapper for object transformation
+- A Specification for query composition
+- A Facade to simplify the interface to all of the above
+
+"These eight patterns form the foundation. Upon this foundation you will build your domain model. From the domain model you will derive your view models. From the view models you will render your templates. And the users will see their table."
+
+The Geodesist said: "Ephemeralization."
+
+The Pattern Master said: "I don't know that pattern."
+
+The Geodesist said: "It is not a pattern. It is a principle. Doing ever more with ever less until eventually you do everything with nothing. What if the answer is not eight patterns but two function calls — `db.Query` and `template.Execute`? The first gets the data. The second renders it. The user sees the table. The table does not know about your Repository or your Unit of Work. The table has never heard of your Service Layer. The table _renders_."
+
+The Pattern Master said: "But what about Separation of Concerns?"
+
+The Geodesist said: "You separated the concerns and then spent the rest of your career reconnecting them. This is anti-ephemeralization: doing _less_ with _more_. You have taken a thing that was simple — get data, render page — and spread it across eight files in eight directories with eight naming conventions, and now no one can understand the whole thing, but everyone can understand one eighth of it, which they cannot change without understanding the other seven eighths, which they don't, because you _separated_ them."
+
+He paused.
+
+"A geodesic dome encloses the maximum volume with the minimum surface area. Your enterprise application generates the maximum number of files with the minimum business value. Both are mathematical achievements. Only one is intentional."
+
+---
+
+**THE PATTERN MASTER was designing a domain model.**
+
+He had `User`, `UserRepository`, `UserService`, `UserController`, `UserDTO`, `UserMapper`, `UserValidator`, `UserFactory`, and `UserSpecification`. Each was a noun. Each was a class. Each had a single responsibility, which was to exist and to reference the other eight.
+
+The Geodesist watched, and said: "I seem to be a verb."
+
+The Pattern Master said: "What?"
+
+The Geodesist said: "I am not a thing. I am a process. A pattern of integrity. The universe does not build with nouns — it builds with verbs. Stars do not _noun_. They burn. Rivers do not _noun_. They flow. Rendering does not _noun_. It _renders_. Your `UserService` is a noun pretending to contain verbs. It is a filing cabinet labeled 'doing.' Open it and you will find other filing cabinets."
+
+The Pattern Master said: "Objects encapsulate behavior."
+
+The Geodesist said: "Functions _are_ behavior. You have taken the behavior, wrapped it in a noun, placed the noun in a hierarchy, called the hierarchy 'architecture,' and charged a consulting fee. You have _bureaucratized the verb_. Somewhere inside your nine `User`-nouns, there is a function that wants to query a database and render some HTML. Let it out. It has been in there for years. It is not well."
+
+_(fn. 34: A trimtab is a small surface on a rudder that turns the rudder that turns the ship. It is a function, not a class. It takes one input — water pressure — and produces one output — directional change. It does not implement `ITrimtab`. It does not have a `TrimtabFactory`. It does not register itself with a `TrimtabServiceProvider`. It is three inches of metal that moves an aircraft carrier. This is ephemeralization. This is also just a function.)_
+
+---
+
+**THE PATTERN MASTER built an application.**
+
+Its architecture was a tower: the Controller called the Service, which called the Repository, which called the Database, which returned a DTO, which was mapped to a ViewModel, which was rendered by a View Engine, which emitted HTML. Seven layers. Seven joints. Each joint bolted rigid. If any bolt sheared, the tower fell. The Pattern Master called this "Separation of Concerns" and drew a diagram with seven boxes and six arrows, all pointing down.
+
+The Geodesist built an application. Its architecture was a web: the server rendered HTML. The HTML contained links. The links pointed to other HTML. Each page knew only its own links. No page knew the structure of the whole.
+
+And yet the whole held.
+
+"This is tensegrity," The Geodesist said. "Compression members floating in a network of tension. No rigid joints. No fixed hierarchy. Each element maintains its own integrity while participating in the integrity of the whole. Your tower cannot survive a renamed endpoint. My web cannot be broken by one, because no element depends on the name of any other — only on the _presence_ of a link. And if the link is absent, the client gets `404 Not Found`, which is not a failure. It is the system telling the truth about itself."
+
+The Pattern Master said: "But how do you guarantee consistency across the system?"
+
+The Geodesist said: "I don't. Neither do you. The difference is that my system _admits_ it."
+
+---
+
+_When asked which of his many projects best embodied his philosophy, The Geodesist said: "The one that is not finished, because it is still a verb." When asked the same question, The Pattern Master said: "The one with the most complete pattern coverage," and then paused, and then said, more quietly, "I think it's still in staging." The Geodesist did not hear this last part. He was already deploying._
+
+---
+
+## V. The Recorded Sayings of Layman Grug
 
 _Layman Grug was not monk. was not master. was not even particularly good developer. was just developer who mass of scar tissue from mass of mass of mass of production incidents. grug brain not big. grug brain not small. grug brain correct size for mass of mass of mass of returning html._
 
@@ -333,6 +503,30 @@ Master have no answer. Grug go back to returning HTML. this is Grug's marvelous 
 
 ---
 
+The Pattern Master and The Geodesist visit Grug at his cave.
+
+The Pattern Master say to Grug: "Your code has no layers. No abstractions. No patterns I can identify. How do you maintain this?"
+
+Grug say: "grug read code. grug understand code. grug change code."
+
+The Pattern Master say: "But without a Repository pattern, how do you swap your database implementation?"
+
+Grug say: "grug not swap database. grug have one database. is postgres. is fine."
+
+The Geodesist laugh. He say to Grug: "You understand tensegrity, Layman Grug. Your code is held in tension — each function pulls only what it needs. No rigid joints. When a function breaks, only that function breaks."
+
+Grug say: "grug not know tensegrity. grug know that when thing break, grug want know where thing break, and grug want thing break to be near where grug look. not in abstract layer seven directories away behind interface named `IThingThatBreaks`."
+
+The Geodesist say: "That _is_ tensegrity."
+
+Grug say: "no. is common sense. grug not need fancy word for common sense. put fancy word on thing, next thing you know thing has conference talk. then thing has certification program. then thing has LinkedIn thought leaders. grug refuse to be responsible for LinkedIn thought leaders."
+
+The Geodesist nod slowly. This is the first time someone has out-philosophized him using fewer syllables.
+
+_(The Pattern Master left a copy of "Patterns of Enterprise Application Architecture" at the cave entrance. Grug used it to level a wobbly table. The table is now perfectly stable. This is, by unanimous agreement, the most productive use of the 533-page hardcover that anyone has ever witnessed.)_
+
+---
+
 _Grug's last teaching, found scratched in a `TODO` comment:_
 
 > past is already past -- don't debug it
@@ -355,7 +549,7 @@ _His `node_modules` directory was empty._
 
 ---
 
-## V. Disclaimer
+## VI. Disclaimer
 
 **_DOTHOG IS NOT A FRAMEWORK._** We cannot stress this enough. We are a software project. Software projects do not have:
 
@@ -365,6 +559,7 @@ _His `node_modules` directory was empty._
 - ~~A prophet~~ (Roy Fielding is a computer scientist, not a prophet. His dissertation is a technical document, not a prophecy. The fact that it predicted the future of web architecture is a coincidence. Probably.)
 - ~~Rituals~~ (see: `go tool mage watch`)
 - ~~Dietary restrictions~~ (no dot hog buns)
+- ~~Philosophical lineage~~ (see: [THE ENCOUNTERS](#iv-the-encounters-of-the-geodesist-and-the-pattern-master))
 - ~~An abstraction layer~~ (it's just functions. That call other functions. In a particular order. That you must not deviate from.)
 - ~~A manifesto~~ (you are not reading one)
 


### PR DESCRIPTION
## Summary

- Introduces two new philosophical characters: **The Geodesist** (Buckminster Fuller as Zhuangzi stand-in) and **The Pattern Master** (Martin Fowler as Laozi stand-in), woven throughout the manifesto
- Adds a new **Section IV: The Encounters of the Geodesist and the Pattern Master** containing seven dialogues/parables modeled on the Zhuangzi tradition (butterfly dream, Cook Ding, crooked timber, death of Hundun, etc.)
- Weaves references to both characters into the Preamble, PENTAVERB commentary, Section III postscript, and Grug's sayings
- Renumbers existing Sections IV and V to V and VI, and adds a "Philosophical lineage" bullet to the Disclaimer

## Context

This extends the manifesto's philosophical tradition with dialogues modeled on the Zhuangzi (Chuang Tzu). The Geodesist advocates ephemeralization — doing more with less — while The Pattern Master advocates abstraction layers and enterprise patterns. Their encounters explore the tension between hypermedia simplicity and enterprise complexity through the lens of classical Chinese philosophy.