### PR TITLE
fix(setup,watch): make HTTP the dev origin; gate HTTPS to caddy feature

### DIFF
--- a/.air/server.toml
+++ b/.air/server.toml
@@ -7,7 +7,7 @@ tmp_dir = "tmp"
   bin = "./tmp/main"
   cmd = "go build -o ./tmp/main . && templ generate --notify-proxy -proxyport={{TEMPL_HTTP_PORT}}"
   delay = 1000
-  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_dir = ["assets", "tmp", "vendor", "testdata", "node_modules", "db", "log", "e2e", "test-results", "playwright-report", "ios", "android", "_template_setup", "web/assets/public/css", "web/assets/public/js", "web/assets/public/images"]
   exclude_file = ["magefile.go", "mage_setup.go", "mage_output_file.go"]
   exclude_regex = ["_test.go", ".*_templ.go"]
   exclude_unchanged = false

--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,7 @@
 # Server
 # setup:env APP_NAME={{APP_NAME}}
 APP_NAME=
-# setup:env SERVER_LISTEN_PORT={{APP_TLS_PORT}}
+# setup:env SERVER_LISTEN_PORT={{APP_HTTP_PORT}}
 SERVER_LISTEN_PORT=5124
 LOG_LEVEL=INFO
 SESSION_SECRET=change-me-in-production
@@ -13,9 +13,10 @@ SESSION_SECRET=change-me-in-production
 # OIDC_ISSUER_URL=https://login.microsoftonline.com/{tenant-id}/v2.0
 # OIDC_CLIENT_ID=
 # OIDC_CLIENT_SECRET=
-# OIDC_REDIRECT_URL=https://localhost:3000/callback
-# OIDC_LOGOUT_REDIRECT_URL=https://localhost:3000
-# OIDC_LOGIN_REDIRECT_URL=https://localhost:3000
+# OIDC_REDIRECT_URL=http://localhost:3000/callback
+# OIDC_LOGOUT_REDIRECT_URL=http://localhost:3000
+# OIDC_LOGIN_REDIRECT_URL=http://localhost:3000
+# (Switch to https://localhost:<CADDY_TLS_PORT> when running `mage watch` with the caddy feature.)
 
 # setup:feature:graph:start
 # Azure Graph API

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ vendor/bundle/
 
 # Local working notes
 plan.md
+plans/
+.agents/
+docs/audit/

--- a/README.harmony.md
+++ b/README.harmony.md
@@ -743,12 +743,12 @@ npm ci
 go tool mage watch
 ```
 
-Harmony starts with TLS on the configured port. Edit `.env.development` to change settings.
+Harmony's Echo origin runs as plain HTTP in development; TLS only appears when the `caddy` feature is enabled and Caddy fronts the templ proxy. Edit `.env.development` to change settings.
 
 Access the application at:
 
-- Direct TLS: `https://localhost:{APP_TLS_PORT}`
-- Via Caddy: `https://localhost:{CADDY_TLS_PORT}`
+- Direct HTTP (Echo origin): `http://localhost:{APP_HTTP_PORT}`
+- Via Caddy (when enabled): `https://localhost:{CADDY_TLS_PORT}`
 
 ### HTTPS Development Setup
 

--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ The wizard walks you through:
 | Avatar Photos    | User photo sync from Azure (requires Graph)           | Selected   |
 | Database (MSSQL) | SQL Server database with SQLx                         | Selected   |
 | SSE              | Server-Sent Events real-time updates (requires Caddy) | Selected   |
-| Caddy (HTTPS)    | Caddy reverse proxy with TLS termination              | Selected   |
+| Caddy            | Optional HTTPS/H3 front-proxy in front of templ       | Selected   |
 | Demo Content     | SQLite demo tables, hypermedia examples               | Unselected |
 
 Deselected features have their code, routes, imports, and related files stripped from the project. Dependencies are auto-resolved (SSE includes Caddy, Avatar includes Graph).
@@ -938,11 +938,18 @@ npm ci
 go tool mage watch
 ```
 
-Dothog starts with TLS on the configured port. Edit `.env.development` to change settings.
+Dothog's Echo origin runs as plain HTTP in development. `mage watch` puts
+templ's HTTP proxy in front of it; when the `caddy` feature is selected, Caddy
+sits in front of templ and provides HTTPS/H3. Without `caddy`, the dev URL is
+`http://localhost:<TEMPL_HTTP_PORT>`. With `caddy`, the dev URL is
+`https://localhost:<CADDY_TLS_PORT>`. Edit `.env.development` to change settings.
 
-### HTTPS Development Setup
+### HTTPS Development Setup (Caddy feature only)
 
-Dothog uses TLS with self-signed certificates in development. Generate them with:
+Only the `caddy` feature provides local HTTPS — and the cert is consumed by
+Caddy, not by Echo. Setup generates `localhost.crt` / `localhost.key` for you
+when `caddy` is selected; without `caddy`, no certificates are needed. If you
+want to regenerate them by hand:
 
 ```bash
 openssl req -x509 -newkey rsa:2048 -keyout localhost.key -out localhost.crt \

--- a/_template_setup/README.template.md
+++ b/_template_setup/README.template.md
@@ -75,11 +75,27 @@ go tool mage watch
 
 This starts templ in watch mode, Air for live reload, and Tailwind in watch mode.
 
-Access the application at: `https://localhost:{{APP_TLS_PORT}}`
+The Echo origin serves plain HTTP on `APP_HTTP_PORT={{APP_HTTP_PORT}}`. The templ
+watcher proxies it on `TEMPL_HTTP_PORT={{TEMPL_HTTP_PORT}}` — that is the URL
+`mage watch` opens by default:
 
-### HTTPS Development Setup
+```
+http://localhost:{{TEMPL_HTTP_PORT}}
+```
 
-When Caddy is configured, the app uses self-signed certificates for local HTTPS.
+If the `caddy` feature is enabled, Caddy fronts the templ proxy with HTTPS/H3
+on `CADDY_TLS_PORT={{CADDY_TLS_PORT}}` and `mage watch` opens
+`https://localhost:{{CADDY_TLS_PORT}}` instead. The Echo origin stays HTTP in
+both modes — TLS lives in Caddy, not in the app.
+
+### HTTPS Development Setup (Caddy feature only)
+
+When the `caddy` feature is selected, setup generates `localhost.crt` /
+`localhost.key` (or reuses pre-existing files) for Caddy to terminate TLS.
+Without the `caddy` feature there is no local HTTPS and no certificates are
+generated.
+
+Trust the certificate on your system:
 
 **Linux (Ubuntu/Debian):**
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -140,7 +140,7 @@ No explicit request body size limits. Echo's default is 4MB. For file upload end
 
 ### TLS at the Application
 
-Dev mode supports `StartTLS` with local certificates. Production assumes deployment behind a TLS-terminating proxy. The app itself does not manage certificates or ACME.
+Dev mode runs the Echo origin as plain HTTP. When `mage watch` is used with the `caddy` feature, Caddy fronts the templ proxy chain with local self-signed certificates and provides HTTPS/H3. Production assumes deployment behind a TLS-terminating proxy. The app itself does not manage certificates or ACME.
 
 ### Session Cookie Secure Flag
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -17,7 +17,7 @@ go tool mage setup -n "My App" --features none  # bare HTMX app
 ## What Setup Does
 
 1. **Rewrites module path** — replaces `catgoose/dothog` with your module path in all `.go` files and `go.mod`
-2. **Configures ports** — sets `APP_TLS_PORT`, `TEMPL_HTTP_PORT` (base+1), `CADDY_TLS_PORT` (base+2) in `.env.development`, Caddyfile, air config
+2. **Configures ports** — sets `APP_HTTP_PORT`, `TEMPL_HTTP_PORT` (base+1), `CADDY_TLS_PORT` (base+2) in `.env.development`, Caddyfile, air config
 3. **Sets app name** — updates binary name in `magefile.go`, Dockerfile, logger, package.json
 4. **Strips features** — removes code blocks and files for features you didn't select
 5. **Generates README** — from `_template_setup/README.template.md` with your app name and ports
@@ -61,7 +61,7 @@ If `sse` is not selected, everything between `:start` and `:end` (inclusive) is 
 | `mssql` | MSSQL dialect | — | Microsoft SQL Server production dialect |
 | `postgres` | PostgreSQL dialect | — | PostgreSQL production dialect |
 | `sse` | SSE | — | Server-Sent Events (requires caddy selected separately) |
-| `caddy` | Caddy (HTTPS) | — | Caddy reverse proxy with TLS |
+| `caddy` | Caddy HTTPS/H3 front-proxy | — | Optional HTTPS/H3 front-proxy in front of templ. Without it dev runs plain HTTP. |
 | `link_relations` | Link Relations | — | Context bars, breadcrumbs, site map |
 | `web_standards` | Web Standards | — | Server-Timing, Vary, Permissions-Policy, Early Hints |
 | `browser_apis` | Browser APIs | sse | sendBeacon and BroadcastChannel support (auto-includes sse) |

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -322,9 +322,10 @@ func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 
 	// Preload critical assets. In production (direct H2), send 103 Early Hints
 	// so the browser fetches CSS/JS while the server generates the response.
-	// Behind the dev proxy chain (TEMPL_PROXY), 1xx responses get mangled, so
-	// fall back to Link headers on the final response — the browser still gets
-	// the preload hint, just slightly later.
+	// In `mage watch` the templ HTTP proxy (and optional Caddy in front of it)
+	// is always in the chain — TEMPL_PROXY=true is set there — and 1xx
+	// responses get mangled, so fall back to Link headers on the final
+	// response. The browser still gets the preload hint, just slightly later.
 	behindProxy := os.Getenv("TEMPL_PROXY") != ""
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -247,7 +247,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	if err != nil || baseNum >= 60000 {
 		return fmt.Errorf("BASE_PORT must be < 60000, got: %s", basePort)
 	}
-	appTLSPort := basePort
+	appHTTPPort := basePort
 	templHTTPPort := strconv.Itoa(baseNum + 1)
 	caddyTLSPort := strconv.Itoa(baseNum + 2)
 
@@ -305,7 +305,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	}
 	mageContent := string(mageData)
 	mageContent = binaryNameRe.ReplaceAllString(mageContent, `binaryName = "`+binaryName+`"`)
-	mageContent = strings.ReplaceAll(mageContent, "{{APP_TLS_PORT}}", appTLSPort)
+	mageContent = strings.ReplaceAll(mageContent, "{{APP_HTTP_PORT}}", appHTTPPort)
 	mageContent = strings.ReplaceAll(mageContent, "{{TEMPL_HTTP_PORT}}", templHTTPPort)
 	mageContent = strings.ReplaceAll(mageContent, "{{CADDY_TLS_PORT}}", caddyTLSPort)
 	if err := os.WriteFile(magePath, []byte(mageContent), 0644); err != nil {
@@ -319,7 +319,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 			continue
 		}
 		content := string(data)
-		content = strings.ReplaceAll(content, "{{APP_TLS_PORT}}", appTLSPort)
+		content = strings.ReplaceAll(content, "{{APP_HTTP_PORT}}", appHTTPPort)
 		content = strings.ReplaceAll(content, "{{TEMPL_HTTP_PORT}}", templHTTPPort)
 		content = strings.ReplaceAll(content, "{{CADDY_TLS_PORT}}", caddyTLSPort)
 		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
@@ -342,7 +342,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	if data, err := os.ReadFile(envDevPath); err == nil {
 		content := composeSetupEnv(string(data))
 		content = strings.ReplaceAll(content, "{{APP_NAME}}", opts.AppName)
-		content = strings.ReplaceAll(content, "{{APP_TLS_PORT}}", appTLSPort)
+		content = strings.ReplaceAll(content, "{{APP_HTTP_PORT}}", appHTTPPort)
 		content = strings.ReplaceAll(content, "{{TEMPL_HTTP_PORT}}", templHTTPPort)
 		content = strings.ReplaceAll(content, "{{CADDY_TLS_PORT}}", caddyTLSPort)
 		// Strip feature-gated blocks that were not selected.
@@ -383,8 +383,8 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		content = strings.ReplaceAll(content, "build /"+templateName, "build /"+binaryName)
 		content = strings.ReplaceAll(content, "/usr/local/bin/"+templateName, "/usr/local/bin/"+binaryName)
 		content = strings.ReplaceAll(content, `ENTRYPOINT ["`+templateName+`"]`, `ENTRYPOINT ["`+binaryName+`"]`)
-		content = strings.ReplaceAll(content, "SERVER_LISTEN_PORT=3000", "SERVER_LISTEN_PORT="+appTLSPort)
-		content = strings.ReplaceAll(content, "EXPOSE 3000", "EXPOSE "+appTLSPort)
+		content = strings.ReplaceAll(content, "SERVER_LISTEN_PORT=3000", "SERVER_LISTEN_PORT="+appHTTPPort)
+		content = strings.ReplaceAll(content, "EXPOSE 3000", "EXPOSE "+appHTTPPort)
 		if err := os.WriteFile(dockerfilePath, []byte(content), 0644); err != nil {
 			return err
 		}
@@ -441,7 +441,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 	templateReadme := filepath.Join(dir, TemplateSetupDir, "README.template.md")
 	if data, err := os.ReadFile(templateReadme); err == nil {
 		content := string(data)
-		content = strings.ReplaceAll(content, "{{APP_TLS_PORT}}", appTLSPort)
+		content = strings.ReplaceAll(content, "{{APP_HTTP_PORT}}", appHTTPPort)
 		content = strings.ReplaceAll(content, "{{TEMPL_HTTP_PORT}}", templHTTPPort)
 		content = strings.ReplaceAll(content, "{{CADDY_TLS_PORT}}", caddyTLSPort)
 		content = strings.ReplaceAll(content, "{{APP_NAME}}", opts.AppName)
@@ -451,8 +451,8 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		content = strings.ReplaceAll(content, "{{FEATURE_TABLE}}", buildFeatureTable(opts.Features))
 		content = strings.ReplaceAll(content, "{{FEATURE_SECTIONS}}", buildFeatureSections(opts.Features))
 		content = strings.ReplaceAll(content, "{{TECH_STACK}}", buildTechStack(opts.Features))
-		content = strings.ReplaceAll(content, "{{QUICK_START}}", buildQuickStart(binaryName, appTLSPort))
-		content = strings.ReplaceAll(content, "{{ENV_TABLE}}", buildEnvTable(opts.Features, opts.AppName, appTLSPort))
+		content = strings.ReplaceAll(content, "{{QUICK_START}}", buildQuickStart(binaryName, appHTTPPort))
+		content = strings.ReplaceAll(content, "{{ENV_TABLE}}", buildEnvTable(opts.Features, opts.AppName, appHTTPPort))
 		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content), 0644); err != nil {
 			return err
 		}
@@ -584,6 +584,13 @@ func removeOptionalContent(dir string, opts Options) error {
 	// Remove the setup package itself — it only exists for template setup (#377).
 	_ = os.RemoveAll(filepath.Join(dir, "internal", "setup"))
 	_ = os.Remove(filepath.Join(dir, "tests", "setup_test.go"))
+
+	// Remove the mage setup target and the README template source — both
+	// reference the (now removed) internal/setup package and only exist to
+	// drive setup itself. Without this, derived apps fail to build their
+	// magefile because mage_setup.go still imports internal/setup.
+	_ = os.Remove(filepath.Join(dir, "mage_setup.go"))
+	_ = os.RemoveAll(filepath.Join(dir, TemplateSetupDir))
 
 	// Replace demo-specific e2e tests with a minimal smoke suite (#356).
 	// Keep helpers.ts and playwright.config.ts (they contain general utilities
@@ -1149,7 +1156,7 @@ var featureDescriptions = map[string]struct{ label, desc string }{
 	FeatureMSSQL:           {"MSSQL", "Microsoft SQL Server dialect support"},
 	FeaturePostgres:        {"PostgreSQL", "PostgreSQL dialect support"},
 	FeatureSSE:             {"SSE", "Server-Sent Events with HTMX integration"},
-	FeatureCaddy:           {"Caddy (HTTPS)", "Caddy reverse proxy with TLS termination"},
+	FeatureCaddy:           {"Caddy HTTPS/H3 front-proxy", "Optional HTTPS/H3 front-proxy that sits in front of the templ watcher for local dev. Without it, dev runs plain HTTP."},
 	FeatureDemo:            {"Demo Content", "Demo pages, seed data, and example routes"},
 	FeatureSessionSettings: {"Session Settings", "Per-session theme and layout preferences"},
 	FeatureAlpine:          {"Alpine.js", "Coordinated view state and browser-API bridges"},
@@ -1256,9 +1263,9 @@ Real-time event broker with topic-based publish/subscribe. HTMX SSE extension is
 	}
 
 	if keep[FeatureCaddy] {
-		sb.WriteString(`### Caddy (HTTPS)
+		sb.WriteString(`### Caddy (HTTPS/H3 front-proxy)
 
-Caddy provides TLS termination for local development. Certificates are generated during setup or can be provided manually. See the HTTPS Development Setup section for trust store installation.
+Caddy sits in front of the templ watcher and provides HTTPS/H3 for local development. The Echo origin remains plain HTTP. Without the ` + "`caddy`" + ` feature, ` + "`mage watch`" + ` exposes the templ HTTP proxy directly with no TLS in the chain. Certificates are generated during setup (only when ` + "`caddy`" + ` is selected) or can be provided manually. See the HTTPS Development Setup section for trust store installation.
 
 `)
 	}
@@ -1335,7 +1342,7 @@ func buildTechStack(features []string) string {
 }
 
 // buildQuickStart generates the Quick Start section with binary name and port.
-func buildQuickStart(binaryName, appTLSPort string) string {
+func buildQuickStart(binaryName, appHTTPPort string) string {
 	var sb strings.Builder
 
 	sb.WriteString("### From Source\n\n")
@@ -1347,7 +1354,7 @@ func buildQuickStart(binaryName, appTLSPort string) string {
 	sb.WriteString("### From Docker\n\n")
 	sb.WriteString("```bash\n")
 	sb.WriteString("docker build -t " + binaryName + " .\n")
-	sb.WriteString("docker run -p " + appTLSPort + ":" + appTLSPort + " " + binaryName + "\n")
+	sb.WriteString("docker run -p " + appHTTPPort + ":" + appHTTPPort + " " + binaryName + "\n")
 	sb.WriteString("```\n\n")
 
 	sb.WriteString("### From Release Binary\n\n")
@@ -1370,7 +1377,7 @@ func buildQuickStart(binaryName, appTLSPort string) string {
 }
 
 // buildEnvTable generates a markdown table of environment variables based on features.
-func buildEnvTable(features []string, appName, appTLSPort string) string {
+func buildEnvTable(features []string, appName, appHTTPPort string) string {
 	expanded := ExpandFeatureDeps(features)
 	keep := make(map[string]bool)
 	for _, f := range expanded {
@@ -1385,7 +1392,7 @@ func buildEnvTable(features []string, appName, appTLSPort string) string {
 	sb.WriteString("| --- | --- | --- |\n")
 
 	// Always included
-	sb.WriteString("| `SERVER_LISTEN_PORT` | Echo server port | " + appTLSPort + " |\n")
+	sb.WriteString("| `SERVER_LISTEN_PORT` | Echo server port | " + appHTTPPort + " |\n")
 	sb.WriteString("| `APP_NAME` | Application name | " + appName + " |\n")
 	sb.WriteString("| `LOG_LEVEL` | DEBUG, INFO, WARN, ERROR | INFO |\n")
 	sb.WriteString("| `DATABASE_URL` | Database connection string (database enabled when set) | -- |\n")
@@ -1627,7 +1634,10 @@ func removeEmptyDirs(dir string) error {
 	return nil
 }
 
-// CopyRepoTo copies directory tree from src to dest, skipping named dirs and symlinks.
+// CopyRepoTo copies directory tree from src to dest, skipping any entry
+// (file or directory) whose basename appears in exclude, and skipping symlinks.
+// The legacy parameter name "excludeDirs" is kept for callers; entries may name
+// either directories (e.g. "node_modules") or files (e.g. "localhost.crt").
 func CopyRepoTo(src, dest string, excludeDirs []string) error {
 	exclude := make(map[string]bool)
 	for _, d := range excludeDirs {
@@ -1655,8 +1665,11 @@ func CopyRepoTo(src, dest string, excludeDirs []string) error {
 		if rel == "." {
 			return os.MkdirAll(dest, info.Mode())
 		}
-		if info.IsDir() && exclude[filepath.Base(path)] {
-			return filepath.SkipDir
+		if exclude[filepath.Base(path)] {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		destPath := filepath.Join(dest, rel)
 		if info.IsDir() {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,7 +1,9 @@
 package setup
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -935,4 +937,103 @@ func TestStripEnvBlocks(t *testing.T) {
 		got := stripEnvBlocks(content, map[string]bool{"graph": true})
 		require.Equal(t, content, got)
 	})
+}
+
+// ---------------------------------------------------------------------------
+// CopyRepoTo — cert exclusion
+// ---------------------------------------------------------------------------
+
+func TestCopyRepoToExcludesLocalhostCerts(t *testing.T) {
+	src := t.TempDir()
+	dest := filepath.Join(t.TempDir(), "out")
+
+	files := map[string]string{
+		"go.mod":         "module example.test\n",
+		"localhost.crt":  "FAKE CERT\n",
+		"localhost.key":  "FAKE KEY\n",
+		"keep/keep.txt":  "keep me\n",
+		"node_modules/x": "junk\n",
+	}
+	for rel, body := range files {
+		full := filepath.Join(src, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+
+	excludes := []string{".git", "node_modules", "localhost.crt", "localhost.key"}
+	require.NoError(t, CopyRepoTo(src, dest, excludes))
+
+	// localhost.* must be excluded.
+	_, err := os.Stat(filepath.Join(dest, "localhost.crt"))
+	require.True(t, os.IsNotExist(err), "localhost.crt should not be copied: %v", err)
+	_, err = os.Stat(filepath.Join(dest, "localhost.key"))
+	require.True(t, os.IsNotExist(err), "localhost.key should not be copied: %v", err)
+
+	// node_modules dir must still be excluded.
+	_, err = os.Stat(filepath.Join(dest, "node_modules"))
+	require.True(t, os.IsNotExist(err), "node_modules should not be copied: %v", err)
+
+	// Regular files should still copy.
+	gotMod, err := os.ReadFile(filepath.Join(dest, "go.mod"))
+	require.NoError(t, err)
+	require.Equal(t, "module example.test\n", string(gotMod))
+	gotKeep, err := os.ReadFile(filepath.Join(dest, "keep", "keep.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "keep me\n", string(gotKeep))
+}
+
+// ---------------------------------------------------------------------------
+// ensureCerts — caddy gating
+// ---------------------------------------------------------------------------
+
+func TestEnsureCertsNoCaddyCreatesNothing(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{Features: []string{FeatureDatabase, FeatureCSRF, FeatureLinkRelations}}
+
+	require.NoError(t, ensureCerts(context.Background(), dir, opts))
+
+	_, err := os.Stat(filepath.Join(dir, "localhost.crt"))
+	require.True(t, os.IsNotExist(err), "no caddy → no localhost.crt: %v", err)
+	_, err = os.Stat(filepath.Join(dir, "localhost.key"))
+	require.True(t, os.IsNotExist(err), "no caddy → no localhost.key: %v", err)
+}
+
+func TestEnsureCertsCaddyGenerates(t *testing.T) {
+	if _, err := exec.LookPath("openssl"); err != nil {
+		t.Skip("openssl not available")
+	}
+	dir := t.TempDir()
+	opts := Options{Features: []string{FeatureCaddy}}
+
+	require.NoError(t, ensureCerts(context.Background(), dir, opts))
+
+	info, err := os.Stat(filepath.Join(dir, "localhost.crt"))
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0), "localhost.crt should be non-empty")
+	info, err = os.Stat(filepath.Join(dir, "localhost.key"))
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0), "localhost.key should be non-empty")
+}
+
+// ---------------------------------------------------------------------------
+// hasCaddyFeature
+// ---------------------------------------------------------------------------
+
+func TestHasCaddyFeature(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+		want bool
+	}{
+		{name: "nil features defaults to caddy", opts: Options{}, want: true},
+		{name: "nil features with NoCaddy", opts: Options{NoCaddy: true}, want: false},
+		{name: "features without caddy", opts: Options{Features: []string{FeatureAuth, FeatureDatabase}}, want: false},
+		{name: "features with caddy", opts: Options{Features: []string{FeatureAuth, FeatureCaddy}}, want: true},
+		{name: "empty features explicit", opts: Options{Features: []string{}}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, hasCaddyFeature(tt.opts))
+		})
+	}
 }

--- a/mage_setup.go
+++ b/mage_setup.go
@@ -35,7 +35,7 @@ var featureLabels = map[string]string{
 	setup.FeaturePostgres:        "PostgreSQL dialect",
 	// Real-time
 	setup.FeatureSSE:             "SSE (requires Caddy)",
-	setup.FeatureCaddy:           "Caddy (HTTPS)",
+	setup.FeatureCaddy:           "Caddy HTTPS/H3 front-proxy (adds local TLS)",
 	// Navigation
 	setup.FeatureLinkRelations:   "Link Relations (context bars, breadcrumbs, site map)",
 	// Performance & Security
@@ -160,7 +160,7 @@ func Setup() error {
 		if err := os.MkdirAll(filepath.Dir(absTarget), 0755); err != nil {
 			return err
 		}
-		if err := setup.CopyRepoTo(".", absTarget, []string{".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp"}); err != nil {
+		if err := setup.CopyRepoTo(".", absTarget, []string{".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp", "localhost.crt", "localhost.key"}); err != nil {
 			return fmt.Errorf("copying template: %w", err)
 		}
 		gitInit, _ := huhConfirm("Run git init in the new directory?")
@@ -275,7 +275,7 @@ func runWizard() (*setup.Options, error) {
 			huh.NewInput().
 				Title("Base port").
 				Placeholder("5-digit port < 60000").
-				Description(fmt.Sprintf("APP_TLS_PORT=BASE, TEMPL_HTTP=BASE+1, CADDY_TLS=BASE+2 (default: %s)", defaultPort)).
+				Description(fmt.Sprintf("APP_HTTP=BASE, TEMPL_HTTP=BASE+1, CADDY_TLS=BASE+2 (default: %s)", defaultPort)).
 				Value(&basePort),
 		).Title("App Configuration"),
 	)
@@ -709,7 +709,7 @@ func printSetupUsage() {
 
   -n APP_NAME        Human-readable app name (e.g. "My App"). Required.
   -m MODULE_PATH     Go module path (e.g. "github.com/you/my-app").
-  -p BASE_PORT       5-digit base port < 60000; APP_TLS_PORT=BASE_PORT, TEMPL_HTTP_PORT=BASE_PORT+1, CADDY_TLS_PORT=BASE_PORT+2.
+  -p BASE_PORT       5-digit base port < 60000; APP_HTTP_PORT=BASE_PORT, TEMPL_HTTP_PORT=BASE_PORT+1, CADDY_TLS_PORT=BASE_PORT+2.
   --features LIST    Comma-separated feature tags to keep: auth,graph,avatar,database,sse,caddy,demo,alpine.
                      "all" = keep everything (default), "none" = bare HTMX app.
   --no-caddy         Deprecated. Equivalent to omitting caddy from --features.

--- a/magefile.go
+++ b/magefile.go
@@ -32,10 +32,10 @@ var (
 	buildPath  = "build"
 	binPath    = "./bin"
 	// The following ports are templated by setup (internal/setup or mage setup):
-	// - APP_TLS_PORT: Echo TLS port (SERVER_LISTEN_PORT)
+	// - APP_HTTP_PORT: Echo origin port (SERVER_LISTEN_PORT) — plain HTTP in dev
 	// - TEMPL_HTTP_PORT: templ's local HTTP proxy port
-	// - CADDY_TLS_PORT: Caddy TLS termination port
-	proxyURL               = fmt.Sprintf("https://%s:{{APP_TLS_PORT}}", proxyHost)
+	// - CADDY_TLS_PORT: Caddy TLS termination port (only when caddy feature is selected)
+	proxyURL               = fmt.Sprintf("http://%s:{{APP_HTTP_PORT}}", proxyHost)
 	proxyPort              = "{{TEMPL_HTTP_PORT}}"
 	// setup:feature:caddy:start
 	caddyTLSPort           = "{{CADDY_TLS_PORT}}"
@@ -156,7 +156,7 @@ func resolveProxyURL() string {
 	}
 	if base := serverListenPortFromEnvFile(envFile); base != "" {
 		if _, err := strconv.Atoi(base); err == nil {
-			return fmt.Sprintf("https://%s:%s", proxyHost, base)
+			return fmt.Sprintf("http://%s:%s", proxyHost, base)
 		}
 	}
 	return proxyURL
@@ -492,11 +492,10 @@ func Watch() error {
 		// setup:feature:caddy:end
 	}
 
-	// setup:feature:caddy:start
-	// Signal to the Go server that it's behind the templ proxy chain.
-	// Echo skips gzip middleware when this is set — Caddy handles compression.
+	// Signal to the Go server that it's behind the templ HTTP proxy in
+	// `mage watch`. Echo skips gzip middleware and 103 Early Hints when this
+	// is set — those don't survive the templ proxy (or Caddy in front of it).
 	os.Setenv("TEMPL_PROXY", "true")
-	// setup:feature:caddy:end
 
 	errc := make(chan error, len(tasks))
 	for _, t := range tasks {
@@ -684,7 +683,7 @@ func SetupTo(dest, appName string) error {
 	}
 
 	fmt.Printf("Copying template to %s...\n", absDest)
-	if err := setup.CopyRepoTo(src, absDest, []string{".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp"}); err != nil {
+	if err := setup.CopyRepoTo(src, absDest, []string{".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp", "localhost.crt", "localhost.key"}); err != nil {
 		return fmt.Errorf("copy: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -218,19 +218,14 @@ func main() {
 	// setup:feature:avatar:end
 
 	go func() {
-		if appenv.Dev() {
-			logger.Info("Starting Echo server with TLS (development mode)", "port", cfg.ServerPort)
-			if err := e.StartTLS(fmt.Sprintf(":%s", cfg.ServerPort), "localhost.crt", "localhost.key"); err != nil {
-				if err != http.ErrServerClosed {
-					logger.Fatal("Failed to start Echo server with TLS", "error", err)
-				}
-			}
-		} else {
-			logger.Info("Starting Echo server without TLS (production mode)", "port", cfg.ServerPort)
-			if err := e.Start(fmt.Sprintf(":%s", cfg.ServerPort)); err != nil {
-				if err != http.ErrServerClosed {
-					logger.Fatal("Failed to start Echo server", "error", err)
-				}
+		// Dev: plain HTTP on cfg.ServerPort. `mage watch` puts templ in front
+		// (and optionally Caddy in front of that) — TLS lives in those layers,
+		// not at the Echo origin.
+		// Prod: TLS termination is expected at the reverse proxy.
+		logger.Info("Starting Echo server", "port", cfg.ServerPort, "dev", appenv.Dev())
+		if err := e.Start(fmt.Sprintf(":%s", cfg.ServerPort)); err != nil {
+			if err != http.ErrServerClosed {
+				logger.Fatal("Failed to start Echo server", "error", err)
 			}
 		}
 	}()

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -54,7 +54,7 @@ func TestSetupReplacesAppNameAndModule(t *testing.T) {
 	require.Contains(t, mageContent, `binaryName = "test-app"`)
 	require.Contains(t, mageContent, "12345")
 	require.Contains(t, mageContent, "12346")
-	require.NotContains(t, mageContent, "{{APP_TLS_PORT}}")
+	require.NotContains(t, mageContent, "{{APP_HTTP_PORT}}")
 	require.NotContains(t, mageContent, "{{TEMPL_HTTP_PORT}}")
 	require.NotContains(t, mageContent, "{{CADDY_TLS_PORT}}")
 
@@ -84,7 +84,7 @@ func TestSetupReplacesAppNameAndModule(t *testing.T) {
 		".env.development should have APP_NAME substituted with the real app name")
 	require.NotContains(t, string(envBytes), "{{APP_NAME}}",
 		".env.development must not contain unreplaced {{APP_NAME}} placeholder")
-	require.NotContains(t, string(envBytes), "{{APP_TLS_PORT}}")
+	require.NotContains(t, string(envBytes), "{{APP_HTTP_PORT}}")
 	require.NotContains(t, string(envBytes), "# setup:env")
 
 	gitignorePath := filepath.Join(dest, ".gitignore")
@@ -172,7 +172,7 @@ func TestSetupUsesRandomPortWhenPOmitted(t *testing.T) {
 	mageContent := string(mageBytes)
 	require.Contains(t, mageContent, baseStr)
 	require.Contains(t, mageContent, templStr)
-	require.NotContains(t, mageContent, "{{APP_TLS_PORT}}")
+	require.NotContains(t, mageContent, "{{APP_HTTP_PORT}}")
 	require.NotContains(t, mageContent, "{{TEMPL_HTTP_PORT}}")
 
 	airPath := filepath.Join(dest, ".air", "server.toml")


### PR DESCRIPTION
## Summary

- Realign `mage setup`/`mage watch` around two intentional dev topologies: HTTP-only (no `caddy`/`sse`) and Caddy HTTPS/H3 in front of templ (when `caddy` or `sse` is selected). The Echo origin is always plain HTTP; TLS lives only in Caddy or the production reverse proxy.
- Stop the template from leaking `localhost.crt`/`localhost.key` into derived apps, drop the dev `StartTLS` path that depended on those leaked files, rename the placeholder to `APP_HTTP_PORT`, and align `TEMPL_PROXY=true` with the fact that templ is always in the proxy chain during watch.
- Tighten the Air watcher so it stops scanning `node_modules`, `db`, `log`, `e2e`, native mobile dirs, and the built asset output; remove `mage_setup.go`/`_template_setup` at the end of `setup.Run` so SetupTo-generated apps actually build.

## Behavior split

- **Without `caddy`/`sse`**: `browser -> templ HTTP proxy (TEMPL_HTTP_PORT) -> Echo HTTP (APP_HTTP_PORT)` — no certs generated.
- **With `caddy`** (auto-included by `sse`): `browser -> Caddy HTTPS/H3 (CADDY_TLS_PORT) -> templ HTTP proxy -> Echo HTTP` — `localhost.crt`/`localhost.key` generated by setup for Caddy.

## Test plan

- [x] `go test ./internal/setup/...` (new cert-exclusion, no-caddy ensureCerts, hasCaddyFeature, and updated placeholder tests).
- [x] `go test ./tests/...` (full setup integration smoke).
- [x] `go test ./...` (full repo).
- [x] `go tool mage lint`.

## Verification: two separate clean regenerations

Each run deleted `/home/jtye/git/asdfasdf` and recreated it from scratch — they were **not** concurrent or layered.

### Run A — no-Caddy (reported repro, current on-disk state)

- Features: `session_settings,csrf,auth,graph,avatar,database,mssql,link_relations,web_standards`, port `33848`.
- On disk: no `config/Caddyfile`, no `web/assets/public/js/htmx.ext.sse.js`, no `localhost.crt`, no `localhost.key`. README feature table lists no Caddy/SSE rows. `magefile.go` opens `http://localhost:<TEMPL_HTTP_PORT>`.
- `mage watch` listens on `33848` (Echo HTTP) and `33849` (templ HTTP proxy). No `33850`. `https://localhost:33848` fails with `wrong version number` (Echo is HTTP-only). Logs show `http server started on [::]:33848`, no TLS line.
- **This is the tree currently checked out at `/home/jtye/git/asdfasdf`.**

### Run B — Caddy via `sse` auto-include (separate regeneration; tree later overwritten by Run A)

- Features: `sse,session_settings,csrf,link_relations,web_standards`, port `33848`.
- `mage watch` listens on `33848` (Echo HTTP), `33849` (templ HTTP), `33850` (Caddy). `https://localhost:33850` returns 200 with `alt-svc: h3=":33850"`. Echo origin stayed HTTP (HTTPS to 33848 still refused).

## Residual risks

- Compression is still skipped when only the templ proxy is in front (no Caddy). Plan flagged this as a possible escalation; kept the unified `TEMPL_PROXY` semantic per the bounded-scope guidance — split if dev compression becomes a real ask.
- Generated apps still need `go tool templ generate` once after setup if stale `_templ.go` files reference stripped components (pre-existing, separate from this fix).