### PR TITLE
fix: run go mod vendor after tidy in setup to keep vendor in sync

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -475,6 +475,18 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		return fmt.Errorf("go mod tidy: %w", err)
 	}
 
+	// Re-vendor if the project uses a vendor directory so modules.txt
+	// stays consistent with the rewritten go.mod.
+	if _, err := os.Stat(filepath.Join(dir, "vendor")); err == nil {
+		vendorCmd := exec.CommandContext(ctx, "go", "mod", "vendor")
+		vendorCmd.Dir = absDir
+		vendorCmd.Stdout = os.Stdout
+		vendorCmd.Stderr = os.Stderr
+		if err := vendorCmd.Run(); err != nil {
+			return fmt.Errorf("go mod vendor: %w", err)
+		}
+	}
+
 	// Failsafe: install npm dependencies if node_modules is missing
 	if _, err := os.Stat(filepath.Join(dir, "node_modules")); os.IsNotExist(err) {
 		if _, err := os.Stat(filepath.Join(dir, "package-lock.json")); err == nil {


### PR DESCRIPTION
## Summary
- The setup process rewrites go.mod with a new module path but only ran `go mod tidy`, leaving `vendor/modules.txt` inconsistent with the rewritten go.mod
- Added `go mod vendor` step after `go mod tidy` in `setup.Run`, gated on the vendor directory existing
- Fixes CI integration test failures (`TestSetup_FeaturesDemoWithoutSSE`, etc.) that reported "is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod"

## Test plan
- [x] `go build -mod=vendor ./...` passes
- [x] `TestSetup_FeaturesDemoWithoutSSE` passes locally (previously failed with vendor inconsistency)
- [x] `mage lint` passes