### PR TITLE
fix: resolve CI fieldalignment and e2e strict mode failures

### DIFF
--- a/e2e/inventory.spec.ts
+++ b/e2e/inventory.spec.ts
@@ -59,7 +59,7 @@ test.describe("Inventory Page", () => {
     await addBtn.click();
     await waitForHtmx(page);
     // A new row or form should appear
-    const newRow = page.locator("#new-item-row, [id*=new-item]");
+    const newRow = page.locator("#new-item-row").first();
     await expect(newRow).toBeVisible();
   });
 

--- a/internal/demo/hotzone_lab.go
+++ b/internal/demo/hotzone_lab.go
@@ -20,8 +20,8 @@ const (
 
 // HotZoneCell represents one cell in a region's text grid.
 type HotZoneCell struct {
-	Glyph    string
-	Palette  int // index into the color palette (0–7)
+	Glyph   string
+	Palette int // index into the color palette (0–7)
 }
 
 // HotZoneRegion is a single independently-updating UI region.
@@ -73,23 +73,22 @@ type HotZoneSettings struct {
 	Preset           HotZonePreset
 	CommandMode      HotZoneMode
 	SwapScope        HotZoneSwapScope
-	UpdateIntervalMS int // ms between ticks (25–5000)
-	RegionCount      int // 1–64
-	GridSize         int // N for NxN grid (2–16)
-	FocusedRegion    int // 0 = random, 1–64 = focused
-	JitterMinMS      int // 0–2000
-	JitterMaxMS      int // 0–5000
+	HeatBaseColor    string
+	HeatColor3       string
+	HeatColor2       string
+	HeatColor1       string
+	JitterMaxMS      int
+	JitterMinMS      int
+	HeatWindowMS     int
+	HeatThreshold1   int
+	HeatThreshold2   int
+	HeatThreshold3   int
+	FocusedRegion    int
+	GridSize         int
+	RegionCount      int
+	UpdateIntervalMS int
 	BurstMode        bool
-	// Heat-map visualization (client-side).
-	HeatEnabled    bool
-	HeatWindowMS   int
-	HeatThreshold1 int
-	HeatThreshold2 int
-	HeatThreshold3 int
-	HeatColor1     string
-	HeatColor2     string
-	HeatColor3     string
-	HeatBaseColor  string
+	HeatEnabled      bool
 }
 
 // DefaultHeatSettings returns sensible heat-map defaults.

--- a/internal/routes/routes_tavern_failures.go
+++ b/internal/routes/routes_tavern_failures.go
@@ -21,9 +21,9 @@ const (
 )
 
 type failuresRoutes struct {
-	broker    *tavern.SSEBroker
-	counter   atomic.Int64
-	latestID  atomic.Value // stores string — most recently published event ID
+	latestID atomic.Value
+	broker   *tavern.SSEBroker
+	counter  atomic.Int64
 }
 
 func (ar *appRoutes) initFailuresRoutes(broker *tavern.SSEBroker) {


### PR DESCRIPTION
## Summary
- Reorder struct fields in `HotZoneSettings`, `HotZoneLab`, and `failuresRoutes` to satisfy `fieldalignment` lint (reduces GC pointer scan bytes)
- Fix e2e inventory test strict mode violation by using `page.locator("#new-item-row").first()` to handle HTMX swap transition overlap

## Test plan
- `fieldalignment ./internal/demo/... ./internal/routes/...` produces no output
- `go build ./...` compiles cleanly
- `mage lint` passes (fieldalignment, golangci-lint, oxlint all clean)
- e2e inventory spec no longer fails on strict mode with dual-element swap transitions