### PR TITLE
fix: remove redundant go mod vendor from test helper

### DIFF
--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -292,17 +292,6 @@ func setupTempDir(t *testing.T) string {
 func assertBuildSucceeds(t *testing.T, dir string) {
 	t.Helper()
 
-	// Re-vendor after module rename so vendor/modules.txt stays consistent.
-	if _, err := os.Stat(filepath.Join(dir, "vendor")); err == nil {
-		ctxV, cancelV := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancelV()
-		cmdV := exec.CommandContext(ctxV, "go", "mod", "vendor")
-		cmdV.Dir = dir
-		cmdV.WaitDelay = 10 * time.Second
-		outV, errV := cmdV.CombinedOutput()
-		require.NoError(t, errV, "go mod vendor failed: %s", string(outV))
-	}
-
 	// Regenerate templ files after feature stripping removed gated code.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Remove the redundant `go mod vendor` call from `assertBuildSucceeds` in `tests/setup_test.go`
- `setup.Run()` already runs `go mod vendor` after tidy (added in #689), so the extra call in the test helper is unnecessary
- The duplicate vendor step causes CI OOM kills on `TestSetup_FeaturesAll` and `TestSetup_NoDothogReferences` due to excessive time/memory consumption

## Test plan
- CI integration tests (`TestSetup_FeaturesAll`, `TestSetup_NoDothogReferences`) should complete without `signal: killed` or `context deadline exceeded`
- `go vet ./tests/...` passes locally