### PR TITLE
ci: restore screenshots workflow with light theme

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ tmp
 node_modules
 test-results
 playwright-report
+docs/screenshots
 site
 log
 *.exe

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,92 @@
+name: Screenshots
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "stable"
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Generate templ files
+        run: go tool templ generate
+
+      - name: Build application
+        run: go build -o dothog .
+
+      - name: Start application
+        run: |
+          SERVER_LISTEN_PORT=3000 ./dothog -env production &
+          echo "APP_PID=$!" >> $GITHUB_ENV
+
+      - name: Capture screenshots
+        run: node scripts/screenshots.mjs --base-url http://localhost:3000
+
+      - name: Stop application
+        if: always()
+        run: kill $APP_PID 2>/dev/null || true
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: screenshots
+          path: docs/screenshots/
+
+  publish:
+    needs: [screenshots]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: screenshots
+          path: output
+
+      - name: Checkout screenshots repo
+        uses: actions/checkout@v6
+        with:
+          repository: catgoose/screenshots
+          token: ${{ secrets.SCREENSHOTS_REPO_TOKEN }}
+          path: screenshots-repo
+
+      - name: Copy and push screenshots
+        run: |
+          mkdir -p screenshots-repo/dothog
+          cp -r output/* screenshots-repo/dothog/
+          cd screenshots-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dothog
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Update dothog screenshots"
+          git pull --rebase origin main
+          git push
+        env:
+          GH_TOKEN: ${{ secrets.SCREENSHOTS_REPO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ build/
 docs/packages/
 site/
 
+# Screenshots (workflow pushes these to catgoose/screenshots)
+docs/screenshots/
+
 # Playwright
 test-results/
 playwright-report/

--- a/scripts/screenshots.mjs
+++ b/scripts/screenshots.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+
+// Captures screenshots of the running demo app.
+// Usage: node scripts/screenshots.mjs [--base-url http://localhost:3000]
+//
+// Requires: npx playwright install chromium
+
+import { chromium } from "playwright";
+import { mkdirSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = resolve(__dirname, "..", "docs", "screenshots");
+const baseURL =
+  process.argv.includes("--base-url")
+    ? process.argv[process.argv.indexOf("--base-url") + 1]
+    : "http://localhost:3000";
+
+mkdirSync(outDir, { recursive: true });
+
+// Pages to screenshot (path, filename, optional setup)
+const pages = [
+  { path: "/", name: "home", title: "Home" },
+  { path: "/dashboard", name: "dashboard", title: "Dashboard" },
+  { path: "/hypermedia/controls", name: "controls", title: "Controls Gallery" },
+  { path: "/demo/inventory", name: "inventory", title: "Inventory Table" },
+  { path: "/demo/catalog", name: "catalog", title: "Catalog" },
+  { path: "/demo/bulk", name: "bulk", title: "Bulk Operations" },
+  { path: "/demo/people", name: "people", title: "People Directory" },
+  { path: "/demo/kanban", name: "kanban", title: "Kanban Board" },
+  { path: "/demo/approvals", name: "approvals", title: "Approvals" },
+  { path: "/demo/feed", name: "feed", title: "Activity Feed" },
+  { path: "/demo/settings", name: "settings", title: "Settings" },
+  { path: "/demo/vendors", name: "vendors", title: "Vendors & Contacts" },
+  { path: "/hypermedia/crud", name: "crud", title: "CRUD" },
+  { path: "/hypermedia/interactions", name: "interactions", title: "Interactions" },
+  { path: "/hypermedia/state", name: "state", title: "State Patterns" },
+  { path: "/hypermedia/components3", name: "components3", title: "Components 3" },
+  { path: "/hypermedia/realtime", name: "realtime", title: "Realtime Dashboard" },
+  { path: "/demo/logging", name: "logging", title: "Retrospective Logging" },
+  { path: "/admin/error-traces", name: "error-traces", title: "Error Traces" },
+  { path: "/demo/people?from=3", name: "breadcrumbs", title: "Breadcrumb Origin Tracking" },
+];
+
+async function waitForApp(url, maxRetries = 30) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const resp = await fetch(`${url}/health`);
+      if (resp.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`App not reachable at ${url} after ${maxRetries}s`);
+}
+
+async function main() {
+  console.log(`Waiting for app at ${baseURL}...`);
+  await waitForApp(baseURL);
+  console.log("App is ready.");
+
+  const browser = await chromium.launch();
+
+  // Use a consistent theme for reproducible screenshots.
+  const defaultTheme = "light";
+  function randomTheme() {
+    return defaultTheme;
+  }
+
+  async function setTheme(page, theme) {
+    await page.evaluate((t) => {
+      document.documentElement.dataset.theme = t;
+    }, theme);
+    await page.waitForTimeout(200);
+  }
+
+  // --- Static screenshots ---
+  const ctx = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 2,
+  });
+
+  for (const { path, name, title } of pages) {
+    const page = await ctx.newPage();
+    try {
+      const theme = randomTheme();
+      console.log(`Capturing ${title} (${path}) [theme: ${theme}]...`);
+      await page.goto(`${baseURL}${path}`, { waitUntil: "networkidle" });
+      await setTheme(page, theme);
+
+      // Full-page screenshot
+      await page.screenshot({
+        path: resolve(outDir, `${name}.png`),
+        fullPage: true,
+      });
+
+      // Viewport-only screenshot (for README cards)
+      await page.screenshot({
+        path: resolve(outDir, `${name}-viewport.png`),
+        fullPage: false,
+      });
+
+      console.log(`  -> ${name}.png, ${name}-viewport.png`);
+    } catch (err) {
+      console.warn(`  WARN: Failed to capture ${title}: ${err.message}`);
+    } finally {
+      await page.close();
+    }
+  }
+
+  await ctx.close();
+
+  // --- Error control screenshots (require interactions) ---
+  console.log("\nCapturing error control screenshots...");
+  const errCtx = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 2,
+  });
+
+  // Reset DB before error screenshots
+  const setupPage = await errCtx.newPage();
+  try {
+    await setupPage.goto(`${baseURL}/admin/db/reinit`, { waitUntil: "networkidle" });
+  } catch { /* POST may not be navigable, use fetch below */ }
+  await setupPage.evaluate((url) => fetch(`${url}/admin/db/reinit`, { method: "POST" }), baseURL);
+  await setupPage.close();
+
+  // Helper: wait for HTMX requests to finish
+  async function waitForHtmx(page, timeout = 5000) {
+    await page.waitForFunction(
+      () => !document.querySelector(".htmx-request"),
+      { timeout },
+    ).catch(() => {});
+    await page.waitForTimeout(300);
+  }
+
+  // Default error controls
+  const defaultErrors = [
+    {
+      name: "error-400-bad-request",
+      title: "400 Bad Request",
+      action: async (page) => {
+        await page.goto(`${baseURL}/demo/repository/tasks/abc`, { waitUntil: "networkidle" });
+        await page.waitForTimeout(500);
+      },
+      fullPage: true,
+    },
+    {
+      name: "error-404-not-found",
+      title: "404 Not Found",
+      action: async (page) => {
+        await page.goto(`${baseURL}/demo/repository/tasks/99999`, { waitUntil: "networkidle" });
+        await page.waitForTimeout(500);
+      },
+      fullPage: true,
+    },
+  ];
+
+  // Custom error recovery controls (all on the controls page)
+  const recoveryErrors = [
+    {
+      name: "error-recovery-transient",
+      title: "Transient Error (Retry)",
+      selector: 'button:has-text("Save Record")',
+      resultId: "#transient-result",
+    },
+    {
+      name: "error-recovery-validation",
+      title: "Validation Error (Fix & Resubmit)",
+      selector: 'form[hx-post*="errors/validate"] button[type="submit"]',
+      resultId: "#validate-result",
+    },
+    {
+      name: "error-recovery-conflict",
+      title: "Conflict Error (Update or Copy)",
+      selector: 'button[hx-post*="errors/conflict"]',
+      resultId: "#conflict-result",
+    },
+    {
+      name: "error-recovery-stale",
+      title: "Stale Data Error (Refresh or Force)",
+      selector: 'form[hx-post*="errors/stale"] button[type="submit"]',
+      resultId: "#stale-result",
+    },
+    {
+      name: "error-recovery-cascade",
+      title: "Cascade Error (Reassign or Force Delete)",
+      selector: 'button[hx-delete*="errors/cascade"]',
+      resultId: "#cascade-result",
+    },
+  ];
+
+  // Capture default error screenshots
+  for (const { name, title, action, fullPage } of defaultErrors) {
+    const page = await errCtx.newPage();
+    try {
+      const theme = randomTheme();
+      console.log(`Capturing ${title} [theme: ${theme}]...`);
+      await action(page);
+      await setTheme(page, theme);
+      await page.screenshot({
+        path: resolve(outDir, `${name}.png`),
+        fullPage: fullPage ?? false,
+      });
+      console.log(`  -> ${name}.png`);
+    } catch (err) {
+      console.warn(`  WARN: Failed to capture ${title}: ${err.message}`);
+    } finally {
+      await page.close();
+    }
+  }
+
+  // Capture recovery error screenshots (each needs a fresh controls page)
+  for (const { name, title, selector, resultId } of recoveryErrors) {
+    const page = await errCtx.newPage();
+    try {
+      const theme = randomTheme();
+      console.log(`Capturing ${title} [theme: ${theme}]...`);
+      await page.goto(`${baseURL}/hypermedia/controls`, { waitUntil: "networkidle" });
+      await setTheme(page, theme);
+      await waitForHtmx(page);
+      await page.locator(selector).click();
+      await waitForHtmx(page);
+      await page.locator(resultId).screenshot({
+        path: resolve(outDir, `${name}.png`),
+      });
+      console.log(`  -> ${name}.png`);
+    } catch (err) {
+      console.warn(`  WARN: Failed to capture ${title}: ${err.message}`);
+    } finally {
+      await page.close();
+    }
+  }
+
+  await errCtx.close();
+
+  // --- Errors page screenshots ---
+  console.log("\nCapturing errors page screenshots...");
+
+  const errPageCtx = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    deviceScaleFactor: 2,
+  });
+
+  // Reset DB
+  const resetPage = await errPageCtx.newPage();
+  await resetPage.goto(`${baseURL}/hypermedia/errors`, { waitUntil: "networkidle" });
+  await resetPage.evaluate((url) => fetch(`${url}/admin/db/reinit`, { method: "POST" }), baseURL);
+  await resetPage.waitForTimeout(500);
+  await resetPage.close();
+
+  const errorsPageShots = [
+    {
+      name: "errors-banner-404",
+      title: "Banner: 404 Not Found",
+      action: async (page) => {
+        await page.locator('button:has-text("Trigger 404")').click();
+        await waitForHtmx(page);
+      },
+    },
+    {
+      name: "errors-banner-400",
+      title: "Banner: 400 Bad Request",
+      action: async (page) => {
+        await page.locator('button:has-text("Trigger 400")').click();
+        await waitForHtmx(page);
+      },
+    },
+    {
+      name: "errors-banner-500",
+      title: "Banner: 500 Internal Server Error",
+      action: async (page) => {
+        await page.locator('button:has-text("Trigger 500")').click();
+        await waitForHtmx(page);
+      },
+    },
+    {
+      name: "errors-banner-403",
+      title: "Banner: 403 Forbidden",
+      action: async (page) => {
+        await page.locator('button:has-text("Trigger 403")').click();
+        await waitForHtmx(page);
+      },
+    },
+    {
+      name: "errors-inline-validation",
+      title: "Inline Form Validation (422)",
+      action: async (page) => {
+        const form = page.locator('form[hx-post*="errors/form"]');
+        await form.locator('input[name="name"]').fill("");
+        await form.locator('input[name="email"]').fill("bad-email");
+        await form.locator('button[type="submit"]').click();
+        await waitForHtmx(page);
+      },
+    },
+    {
+      name: "errors-oob-warning",
+      title: "OOB Warning + Success",
+      action: async (page) => {
+        await page.locator('button:has-text("Load with Warning")').click();
+        await waitForHtmx(page);
+      },
+    },
+    {
+      name: "errors-flaky-retry",
+      title: "Flaky Endpoint (Retry)",
+      action: async (page) => {
+        await page.locator('button:has-text("Call Flaky Endpoint")').click();
+        await waitForHtmx(page);
+      },
+    },
+    {
+      name: "errors-report-modal",
+      title: "Report Issue Modal",
+      action: async (page) => {
+        await page.locator('button:has-text("Trigger 500")').click();
+        await waitForHtmx(page);
+        await page.locator('#error-status button:has-text("Report Issue")').click();
+        await waitForHtmx(page);
+        await page.waitForTimeout(300);
+      },
+    },
+  ];
+
+  for (const { name, title, action } of errorsPageShots) {
+    const page = await errPageCtx.newPage();
+    try {
+      const theme = randomTheme();
+      console.log(`Capturing ${title} [theme: ${theme}]...`);
+      await page.goto(`${baseURL}/hypermedia/errors`, { waitUntil: "networkidle" });
+      await setTheme(page, theme);
+      await action(page);
+      await page.screenshot({
+        path: resolve(outDir, `${name}.png`),
+        fullPage: true,
+      });
+      console.log(`  -> ${name}.png`);
+    } catch (err) {
+      console.warn(`  WARN: Failed to capture ${title}: ${err.message}`);
+    } finally {
+      await page.close();
+    }
+  }
+
+  await errPageCtx.close();
+
+  await browser.close();
+  console.log("\nDone. Screenshots saved to docs/screenshots/");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Resurrects `scripts/screenshots.mjs` and `.github/workflows/screenshots.yml` removed in #401
- Theme pinned to `light` for reproducible captures (no random selection)
- `workflow_dispatch` only; publishes to `catgoose/screenshots` under `dothog/`
- Restores `docs/screenshots/` ignore entries in `.gitignore` and `.dockerignore`

## Test plan
- [ ] Merge, then trigger workflow once via `gh workflow run Screenshots`
- [ ] Confirm screenshots refresh in `catgoose/screenshots/dothog/`
- [ ] Open follow-up PR removing the workflow + script (one-shot intent)