### PR TITLE
fix: make TestHotZoneLab_CellCount deterministic

### DIFF
--- a/internal/demo/hotzone_lab_test.go
+++ b/internal/demo/hotzone_lab_test.go
@@ -66,14 +66,11 @@ func TestHotZoneLab_CellCount(t *testing.T) {
 	lab := NewHotZoneLab()
 	lab.UpdateSettings(func(s *HotZoneSettings) {
 		s.GridSize = 4
+		s.BurstMode = true
 	})
 	lab.SimTick()
 	r := lab.Region(1)
-	// After a tick with GridSize=4, cells should be 4*4=16.
-	if len(r.Cells) > 0 {
-		// The region was updated by SimTick.
-		assert.Len(t, r.Cells, 16)
-	}
+	assert.Len(t, r.Cells, 16)
 }
 
 func TestHotZoneLab_ToggleLock(t *testing.T) {


### PR DESCRIPTION
## Summary
- Enable `BurstMode` in `TestHotZoneLab_CellCount` so `SimTick` updates all regions deterministically instead of picking one at random (~25% pass rate)
- Remove the `if len(r.Cells) > 0` guard that silently skipped the assertion when region 1 wasn't selected

## Test plan
- Ran `go test ./internal/demo/... -count=100 -run TestHotZoneLab_CellCount` — all 100 iterations pass