### PR TITLE
fix: substitute APP_NAME in env and guarantee GET / for non-demo apps

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -131,6 +131,7 @@ func (ar *appRoutes) InitRoutes() error {
 	if err != nil {
 		return fmt.Errorf("handler init: %w", err)
 	}
+	ar.e.GET("/", handler.HandleComponent(views.HomePage(cfg.AppName)))
 	// setup:feature:demo:start
 	ar.e.GET("/", handler.HandleComponent(views.ArchitecturePage()))
 	// setup:feature:demo:end

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -341,6 +341,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	envDevPath := filepath.Join(dir, ".env.development")
 	if data, err := os.ReadFile(envDevPath); err == nil {
 		content := composeSetupEnv(string(data))
+		content = strings.ReplaceAll(content, "{{APP_NAME}}", opts.AppName)
 		content = strings.ReplaceAll(content, "{{APP_TLS_PORT}}", appTLSPort)
 		content = strings.ReplaceAll(content, "{{TEMPL_HTTP_PORT}}", templHTTPPort)
 		content = strings.ReplaceAll(content, "{{CADDY_TLS_PORT}}", caddyTLSPort)

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -80,6 +80,10 @@ func TestSetupReplacesAppNameAndModule(t *testing.T) {
 	envBytes, err := os.ReadFile(envPath)
 	require.NoError(t, err)
 	require.Contains(t, string(envBytes), "SERVER_LISTEN_PORT=12345")
+	require.Contains(t, string(envBytes), "APP_NAME=Test App",
+		".env.development should have APP_NAME substituted with the real app name")
+	require.NotContains(t, string(envBytes), "{{APP_NAME}}",
+		".env.development must not contain unreplaced {{APP_NAME}} placeholder")
 	require.NotContains(t, string(envBytes), "{{APP_TLS_PORT}}")
 	require.NotContains(t, string(envBytes), "# setup:env")
 
@@ -536,6 +540,36 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	require.Contains(t, readmeContent, "## Setup Configuration")
 	// Minimal config should still have implicit features (database, alpine)
 	require.Contains(t, readmeContent, "Database (chuck)")
+
+	// env substitution must survive feature stripping (#regression)
+	envBytes, err := os.ReadFile(filepath.Join(dest, ".env.development"))
+	require.NoError(t, err)
+	require.Contains(t, string(envBytes), "APP_NAME=No Features App",
+		".env.development must have APP_NAME substituted even when demo is stripped")
+	require.NotContains(t, string(envBytes), "{{APP_NAME}}",
+		".env.development must not contain unreplaced {{APP_NAME}} placeholder")
+
+	// Non-demo apps must still register GET / so breadcrumbs and not-found
+	// recovery links to Home point at a real route (#regression).
+	routesBytes, err := os.ReadFile(filepath.Join(dest, "internal", "routes", "routes.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(routesBytes), `ar.e.GET("/"`,
+		"routes.go must register GET / when demo is stripped")
+	require.Contains(t, string(routesBytes), "views.HomePage",
+		"routes.go must use views.HomePage as the non-demo landing page")
+	require.NotContains(t, string(routesBytes), "ArchitecturePage",
+		"ArchitecturePage is demo-only and should be stripped in non-demo setups")
+
+	// Not-found page should not advertise demo routes when demo is stripped.
+	notFoundBytes, err := os.ReadFile(filepath.Join(dest, "web", "views", "not_found.templ"))
+	require.NoError(t, err)
+	notFound := string(notFoundBytes)
+	require.Contains(t, notFound, `@notFoundLink("Home", "/")`,
+		"not_found page should still advertise Home since GET / is registered")
+	require.NotContains(t, notFound, "Dashboard",
+		"not_found page should not advertise demo routes when demo is stripped")
+	require.NotContains(t, notFound, "apps/inventory",
+		"not_found page should not advertise demo routes when demo is stripped")
 }
 
 func TestSetup_FeaturesAuthOnly(t *testing.T) {

--- a/web/views/not_found.templ
+++ b/web/views/not_found.templ
@@ -17,6 +17,9 @@ templ NotFoundPage(path string) {
 				<p class="text-sm text-base-content/60">You can navigate to any of these resources:</p>
 				<div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
 					@notFoundLink("Home", "/")
+					// setup:feature:session_settings:start
+					@notFoundLink("Settings", "/settings")
+					// setup:feature:session_settings:end
 					// setup:feature:demo:start
 					@notFoundLink("Dashboard", "/dashboard")
 					@notFoundLink("Inventory", "/apps/inventory")

--- a/web/views/not_found_templ.go
+++ b/web/views/not_found_templ.go
@@ -53,6 +53,10 @@ func NotFoundPage(path string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = notFoundLink("Settings", "/settings").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = notFoundLink("Dashboard", "/dashboard").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -109,7 +113,7 @@ func notFoundLink(label, href string) templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(href))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/not_found.templ`, Line: 35, Col: 24}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/not_found.templ`, Line: 38, Col: 24}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -122,7 +126,7 @@ func notFoundLink(label, href string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/not_found.templ`, Line: 38, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/views/not_found.templ`, Line: 41, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Setup composed `.env.development` replaced port placeholders but left `APP_NAME={{APP_NAME}}` unsubstituted, so derived apps rendered `{{APP_NAME}}` in their page title and nav brand at runtime.
- Template registered `GET /` only inside the demo feature gate, so non-demo derived apps booted with no `/` route while the not-found page still advertised `Home -> /`, producing a 404 recovery loop.

## Changes

- `internal/setup/setup.go`: substitute `{{APP_NAME}}` alongside port placeholders during `.env.development` composition.
- `internal/routes/routes.go`: register `views.HomePage(cfg.AppName)` unconditionally at `/`; the demo-gated `ArchitecturePage` registration still overrides when demo is selected.
- `web/views/not_found.templ`: add a `Settings` recovery link under the `session_settings` feature gate.
- `tests/setup_test.go`: extend regression coverage — assert `APP_NAME` substitution, non-demo `GET /` registration, and that the 404 page does not advertise stripped demo routes.

Follows `plan.md`.

## Test plan

- [x] `go test ./tests -run 'TestSetupReplacesAppNameAndModule|TestSetup_FeaturesNone'`
- [x] `go test ./internal/setup/... ./internal/routes/...`
- [x] `go build ./...`
- [x] `mage lint`