### PR TITLE
feat: inline-full error panel size variants and full-page theme fix

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -876,7 +876,7 @@ There are four error rendering surfaces. Recovery scope should match render scop
 
 - **`banner`** — page-global contextual error delivered via OOB swap. Does not own layout; the user stays on their current page.
 - **`inline`** — compact local error within a container, rendered near the trigger element. No page navigation, no lost state.
-- **`inline-full`** — container-owning error for panels and embedded regions. Fills the entire container with a centered error display, like a full-page error scoped to a sub-region (e.g., a rate-limited calendar preview).
+- **`inline-full`** — container-owning error for panels and embedded regions. Fills the entire container with a centered error display, like a full-page error scoped to a sub-region (e.g., a rate-limited calendar preview). Comes in **sm/md/lg** size variants (`InlineFullErrorPanel(ec, size)`) chosen by the container owner to match the replaced content's density.
 - **`full-page`** — document-level blocking/failure state. Standalone HTML page with composable action row via `ErrorPageShell` + `ErrorPageContent` children.
 
 The composable primitives (`ErrorPageShell`, `ErrorPageContent`, `ErrorPageHeader`, `ErrorPageDetails`) support slotted action rows so each full-page error can carry its own recovery controls — "Go Home" for 404, "Go Back + Retry" for 429, "Go Home + Report Issue" for 500.

--- a/internal/routes/routes_hypermedia_error_modes.go
+++ b/internal/routes/routes_hypermedia_error_modes.go
@@ -4,6 +4,7 @@ package routes
 
 import (
 	"catgoose/dothog/internal/routes/handler"
+	"catgoose/dothog/internal/session"
 	"catgoose/dothog/web/views"
 
 	"github.com/labstack/echo/v4"
@@ -21,12 +22,26 @@ func (ar *appRoutes) initErrorModesRoutes() {
 
 	// Full-page error demos with different action rows.
 	ar.e.GET(base+"/full-page/404", func(c echo.Context) error {
-		return handler.RenderComponent(c, views.ErrorModes404())
+		theme := session.GetSettings(c.Request()).Theme
+		return handler.RenderComponent(c, views.ErrorModes404(theme))
 	})
 	ar.e.GET(base+"/full-page/429", func(c echo.Context) error {
-		return handler.RenderComponent(c, views.ErrorModes429())
+		theme := session.GetSettings(c.Request()).Theme
+		return handler.RenderComponent(c, views.ErrorModes429(theme))
 	})
 	ar.e.GET(base+"/full-page/500", func(c echo.Context) error {
-		return handler.RenderComponent(c, views.ErrorModes500())
+		theme := session.GetSettings(c.Request()).Theme
+		return handler.RenderComponent(c, views.ErrorModes500(theme))
+	})
+
+	// Inline-full error demo triggers — return sized InlineFullErrorPanel.
+	ar.e.GET(base+"/inline-full/sm", func(c echo.Context) error {
+		return handler.RenderComponent(c, views.ErrorModesInlineFullResult("sm"))
+	})
+	ar.e.GET(base+"/inline-full/md", func(c echo.Context) error {
+		return handler.RenderComponent(c, views.ErrorModesInlineFullResult("md"))
+	})
+	ar.e.GET(base+"/inline-full/lg", func(c echo.Context) error {
+		return handler.RenderComponent(c, views.ErrorModesInlineFullResult("lg"))
 	})
 }

--- a/web/components/core/error_status.templ
+++ b/web/components/core/error_status.templ
@@ -234,6 +234,157 @@ templ inlineErrorActions(controls []linkwell.Control) {
 	</div>
 }
 
+// InlineFullErrorPanel renders a container-owning error that fills its parent.
+// Size must be "sm", "md", or "lg" and controls text size, padding, and layout density.
+templ InlineFullErrorPanel(ec linkwell.ErrorContext, size string) {
+	switch size {
+		case "sm":
+			@inlineFullSM(ec)
+		case "lg":
+			@inlineFullLG(ec)
+		default:
+			@inlineFullMD(ec)
+	}
+}
+
+// inlineFullSM renders a compact inline-full error: small text, tight padding, single-row actions.
+templ inlineFullSM(ec linkwell.ErrorContext) {
+	<div class="flex flex-col items-center justify-center h-full min-h-[80px] bg-error/5 border border-error/20 rounded-lg p-2 text-center">
+		<p class="text-xs font-semibold text-error">
+			<span class="badge badge-xs badge-error badge-outline mr-1">{ strconv.Itoa(ec.StatusCode) }</span>
+			{ ec.Message }
+		</p>
+		if ec.Err != nil {
+			<p class="text-xs text-base-content/60 mt-0.5">{ ec.Err.Error() }</p>
+		}
+		<div class="flex items-center gap-1.5 mt-1.5">
+			if dismiss, ok := inlineDismissControl(ec.Controls); ok {
+				<button
+					class="btn btn-xs border-error/20 bg-error/10 text-error hover:bg-error/20"
+					x-data="dismissError"
+					x-on:click="dismiss()"
+				>
+					{ dismiss.Label }
+				</button>
+			}
+			for _, ctrl := range inlineActionControls(ec.Controls) {
+				<button
+					{ hxAttrsFromControl(ctrl)... }
+					class="btn btn-xs border-error/20 bg-error/10 text-error hover:bg-error/20"
+					disabled?={ ctrl.Disabled }
+				>
+					{ ctrl.Label }
+				</button>
+			}
+			if report, ok := inlineReportControl(ec.Controls); ok {
+				<button
+					{ hxAttrsFromControl(report)... }
+					class="btn btn-xs border-error/20 bg-error/10 text-error hover:bg-error/20"
+				>
+					{ report.Label }
+				</button>
+			}
+		</div>
+	</div>
+}
+
+// inlineFullMD renders the standard inline-full error: moderate text, two-row actions.
+templ inlineFullMD(ec linkwell.ErrorContext) {
+	<div class="flex flex-col items-center justify-center h-full min-h-[120px] bg-error/5 border border-error/20 rounded-lg p-3 text-center">
+		<p class="text-sm font-semibold text-error">
+			<span class="badge badge-sm badge-error badge-outline mr-1">{ strconv.Itoa(ec.StatusCode) }</span>
+			{ ec.Message }
+		</p>
+		if ec.Err != nil {
+			<p class="text-xs text-base-content/60 mt-1">{ ec.Err.Error() }</p>
+		}
+		if ec.Route != "" {
+			<p class="text-xs text-base-content/40 mt-0.5">Route: { ec.Route }</p>
+		}
+		<div class="flex items-center gap-2 mt-2">
+			if dismiss, ok := inlineDismissControl(ec.Controls); ok {
+				<button
+					class="btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20"
+					x-data="dismissError"
+					x-on:click="dismiss()"
+				>
+					{ dismiss.Label }
+				</button>
+			}
+			for _, ctrl := range inlineActionControls(ec.Controls) {
+				<button
+					{ hxAttrsFromControl(ctrl)... }
+					class="btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20"
+					disabled?={ ctrl.Disabled }
+				>
+					{ ctrl.Label }
+				</button>
+			}
+			if report, ok := inlineReportControl(ec.Controls); ok {
+				<button
+					{ hxAttrsFromControl(report)... }
+					class="btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20 gap-1"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"></path>
+					</svg>
+					{ report.Label }
+				</button>
+			}
+		</div>
+	</div>
+}
+
+// inlineFullLG renders a spacious inline-full error: large status display, generous padding, centered layout.
+templ inlineFullLG(ec linkwell.ErrorContext) {
+	<div class="flex flex-col items-center justify-center h-full min-h-[180px] bg-error/5 border border-error/20 rounded-lg p-6 text-center">
+		<p class="text-5xl font-black text-error/20 select-none leading-none">{ strconv.Itoa(ec.StatusCode) }</p>
+		<p class="text-base font-semibold text-error mt-1">{ ec.Message }</p>
+		if ec.Err != nil {
+			<p class="text-sm text-base-content/60 mt-1">{ ec.Err.Error() }</p>
+		}
+		if ec.Route != "" {
+			<p class="text-xs text-base-content/40 mt-0.5">Route: { ec.Route }</p>
+		}
+		if ec.RequestID != "" {
+			<p class="text-xs text-base-content/40">
+				Request ID: <code class="font-mono bg-base-200 px-1 py-0.5 rounded">{ ec.RequestID }</code>
+			</p>
+		}
+		<div class="flex items-center gap-2 mt-4">
+			if dismiss, ok := inlineDismissControl(ec.Controls); ok {
+				<button
+					class="btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20"
+					x-data="dismissError"
+					x-on:click="dismiss()"
+				>
+					{ dismiss.Label }
+				</button>
+			}
+			for _, ctrl := range inlineActionControls(ec.Controls) {
+				<button
+					{ hxAttrsFromControl(ctrl)... }
+					class="btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20"
+					disabled?={ ctrl.Disabled }
+				>
+					{ ctrl.Label }
+				</button>
+			}
+			if report, ok := inlineReportControl(ec.Controls); ok {
+				<button
+					{ hxAttrsFromControl(report)... }
+					class="btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20 gap-1"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"></path>
+					</svg>
+					{ report.Label }
+				</button>
+			}
+		</div>
+	</div>
+}
+
 // ErrorStatus is the backward-compatible wrapper. All existing call sites are unchanged.
 templ ErrorStatus(statusCode int, message string, err error, route string, requestID string, closable bool) {
 	@ErrorStatusFromContext(linkwell.ErrorContext{

--- a/web/components/core/error_status_templ.go
+++ b/web/components/core/error_status_templ.go
@@ -624,8 +624,9 @@ func inlineErrorActions(controls []linkwell.Control) templ.Component {
 	})
 }
 
-// ErrorStatus is the backward-compatible wrapper. All existing call sites are unchanged.
-func ErrorStatus(statusCode int, message string, err error, route string, requestID string, closable bool) templ.Component {
+// InlineFullErrorPanel renders a container-owning error that fills its parent.
+// Size must be "sm", "md", or "lg" and controls text size, padding, and layout density.
+func InlineFullErrorPanel(ec linkwell.ErrorContext, size string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -644,6 +645,604 @@ func ErrorStatus(statusCode int, message string, err error, route string, reques
 		templ_7745c5c3_Var21 := templ.GetChildren(ctx)
 		if templ_7745c5c3_Var21 == nil {
 			templ_7745c5c3_Var21 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		switch size {
+		case "sm":
+			templ_7745c5c3_Err = inlineFullSM(ec).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		case "lg":
+			templ_7745c5c3_Err = inlineFullLG(ec).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		default:
+			templ_7745c5c3_Err = inlineFullMD(ec).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		return nil
+	})
+}
+
+// inlineFullSM renders a compact inline-full error: small text, tight padding, single-row actions.
+func inlineFullSM(ec linkwell.ErrorContext) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var22 == nil {
+			templ_7745c5c3_Var22 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<div class=\"flex flex-col items-center justify-center h-full min-h-[80px] bg-error/5 border border-error/20 rounded-lg p-2 text-center\"><p class=\"text-xs font-semibold text-error\"><span class=\"badge badge-xs badge-error badge-outline mr-1\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(ec.StatusCode))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 254, Col: 92}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(ec.Message)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 255, Col: 15}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if ec.Err != nil {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<p class=\"text-xs text-base-content/60 mt-0.5\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(ec.Err.Error())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 258, Col: 66}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<div class=\"flex items-center gap-1.5 mt-1.5\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if dismiss, ok := inlineDismissControl(ec.Controls); ok {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<button class=\"btn btn-xs border-error/20 bg-error/10 text-error hover:bg-error/20\" x-data=\"dismissError\" x-on:click=\"dismiss()\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var26 string
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(dismiss.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 267, Col: 20}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</button> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		for _, ctrl := range inlineActionControls(ec.Controls) {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<button")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, hxAttrsFromControl(ctrl))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, " class=\"btn btn-xs border-error/20 bg-error/10 text-error hover:bg-error/20\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if ctrl.Disabled {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, " disabled")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(ctrl.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 276, Col: 17}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</button> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if report, ok := inlineReportControl(ec.Controls); ok {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<button")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, hxAttrsFromControl(report))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, " class=\"btn btn-xs border-error/20 bg-error/10 text-error hover:bg-error/20\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(report.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 284, Col: 19}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</button>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// inlineFullMD renders the standard inline-full error: moderate text, two-row actions.
+func inlineFullMD(ec linkwell.ErrorContext) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var29 == nil {
+			templ_7745c5c3_Var29 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<div class=\"flex flex-col items-center justify-center h-full min-h-[120px] bg-error/5 border border-error/20 rounded-lg p-3 text-center\"><p class=\"text-sm font-semibold text-error\"><span class=\"badge badge-sm badge-error badge-outline mr-1\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var30 string
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(ec.StatusCode))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 295, Col: 92}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</span> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var31 string
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(ec.Message)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 296, Col: 15}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if ec.Err != nil {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<p class=\"text-xs text-base-content/60 mt-1\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var32 string
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(ec.Err.Error())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 299, Col: 64}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if ec.Route != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<p class=\"text-xs text-base-content/40 mt-0.5\">Route: ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(ec.Route)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 302, Col: 67}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "<div class=\"flex items-center gap-2 mt-2\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if dismiss, ok := inlineDismissControl(ec.Controls); ok {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<button class=\"btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20\" x-data=\"dismissError\" x-on:click=\"dismiss()\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var34 string
+			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(dismiss.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 311, Col: 20}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</button> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		for _, ctrl := range inlineActionControls(ec.Controls) {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "<button")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, hxAttrsFromControl(ctrl))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, " class=\"btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if ctrl.Disabled {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, " disabled")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var35 string
+			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(ctrl.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 320, Col: 17}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</button> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if report, ok := inlineReportControl(ec.Controls); ok {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<button")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, hxAttrsFromControl(report))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, " class=\"btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20 gap-1\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-3.5 w-3.5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z\"></path></svg> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var36 string
+			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(report.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 331, Col: 19}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</button>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// inlineFullLG renders a spacious inline-full error: large status display, generous padding, centered layout.
+func inlineFullLG(ec linkwell.ErrorContext) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var37 == nil {
+			templ_7745c5c3_Var37 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<div class=\"flex flex-col items-center justify-center h-full min-h-[180px] bg-error/5 border border-error/20 rounded-lg p-6 text-center\"><p class=\"text-5xl font-black text-error/20 select-none leading-none\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var38 string
+		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(ec.StatusCode))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 341, Col: 101}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "</p><p class=\"text-base font-semibold text-error mt-1\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var39 string
+		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(ec.Message)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 342, Col: 65}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if ec.Err != nil {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "<p class=\"text-sm text-base-content/60 mt-1\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var40 string
+			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(ec.Err.Error())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 344, Col: 64}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if ec.Route != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<p class=\"text-xs text-base-content/40 mt-0.5\">Route: ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var41 string
+			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(ec.Route)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 347, Col: 67}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if ec.RequestID != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<p class=\"text-xs text-base-content/40\">Request ID: <code class=\"font-mono bg-base-200 px-1 py-0.5 rounded\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var42 string
+			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(ec.RequestID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 351, Col: 86}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</code></p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<div class=\"flex items-center gap-2 mt-4\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if dismiss, ok := inlineDismissControl(ec.Controls); ok {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<button class=\"btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20\" x-data=\"dismissError\" x-on:click=\"dismiss()\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var43 string
+			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(dismiss.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 361, Col: 20}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</button> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		for _, ctrl := range inlineActionControls(ec.Controls) {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<button")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, hxAttrsFromControl(ctrl))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, " class=\"btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if ctrl.Disabled {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, " disabled")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var44 string
+			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(ctrl.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 370, Col: 17}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "</button> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if report, ok := inlineReportControl(ec.Controls); ok {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "<button")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, hxAttrsFromControl(report))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, " class=\"btn btn-sm border-error/20 bg-error/10 text-error hover:bg-error/20 gap-1\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-3.5 w-3.5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z\"></path></svg> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var45 string
+			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(report.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/core/error_status.templ`, Line: 381, Col: 19}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "</button>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// ErrorStatus is the backward-compatible wrapper. All existing call sites are unchanged.
+func ErrorStatus(statusCode int, message string, err error, route string, requestID string, closable bool) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var46 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var46 == nil {
+			templ_7745c5c3_Var46 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = ErrorStatusFromContext(linkwell.ErrorContext{

--- a/web/views/error_modes.go
+++ b/web/views/error_modes.go
@@ -20,3 +20,17 @@ func errorModesInlineEC() linkwell.ErrorContext {
 		},
 	}
 }
+
+func errorModesInlineFullEC() linkwell.ErrorContext {
+	return linkwell.ErrorContext{
+		StatusCode: http.StatusTooManyRequests,
+		Message:    "Too Many Requests",
+		Err:        errors.New("rate limit exceeded for this panel"),
+		Route:      "/patterns/errors/modes/inline-full",
+		RequestID:  "req-demo-429-inline",
+		Closable:   true,
+		Controls: []linkwell.Control{
+			linkwell.DismissButton(linkwell.LabelDismiss),
+		},
+	}
+}

--- a/web/views/error_modes.templ
+++ b/web/views/error_modes.templ
@@ -84,18 +84,50 @@ templ ErrorModesPage() {
 			</div>
 		</div>
 
-		<!-- Inline-Full Mode (Placeholder) -->
-		<div class="card bg-base-100 shadow border border-base-300 border-dashed opacity-70">
+		<!-- Inline-Full Mode -->
+		<div class="card bg-base-100 shadow border border-base-300">
 			<div class="card-body p-4">
-				<h2 class="card-title text-base">
-					Inline-Full
-					<span class="badge badge-sm badge-ghost">planned</span>
-				</h2>
+				<h2 class="card-title text-base">Inline-Full</h2>
 				<p class="text-sm text-base-content/70 mb-3">
 					Container-owning error for panels and embedded regions. Fills the entire
 					container with a centered error display — like full-page but scoped to
-					a sub-region. Useful for embedded views like calendar previews under rate-limiting.
+					a sub-region. Comes in sm/md/lg size variants chosen by the container owner.
 				</p>
+				<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+					<!-- SM -->
+					<div>
+						<p class="text-xs font-semibold text-base-content/50 mb-1">Small (sm)</p>
+						<button
+							class="btn btn-xs btn-error btn-outline mb-2"
+							hx-get="/patterns/errors/modes/inline-full/sm"
+							hx-target="#errors-modes-inline-full-sm"
+							hx-swap="innerHTML"
+						>Trigger SM</button>
+						<div id="errors-modes-inline-full-sm" class="min-h-[80px] border border-base-300 rounded-lg"></div>
+					</div>
+					<!-- MD -->
+					<div>
+						<p class="text-xs font-semibold text-base-content/50 mb-1">Medium (md)</p>
+						<button
+							class="btn btn-xs btn-error btn-outline mb-2"
+							hx-get="/patterns/errors/modes/inline-full/md"
+							hx-target="#errors-modes-inline-full-md"
+							hx-swap="innerHTML"
+						>Trigger MD</button>
+						<div id="errors-modes-inline-full-md" class="min-h-[120px] border border-base-300 rounded-lg"></div>
+					</div>
+					<!-- LG -->
+					<div class="md:col-span-1">
+						<p class="text-xs font-semibold text-base-content/50 mb-1">Large (lg)</p>
+						<button
+							class="btn btn-xs btn-error btn-outline mb-2"
+							hx-get="/patterns/errors/modes/inline-full/lg"
+							hx-target="#errors-modes-inline-full-lg"
+							hx-swap="innerHTML"
+						>Trigger LG</button>
+						<div id="errors-modes-inline-full-lg" class="min-h-[180px] border border-base-300 rounded-lg"></div>
+					</div>
+				</div>
 			</div>
 		</div>
 
@@ -104,7 +136,7 @@ templ ErrorModesPage() {
 			@errorModeCard("Banner", "OOB swap to #error-status", "Page-global contextual error. Does not own layout. User stays on their current page.")
 			@errorModeCard("Inline", "hx-target on trigger", "Compact local error within a container. Replaces content near the trigger element.")
 			@errorModeCard("Full-Page", "Standalone HTML document", "Document-level blocking error. Owns the entire viewport with composable action row.")
-			@errorModeCard("Inline-Full", "Container fill (planned)", "Container-owning error for panels and embedded regions. Scoped full-page experience.")
+			@errorModeCard("Inline-Full", "Container fill (sm/md/lg)", "Container-owning error for panels and embedded regions. Size variant chosen by container owner.")
 		</div>
 	</div>
 }
@@ -125,8 +157,8 @@ templ ErrorModesInlineResult() {
 }
 
 // ErrorModes404 renders a standalone 404 full-page error with a "Go Home" action.
-templ ErrorModes404() {
-	@corecomponents.ErrorPageShell("Not Found", "") {
+templ ErrorModes404(theme string) {
+	@corecomponents.ErrorPageShell("Not Found", theme) {
 		@corecomponents.ErrorPageContent(404, "Not Found", "The page you requested does not exist.", "/patterns/errors/modes/full-page/404", "") {
 			<div class="flex items-center justify-center gap-3">
 				<a href="/" class="btn btn-primary btn-sm">Go Home</a>
@@ -136,8 +168,8 @@ templ ErrorModes404() {
 }
 
 // ErrorModes429 renders a standalone 429 full-page error with "Go Back" and "Retry" actions.
-templ ErrorModes429() {
-	@corecomponents.ErrorPageShell("Too Many Requests", "") {
+templ ErrorModes429(theme string) {
+	@corecomponents.ErrorPageShell("Too Many Requests", theme) {
 		@corecomponents.ErrorPageContent(429, "Too Many Requests", "Please wait a moment before trying again.", "/patterns/errors/modes/full-page/429", "") {
 			<div class="flex items-center justify-center gap-3">
 				<button class="btn btn-ghost btn-sm" onclick="history.back()">Go Back</button>
@@ -148,8 +180,8 @@ templ ErrorModes429() {
 }
 
 // ErrorModes500 renders a standalone 500 full-page error with "Go Home" and "Report Issue" actions.
-templ ErrorModes500() {
-	@corecomponents.ErrorPageShell("Internal Server Error", "") {
+templ ErrorModes500(theme string) {
+	@corecomponents.ErrorPageShell("Internal Server Error", theme) {
 		@corecomponents.ErrorPageContent(500, "Internal Server Error", "An unexpected error occurred while processing your request.", "/patterns/errors/modes/full-page/500", "req-demo-500-abc123") {
 			<div class="flex items-center justify-center gap-3">
 				<a href="/" class="btn btn-primary btn-sm">Go Home</a>
@@ -167,4 +199,9 @@ templ ErrorModes500() {
 			</div>
 		}
 	}
+}
+
+// ErrorModesInlineFullResult renders an inline-full error panel at the given size for the modes demo.
+templ ErrorModesInlineFullResult(size string) {
+	@corecomponents.InlineFullErrorPanel(errorModesInlineFullEC(), size)
 }

--- a/web/views/error_modes_templ.go
+++ b/web/views/error_modes_templ.go
@@ -36,7 +36,7 @@ func ErrorModesPage() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><h1 class=\"text-2xl font-bold mb-4\">Error Modes</h1><div role=\"alert\" class=\"alert alert-info text-sm\"><span>Demonstrates the four error rendering surfaces: <strong>banner</strong>, <strong>inline</strong>, <strong>full-page</strong>, and <strong>inline-full</strong> (placeholder). Recovery scope should match render scope.</span></div><!-- Banner Mode --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Banner</h2><p class=\"text-sm text-base-content/70 mb-3\">Page-global contextual error. Does not own layout — swaps OOB into <code class=\"text-xs bg-base-200 px-1 rounded\">#error-status</code>. The user stays on their current page.</p><div class=\"flex flex-wrap gap-2\"><button class=\"btn btn-sm btn-error btn-outline\" hx-get=\"/patterns/errors/trigger/500\" hx-target=\"#errors-modes-banner-result\" hx-swap=\"innerHTML\">Trigger 500 Banner</button></div><div id=\"errors-modes-banner-result\" class=\"mt-2\"></div></div></div><!-- Inline Mode --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Inline</h2><p class=\"text-sm text-base-content/70 mb-3\">Compact local error within a container. Replaces content in-place near the element that triggered the error. No page navigation, no lost state.</p><button class=\"btn btn-sm btn-error btn-outline\" hx-get=\"/patterns/errors/modes/inline\" hx-target=\"#errors-modes-inline-result\" hx-swap=\"innerHTML\">Trigger Inline Error</button><div id=\"errors-modes-inline-result\" class=\"mt-2\"></div></div></div><!-- Full-Page Mode --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Full-Page</h2><p class=\"text-sm text-base-content/70 mb-3\">Document-level blocking error state. Standalone HTML page with composable action row. Each example demonstrates a different set of recovery controls.</p><div class=\"flex flex-wrap gap-2\"><a href=\"/patterns/errors/modes/full-page/404\" class=\"btn btn-sm btn-primary btn-outline\" target=\"_blank\">404 — Go Home</a> <a href=\"/patterns/errors/modes/full-page/429\" class=\"btn btn-sm btn-warning btn-outline\" target=\"_blank\">429 — Go Back + Retry</a> <a href=\"/patterns/errors/modes/full-page/500\" class=\"btn btn-sm btn-error btn-outline\" target=\"_blank\">500 — Go Home + Report</a></div></div></div><!-- Inline-Full Mode (Placeholder) --><div class=\"card bg-base-100 shadow border border-base-300 border-dashed opacity-70\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Inline-Full <span class=\"badge badge-sm badge-ghost\">planned</span></h2><p class=\"text-sm text-base-content/70 mb-3\">Container-owning error for panels and embedded regions. Fills the entire container with a centered error display — like full-page but scoped to a sub-region. Useful for embedded views like calendar previews under rate-limiting.</p></div></div><!-- Taxonomy Summary --><div class=\"grid grid-cols-1 md:grid-cols-2 gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"p-4 space-y-6 max-w-4xl mx-auto\"><h1 class=\"text-2xl font-bold mb-4\">Error Modes</h1><div role=\"alert\" class=\"alert alert-info text-sm\"><span>Demonstrates the four error rendering surfaces: <strong>banner</strong>, <strong>inline</strong>, <strong>full-page</strong>, and <strong>inline-full</strong> (placeholder). Recovery scope should match render scope.</span></div><!-- Banner Mode --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Banner</h2><p class=\"text-sm text-base-content/70 mb-3\">Page-global contextual error. Does not own layout — swaps OOB into <code class=\"text-xs bg-base-200 px-1 rounded\">#error-status</code>. The user stays on their current page.</p><div class=\"flex flex-wrap gap-2\"><button class=\"btn btn-sm btn-error btn-outline\" hx-get=\"/patterns/errors/trigger/500\" hx-target=\"#errors-modes-banner-result\" hx-swap=\"innerHTML\">Trigger 500 Banner</button></div><div id=\"errors-modes-banner-result\" class=\"mt-2\"></div></div></div><!-- Inline Mode --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Inline</h2><p class=\"text-sm text-base-content/70 mb-3\">Compact local error within a container. Replaces content in-place near the element that triggered the error. No page navigation, no lost state.</p><button class=\"btn btn-sm btn-error btn-outline\" hx-get=\"/patterns/errors/modes/inline\" hx-target=\"#errors-modes-inline-result\" hx-swap=\"innerHTML\">Trigger Inline Error</button><div id=\"errors-modes-inline-result\" class=\"mt-2\"></div></div></div><!-- Full-Page Mode --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Full-Page</h2><p class=\"text-sm text-base-content/70 mb-3\">Document-level blocking error state. Standalone HTML page with composable action row. Each example demonstrates a different set of recovery controls.</p><div class=\"flex flex-wrap gap-2\"><a href=\"/patterns/errors/modes/full-page/404\" class=\"btn btn-sm btn-primary btn-outline\" target=\"_blank\">404 — Go Home</a> <a href=\"/patterns/errors/modes/full-page/429\" class=\"btn btn-sm btn-warning btn-outline\" target=\"_blank\">429 — Go Back + Retry</a> <a href=\"/patterns/errors/modes/full-page/500\" class=\"btn btn-sm btn-error btn-outline\" target=\"_blank\">500 — Go Home + Report</a></div></div></div><!-- Inline-Full Mode --><div class=\"card bg-base-100 shadow border border-base-300\"><div class=\"card-body p-4\"><h2 class=\"card-title text-base\">Inline-Full</h2><p class=\"text-sm text-base-content/70 mb-3\">Container-owning error for panels and embedded regions. Fills the entire container with a centered error display — like full-page but scoped to a sub-region. Comes in sm/md/lg size variants chosen by the container owner.</p><div class=\"grid grid-cols-1 md:grid-cols-3 gap-4\"><!-- SM --><div><p class=\"text-xs font-semibold text-base-content/50 mb-1\">Small (sm)</p><button class=\"btn btn-xs btn-error btn-outline mb-2\" hx-get=\"/patterns/errors/modes/inline-full/sm\" hx-target=\"#errors-modes-inline-full-sm\" hx-swap=\"innerHTML\">Trigger SM</button><div id=\"errors-modes-inline-full-sm\" class=\"min-h-[80px] border border-base-300 rounded-lg\"></div></div><!-- MD --><div><p class=\"text-xs font-semibold text-base-content/50 mb-1\">Medium (md)</p><button class=\"btn btn-xs btn-error btn-outline mb-2\" hx-get=\"/patterns/errors/modes/inline-full/md\" hx-target=\"#errors-modes-inline-full-md\" hx-swap=\"innerHTML\">Trigger MD</button><div id=\"errors-modes-inline-full-md\" class=\"min-h-[120px] border border-base-300 rounded-lg\"></div></div><!-- LG --><div class=\"md:col-span-1\"><p class=\"text-xs font-semibold text-base-content/50 mb-1\">Large (lg)</p><button class=\"btn btn-xs btn-error btn-outline mb-2\" hx-get=\"/patterns/errors/modes/inline-full/lg\" hx-target=\"#errors-modes-inline-full-lg\" hx-swap=\"innerHTML\">Trigger LG</button><div id=\"errors-modes-inline-full-lg\" class=\"min-h-[180px] border border-base-300 rounded-lg\"></div></div></div></div></div><!-- Taxonomy Summary --><div class=\"grid grid-cols-1 md:grid-cols-2 gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -52,7 +52,7 @@ func ErrorModesPage() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = errorModeCard("Inline-Full", "Container fill (planned)", "Container-owning error for panels and embedded regions. Scoped full-page experience.").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = errorModeCard("Inline-Full", "Container fill (sm/md/lg)", "Container-owning error for panels and embedded regions. Size variant chosen by container owner.").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -92,7 +92,7 @@ func errorModeCard(title, method, desc string) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/error_modes.templ`, Line: 115, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/error_modes.templ`, Line: 147, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -105,7 +105,7 @@ func errorModeCard(title, method, desc string) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(method)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/error_modes.templ`, Line: 116, Col: 76}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/error_modes.templ`, Line: 148, Col: 76}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -118,7 +118,7 @@ func errorModeCard(title, method, desc string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(desc)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/error_modes.templ`, Line: 117, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/error_modes.templ`, Line: 149, Col: 49}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -163,7 +163,7 @@ func ErrorModesInlineResult() templ.Component {
 }
 
 // ErrorModes404 renders a standalone 404 full-page error with a "Go Home" action.
-func ErrorModes404() templ.Component {
+func ErrorModes404(theme string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -220,7 +220,7 @@ func ErrorModes404() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = corecomponents.ErrorPageShell("Not Found", "").Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = corecomponents.ErrorPageShell("Not Found", theme).Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -229,7 +229,7 @@ func ErrorModes404() templ.Component {
 }
 
 // ErrorModes429 renders a standalone 429 full-page error with "Go Back" and "Retry" actions.
-func ErrorModes429() templ.Component {
+func ErrorModes429(theme string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -286,7 +286,7 @@ func ErrorModes429() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = corecomponents.ErrorPageShell("Too Many Requests", "").Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = corecomponents.ErrorPageShell("Too Many Requests", theme).Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -295,7 +295,7 @@ func ErrorModes429() templ.Component {
 }
 
 // ErrorModes500 renders a standalone 500 full-page error with "Go Home" and "Report Issue" actions.
-func ErrorModes500() templ.Component {
+func ErrorModes500(theme string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -352,7 +352,37 @@ func ErrorModes500() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = corecomponents.ErrorPageShell("Internal Server Error", "").Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = corecomponents.ErrorPageShell("Internal Server Error", theme).Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// ErrorModesInlineFullResult renders an inline-full error panel at the given size for the modes demo.
+func ErrorModesInlineFullResult(size string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = corecomponents.InlineFullErrorPanel(errorModesInlineFullEC(), size).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- Fix full-page error demos (404, 429, 500) to resolve theme from session instead of passing empty string, so they preserve the user's current theme when opened in a new window
- Add `InlineFullErrorPanel(ec, size)` component with sm/md/lg size variants for container-owning errors that match the density of the content they replace
- Replace the inline-full placeholder card in the error modes demo with working trigger buttons and realistic containers for each size
- Add route handlers for inline-full demo triggers
- Update PHILOSOPHY.md error-surface taxonomy to document sm/md/lg variants

## Test plan
- Navigate to `/patterns/errors/modes` and click each full-page error link (404, 429, 500) — verify they open with the correct theme instead of falling back to light/dark default
- On the error modes page, click the SM, MD, and LG inline-full trigger buttons — verify each renders an appropriately sized error panel in its container
- Verify dismiss buttons work on all three inline-full sizes
- Test with both light and dark themes to confirm full-page demos respect the session theme

Closes #694