### PR TITLE
docs: align stack prose with _hyperscript-first posture (#703 phase 3)

### DIFF
--- a/README.harmony.md
+++ b/README.harmony.md
@@ -493,9 +493,9 @@ Every tool in the stack exists because HTML alone could not express something. Y
     |  +--------------------------------------------------+
     |  |  inline <script>    locality bent                  |
     |  +--------------------------------------------------+
-    |  |  Alpine.js          reactive client state         |
+    |  |  Alpine.js          coordinated view state        |
     |  +--------------------------------------------------+---------------------+
-    |  |  _hyperscript       client-side behavior          |  Tailwind utilities |
+    |  |  _hyperscript       local DOM behavior            |  Tailwind utilities |
     |  +--------------------------------------------------+  layout + spacing   |
     |  |  HTMX               completes hypertext           +---------------------+
     |  +--------------------------------------------------+  DaisyUI components |
@@ -519,14 +519,14 @@ Map two dimensions -- **where it runs** and **what it manages** -- and six domai
            |                  |                      |                      |
            +------------------+----------------------+----------------------+
            |                  |                      |                      |
-  Client   |  Alpine.js       |  _hyperscript        |  Tailwind + CSS      |
-           |  view state      |  DOM interactions    |  layout, spacing     |
-           |  ephemeral       |  transitions, toggles|  visual adjustments  |
+  Client   |  _hyperscript    |  _hyperscript        |  Tailwind + CSS      |
+           |  + Alpine.js     |  DOM interactions    |  layout, spacing     |
+           |  local + bridges |  transitions, toggles|  visual adjustments  |
            |                  |                      |                      |
            +------------------+----------------------+----------------------+
 ```
 
-The left column is authority. **Server state** (Go + SQL) is the single source of truth. **Client state** (Alpine.js) is ephemeral view data the server does not need to know about. Nothing in the client row pretends to be the server row.
+The left column is authority. **Server state** (Go + SQL) is the single source of truth. **Client state** is ephemeral view data the server does not need to know about -- `_hyperscript` handles the common case (local DOM toggles, transitions, one-off bindings) and `Alpine.js` stays in reserve for the rarer cases that need coordinated view state or a browser-API bridge (theme picker, offline indicator). Nothing in the client row pretends to be the server row.
 
 The handler layer is the thickest: it knows the domain, selects templates, and assembles hypermedia controls. The service layer handles business logic. The repository layer is a thin SQL interface. Each layer does less than the one above it.
 

--- a/README.md
+++ b/README.md
@@ -681,9 +681,9 @@ Every tool in this stack exists because HTML alone couldn't express something. Y
     |  +--------------------------------------------------+
     |  |  inline <script>    locality bent                  |
     |  +--------------------------------------------------+
-    |  |  Alpine.js          reactive client state         |
+    |  |  Alpine.js          coordinated view state        |
     |  +--------------------------------------------------+---------------------+
-    |  |  _hyperscript       client-side behavior          |  Tailwind utilities |
+    |  |  _hyperscript       local DOM behavior            |  Tailwind utilities |
     |  +--------------------------------------------------+  layout + spacing   |
     |  |  HTMX               completes hypertext           +---------------------+
     |  +--------------------------------------------------+  DaisyUI components |
@@ -707,14 +707,14 @@ Map two dimensions -- **where it runs** and **what it manages** -- and six domai
            |                  |                      |                      |
            +------------------+----------------------+----------------------+
            |                  |                      |                      |
-  Client   |  Alpine.js       |  _hyperscript        |  Tailwind + CSS      |
-           |  view state      |  DOM interactions    |  layout, spacing     |
-           |  ephemeral       |  transitions, toggles|  visual adjustments  |
+  Client   |  _hyperscript    |  _hyperscript        |  Tailwind + CSS      |
+           |  + Alpine.js     |  DOM interactions    |  layout, spacing     |
+           |  local + bridges |  transitions, toggles|  visual adjustments  |
            |                  |                      |                      |
            +------------------+----------------------+----------------------+
 ```
 
-The left column is authority. **Server state** (Go + SQL) is the single source of truth. **Client state** (Alpine.js) is ephemeral view data the server doesn't care about. Nothing in the bottom row pretends to be the top row. If your client state is pretending to be server state, you have a distributed systems problem. You do not want a distributed systems problem. Nobody wants a distributed systems problem. People who say they want a distributed systems problem have not had a distributed systems problem.
+The left column is authority. **Server state** (Go + SQL) is the single source of truth. **Client state** is ephemeral view data the server doesn't care about -- `_hyperscript` handles the common case (local DOM toggles, transitions, one-off bindings) and `Alpine.js` stays in reserve for the rarer cases that need coordinated view state or a browser-API bridge (theme picker, offline indicator). Nothing in the bottom row pretends to be the top row. If your client state is pretending to be server state, you have a distributed systems problem. You do not want a distributed systems problem. Nobody wants a distributed systems problem. People who say they want a distributed systems problem have not had a distributed systems problem.
 
 ### The Two Triangles, Or Why Your Backend Has a Frontend Problem
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,9 +17,9 @@ These are active in every generated app by default.
 
 Provided via `dorman.SecurityHeaders()` middleware.
 
-### Alpine.js CSP Build
+### CSP-Friendly Client Behavior
 
-Uses `@alpinejs/csp` which eliminates `eval()` and `new Function()`. All components registered via `Alpine.data()`. Downstream apps do not need `unsafe-eval` in their Content Security Policy.
+`_hyperscript` is the default tool for local DOM behavior and runs without `eval()` or `new Function()`. The small remaining Alpine.js footprint (coordinated view state, browser-API bridges) uses `@alpinejs/csp`, which also eliminates `eval()` and `new Function()`; any Alpine component is registered via `Alpine.data()`. Downstream apps do not need `unsafe-eval` in their Content Security Policy.
 
 ### Template Auto-Escaping
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -73,7 +73,7 @@ If `sse` is not selected, everything between `:start` and `:end` (inclusive) is 
 
 ### Implicit Features
 
-`database` and `alpine` are always included and not presented in the wizard. SQLite is the base database engine; Alpine.js (CSP build) is the standard client-side state layer. The CSP build eliminates `unsafe-eval` from Content Security Policy requirements; all components are registered via `Alpine.data()` in `alpine-components.js`.
+`database` and `alpine` are always included and not presented in the wizard. SQLite is the base database engine. `_hyperscript` is the default tool for client-side DOM behavior (loaded with HTMX); Alpine.js (CSP build) is kept available for coordinated view state and browser-API bridges — currently the theme picker and offline indicator. The CSP build eliminates `unsafe-eval` from Content Security Policy requirements; any remaining Alpine component is registered via `Alpine.data()` in `alpine-components.js`.
 
 ### Feature Dependencies
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -57,7 +57,9 @@ var AllFeatures = []string{FeatureAuth, FeatureGraph, FeatureDatabase, FeatureMS
 
 // ImplicitFeatures are always selected and not presented to the user.
 // "database" is implicit because SQLite is the base database engine.
-// "alpine" is implicit because Alpine.js is the standard client-side state layer.
+// "alpine" is implicit because Alpine.js is kept available for coordinated view state
+// and browser-API bridges (theme picker, offline indicator). _hyperscript handles the
+// common local-DOM case and ships with HTMX.
 var ImplicitFeatures = []string{FeatureDatabase, FeatureAlpine}
 
 // featureDeps maps a feature to the features it implies.
@@ -1149,7 +1151,7 @@ var featureDescriptions = map[string]struct{ label, desc string }{
 	FeatureCaddy:           {"Caddy (HTTPS)", "Caddy reverse proxy with TLS termination"},
 	FeatureDemo:            {"Demo Content", "Demo pages, seed data, and example routes"},
 	FeatureSessionSettings: {"Session Settings", "Per-session theme and layout preferences"},
-	FeatureAlpine:          {"Alpine.js", "Client-side state management"},
+	FeatureAlpine:          {"Alpine.js", "Coordinated view state and browser-API bridges"},
 	FeatureCapacitor:       {"Capacitor", "Native mobile wrapper (iOS/Android)"},
 	FeatureOffline:         {"Offline Mode", "Service worker and write queue for offline use"},
 	FeatureSync:            {"Sync", "SQLite data synchronization between client and server"},
@@ -1321,7 +1323,7 @@ func buildTechStack(features []string) string {
 		sb.WriteString("| [Caddy](https://caddyserver.com/) | HTTPS reverse proxy |\n")
 	}
 	if keep[FeatureAlpine] {
-		sb.WriteString("| [Alpine.js](https://alpinejs.dev/) | Client-side state management |\n")
+		sb.WriteString("| [Alpine.js](https://alpinejs.dev/) | Coordinated view state and browser-API bridges |\n")
 	}
 
 	// Always included (dev tools)


### PR DESCRIPTION
Phase 3 of #703 audit. Docs-only follow-on to #706 and #707. Before this PR, the stack prose still described Alpine.js as the standard client-side state layer. After phases 1 and 2 that framing no longer matches the repo — \`_hyperscript\` is the default for local DOM behavior, and Alpine is reserved for coordinated view state and browser-API bridges (theme picker, offline indicator).

## Changes

- \`README.md\` / \`README.harmony.md\` — reach-up diagram labels and Sacred Table client row reframed around \`_hyperscript\` as the default; Alpine called out as the narrower bridge tier
- \`docs/SETUP.md\` — implicit \`alpine\` feature description now mentions \`_hyperscript\` as the default small tool and scopes Alpine to its remaining responsibilities
- \`docs/SECURITY.md\` — section retitled "CSP-Friendly Client Behavior"; now calls out that \`_hyperscript\` runs without \`eval\` and that the small Alpine footprint keeps the CSP guarantee
- \`internal/setup/setup.go\` — implicit feature comment + feature label ("Coordinated view state and browser-API bridges") + generated README row match the new posture

No code behavior changes. \`alpine\` remains an implicit feature — per plan.md the decision to make it opt-in is deferred.

## Test plan

- [x] \`go build ./...\` green
- [x] \`mage lint\` green
- [ ] render README.md and README.harmony.md, confirm the reach-up diagram and Sacred Table still make sense visually

Closes #703 once merged.