### PR TITLE
fix: align HAL docs with actual route-based implementation

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -280,13 +280,15 @@ The key constraint: every resource must be reachable without JavaScript. Links a
 
 ### HAL: Content Negotiation for APIs
 
-Content negotiation extends beyond the HTML/fragment split. The same resource graph can serve `application/hal+json` — [HAL](https://datatracker.ietf.org/doc/html/draft-kelly-json-hal) adds `_links` and `_embedded` to JSON, giving API clients navigable relationships without out-of-band URL construction. A browser sees HTML with HTMX controls. A `curl` user sees HAL+JSON with link relations. Same resource, same relationships, different media type.
+Content negotiation extends beyond the HTML/fragment split. [HAL](https://datatracker.ietf.org/doc/html/draft-kelly-json-hal) (`application/hal+json`) adds `_links` and `_embedded` to JSON, giving API clients navigable relationships without out-of-band URL construction. In the ideal model, a browser sees HTML with HTMX controls and a `curl` user sees HAL+JSON with link relations — same resource, same URL, different media type.
 
-HAL gives JSON what `<a>` tags give HTML. It does not give JSON what `<form>` tags give HTML — and that gap is where the interesting architectural questions live. The `/hypermedia/hal` demo renders both representations side by side so the gap is visible. See [docs/HAL.md](docs/HAL.md) for the full Socratic inquiry into what HAL provides, what it doesn't, and what Fielding would say about both.
+The current `/api/hal` demo does not yet implement same-URL negotiation. The HTML page and the HAL+JSON endpoints live at separate routes (`/api/hal` for the page, `/api/hal/api/...` for the JSON resources). This teaches HAL structure and link traversal, but the representation selection is route-based rather than `Accept`-header-based. True content negotiation — where a single URL serves HTML or HAL+JSON depending on the client's `Accept` header — is the architectural goal described above; the demo is an incremental step toward it.
+
+HAL gives JSON what `<a>` tags give HTML. It does not give JSON what `<form>` tags give HTML — and that gap is where the interesting architectural questions live. See [docs/HAL.md](docs/HAL.md) for the full Socratic inquiry into what HAL provides, what it doesn't, and what Fielding would say about both.
 
 ### Accept Header: The Full Negotiation Mechanism
 
-The current architecture keys content negotiation off the `HX-Request` header (HTMX partials vs. full pages) and explicit `Accept: application/hal+json` (HAL responses). But the HTTP spec defines a richer negotiation vocabulary that the same pattern extends to naturally.
+The current architecture keys content negotiation off the `HX-Request` header (HTMX partials vs. full pages). The HAL demo serves `application/hal+json` from dedicated API routes rather than via `Accept`-header dispatch, but the HTTP spec defines a richer negotiation vocabulary that the same pattern extends to naturally.
 
 The `Accept` header supports quality factors: `Accept: text/html, application/hal+json;q=0.9, application/json;q=0.8` tells the server the client prefers HTML, will accept HAL, and will settle for plain JSON. The server picks the best match from what it can produce. This is how content negotiation was designed to work — the client declares capabilities, the server selects the optimal representation.
 

--- a/docs/HAL.md
+++ b/docs/HAL.md
@@ -172,7 +172,7 @@ This project — Dothog — uses HTML as its hypermedia format. HTMX extends HTM
 
 **If you are building a JSON API that other programs consume:** HAL is a meaningful improvement over bare JSON. Your API consumers discover URLs instead of hardcoding them. Your API can evolve its URL structure without breaking clients. Link relations carry semantic meaning via the IANA registry. This is real value. It is incomplete value — the client still needs out-of-band knowledge for mutations — but it is value.
 
-**If you are building both:** serve HTML to browsers, HAL+JSON to API clients, from the same resource. This is content negotiation. The browser gets `text/html` with full hypermedia controls. The API client gets `application/hal+json` with navigation links. Same resource, same relationships, different media types. The `/hypermedia/hal` demo shows exactly this — the same bookshop resource graph rendered as interactive HTML cards alongside the raw HAL+JSON.
+**If you are building both:** the architectural ideal is to serve HTML to browsers and HAL+JSON to API clients from the same URL, using `Accept`-header content negotiation. The browser gets `text/html` with full hypermedia controls. The API client gets `application/hal+json` with navigation links. Same resource, same relationships, different media types. The `/api/hal` demo does not yet implement this — the HTML page and HAL+JSON endpoints use separate route trees. But the demo renders the same bookshop resource graph as interactive HTML cards alongside the raw HAL+JSON, making the structural relationship between the two representations visible even though they are not yet served from the same URL.
 
 **THE NOVICE said: "So HAL is good enough?"**
 
@@ -262,11 +262,11 @@ Resource
 
 | Path | What It Does |
 |------|-------------|
-| `/hypermedia/hal` | Interactive HAL explorer — navigate a bookshop resource graph via HTMX |
-| `/hypermedia/hal/api/catalog` | HAL+JSON root resource |
-| `/hypermedia/hal/api/books` | HAL+JSON book collection with `_embedded` |
-| `/hypermedia/hal/api/books/:id` | HAL+JSON individual book with author link |
-| `/hypermedia/hal/api/authors/:id` | HAL+JSON author with book links |
-| `/hypermedia/hal/explore?url=...` | HTMX fragment endpoint — renders any HAL resource as an interactive card |
+| `/api/hal` | Interactive HAL explorer — HTML page that navigates the bookshop resource graph via HTMX |
+| `/api/hal/api/catalog` | HAL+JSON root resource |
+| `/api/hal/api/books` | HAL+JSON book collection with `_embedded` |
+| `/api/hal/api/books/:id` | HAL+JSON individual book with author link |
+| `/api/hal/api/authors/:id` | HAL+JSON author with book links |
+| `/api/hal/explore?url=...` | HTMX fragment endpoint — renders any HAL resource as an interactive card |
 
-The explorer fetches HAL+JSON from the API endpoints and renders it as interactive HTML alongside the raw JSON. Every `_link` becomes a clickable button that navigates to the target resource. Every `_embedded` resource becomes an expandable card. The dual view makes the relationship between HAL and HTML visible: same data, same relationships, different affordances.
+Note: The HTML page (`/api/hal`) and the HAL+JSON endpoints (`/api/hal/api/...`) use separate route trees. Representation selection is route-based, not `Accept`-header-based. The explorer fetches HAL+JSON from the API endpoints and renders it as interactive HTML alongside the raw JSON. Every `_link` becomes a clickable button that navigates to the target resource. Every `_embedded` resource becomes an expandable card. The dual view makes the structural relationship between HAL and HTML visible — same data, same relationships, different affordances — even though they are served from different URLs.

--- a/web/views/hypermedia_hal.templ
+++ b/web/views/hypermedia_hal.templ
@@ -78,7 +78,7 @@ templ HALPage(rawJSON string, resource HALResourceView) {
 				"URI Templates (RFC 6570) allow parameterized links. The explorer detects these and shows an input field.")
 			@halPatternCard("Content Negotiation",
 				"Accept: application/hal+json",
-				"The same endpoints serve HAL+JSON to API clients. The explorer uses HTMX to render them as HTML fragments.")
+				"The HAL+JSON endpoints live under /api/hal/api/... while this page lives at /api/hal. The explorer fetches the JSON and renders it as HTML fragments — route-based separation, not yet same-URL Accept-header negotiation.")
 		</div>
 	</div>
 }

--- a/web/views/hypermedia_hal_templ.go
+++ b/web/views/hypermedia_hal_templ.go
@@ -102,7 +102,7 @@ func HALPage(rawJSON string, resource HALResourceView) templ.Component {
 		}
 		templ_7745c5c3_Err = halPatternCard("Content Negotiation",
 			"Accept: application/hal+json",
-			"The same endpoints serve HAL+JSON to API clients. The explorer uses HTMX to render them as HTML fragments.").Render(ctx, templ_7745c5c3_Buffer)
+			"The HAL+JSON endpoints live under /api/hal/api/... while this page lives at /api/hal. The explorer fetches the JSON and renders it as HTML fragments — route-based separation, not yet same-URL Accept-header negotiation.").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- PHILOSOPHY.md claimed same-URL Accept-header content negotiation for the HAL demo, but the demo uses separate route trees (`/api/hal` for HTML, `/api/hal/api/...` for HAL+JSON)
- Rewrote the "HAL: Content Negotiation for APIs" section and "Accept Header" section in PHILOSOPHY.md to describe the current route-based implementation honestly, while noting true content negotiation as the architectural goal
- Updated docs/HAL.md "If you are building both" paragraph and "In This Project" route table to match reality
- Updated the Content Negotiation pattern card in `web/views/hypermedia_hal.templ` to describe route-based separation instead of claiming same-URL negotiation

## Test plan
- Read the updated PHILOSOPHY.md section (around line 281-289) and confirm it accurately describes the demo's route-based approach
- Read the updated docs/HAL.md and confirm the route table paths match the actual routes in `internal/routes/routes_hal.go`
- Verify `go build ./...` passes (confirmed)
- Verify `mage lint` passes with no new issues (confirmed — golangci-lint: 0 issues)

Closes #680