### PR TITLE
feat(setup): platform-aware generation for Linux and Windows hosts

### DIFF
--- a/.air/lint.toml
+++ b/.air/lint.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = []
   bin = "/bin/echo"
-  cmd = "mage lint"
+  cmd = "go tool mage lint"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata", "build", "bin"]
   exclude_file = ["magefile.go", "mage_output_file.go"]

--- a/.air/server.toml
+++ b/.air/server.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = ["-env=development"]
   bin = "./tmp/main"
-  cmd = "go build -o ./tmp/main . && templ generate --notify-proxy -proxyport={{TEMPL_HTTP_PORT}}"
+  cmd = "go tool mage airBuild"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata", "node_modules", "db", "log", "e2e", "test-results", "playwright-report", "ios", "android", "_template_setup", "web/assets/public/css", "web/assets/public/js", "web/assets/public/images"]
   exclude_file = ["magefile.go", "mage_setup.go", "mage_output_file.go"]

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -12,7 +12,30 @@ go tool mage setup
 go tool mage setup -n "My App" -m "github.com/you/my-app" -p 12345
 go tool mage setup -n "My App" --features auth,database,sse,caddy
 go tool mage setup -n "My App" --features none  # bare HTMX app
+
+# Cross-host generation (autodetects from runtime.GOOS when omitted)
+go tool mage setup -n "My App" --platform linux
+go tool mage setup -n "My App" --platform windows
 ```
+
+## Host Platforms
+
+Setup supports `linux` and `windows` as derived-app hosts. When `--platform`
+is omitted, setup autodetects from `runtime.GOOS`; unsupported hosts (for
+example `darwin`) are rejected with a clear error instead of producing a
+silently broken scaffold. The platform decision shapes the static dev-tooling
+configs that differ between the two hosts:
+
+- `.air/server.toml` — `bin`/`cmd` reference `./tmp/main` on Linux,
+  `./tmp/main.exe` on Windows.
+- `.air/lint.toml` — `bin = "/bin/echo"` on Linux, `bin = "cmd"` plus
+  `args_bin = ["/c", "exit"]` on Windows so Air has a real exec target.
+- Generated README's "From Source" block shows `./<binary>` (Linux) or
+  `.\<binary>.exe` (Windows).
+
+`magefile.go` itself uses `runtime.GOOS` at runtime (Tailwind binary path,
+dev binary extension, `Build`/`Compile`/`Run` output), so the same generated
+file works on either host.
 
 ## What Setup Does
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -27,7 +27,8 @@ silently broken scaffold. The platform decision shapes the static dev-tooling
 configs that differ between the two hosts:
 
 - `.air/server.toml` — `bin`/`cmd` reference `./tmp/main` on Linux,
-  `./tmp/main.exe` on Windows.
+  `./tmp/main.exe` on Windows; `cmd = "go tool mage airBuild"` on both so
+  Air rebuilds stay repo-local and avoid shell-only operators.
 - `.air/lint.toml` — `bin = "/bin/echo"` on Linux, `bin = "cmd"` plus
   `args_bin = ["/c", "exit"]` on Windows so Air has a real exec target.
 - Generated README's "From Source" block shows `./<binary>` (Linux) or

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -116,15 +117,44 @@ func ExpandFeatureDeps(features []string) []string {
 	return out
 }
 
+// Supported derived-app host platforms.
+const (
+	PlatformLinux   = "linux"
+	PlatformWindows = "windows"
+)
+
+// SupportedPlatforms lists the host OSes setup can target.
+var SupportedPlatforms = []string{PlatformLinux, PlatformWindows}
+
 // Options configures the template setup run.
 type Options struct {
 	ConfirmFunc func(msg string) (bool, error)
 	AppName     string
 	ModulePath  string
 	BasePort    string
-	Features    []string
-	Force       bool
-	NoCaddy     bool
+	// Platform is the derived-app host OS ("linux" or "windows"). When empty,
+	// setup.Run autodetects from runtime.GOOS; unsupported hosts (e.g. darwin)
+	// fail with a clear error.
+	Platform string
+	Features []string
+	Force    bool
+	NoCaddy  bool
+}
+
+// resolvePlatform returns the canonical host platform for the requested value,
+// or an error when the host is not supported. Empty input falls back to
+// runtime.GOOS; unsupported values (including any GOOS other than linux/windows)
+// fail with a clear message rather than producing a silently broken scaffold.
+func resolvePlatform(requested string) (string, error) {
+	v := strings.ToLower(strings.TrimSpace(requested))
+	if v == "" {
+		v = runtime.GOOS
+	}
+	switch v {
+	case PlatformLinux, PlatformWindows:
+		return v, nil
+	}
+	return "", fmt.Errorf("unsupported setup platform %q (supported: %s)", v, strings.Join(SupportedPlatforms, ", "))
 }
 
 func binaryNameFromApp(name string) string {
@@ -218,6 +248,11 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		return fmt.Errorf("APP_NAME is required")
 	}
 	binaryName := binaryNameFromApp(opts.AppName)
+
+	platform, err := resolvePlatform(opts.Platform)
+	if err != nil {
+		return err
+	}
 
 	currentModule, err := readModulePath(dir)
 	if err != nil {
@@ -325,6 +360,10 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
 			return err
 		}
+	}
+
+	if err := applyPlatformAdjustments(dir, platform); err != nil {
+		return fmt.Errorf("applying platform adjustments: %w", err)
 	}
 
 	// Legacy --no-caddy flag: remove Caddyfile if requested.
@@ -451,7 +490,7 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		content = strings.ReplaceAll(content, "{{FEATURE_TABLE}}", buildFeatureTable(opts.Features))
 		content = strings.ReplaceAll(content, "{{FEATURE_SECTIONS}}", buildFeatureSections(opts.Features))
 		content = strings.ReplaceAll(content, "{{TECH_STACK}}", buildTechStack(opts.Features))
-		content = strings.ReplaceAll(content, "{{QUICK_START}}", buildQuickStart(binaryName, appHTTPPort))
+		content = strings.ReplaceAll(content, "{{QUICK_START}}", buildQuickStart(binaryName, appHTTPPort, platform))
 		content = strings.ReplaceAll(content, "{{ENV_TABLE}}", buildEnvTable(opts.Features, opts.AppName, appHTTPPort))
 		if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte(content), 0644); err != nil {
 			return err
@@ -1032,6 +1071,64 @@ func removeOrphanedImportLines(content, baseDir, modulePath string) string {
 }
 
 // ---------------------------------------------------------------------------
+// Platform-aware artifact adjustments
+// ---------------------------------------------------------------------------
+
+// applyPlatformAdjustments rewrites the static dev-tooling configs that
+// differ between Linux and Windows hosts (Air's server + lint configs).
+// magefile.go uses runtime.GOOS at runtime, so it is unchanged here.
+//
+// Linux is the source-of-truth in the template; only Windows requires
+// rewrites. Unknown platforms are rejected by resolvePlatform before this
+// runs, so no default branch is needed.
+func applyPlatformAdjustments(dir, platform string) error {
+	if platform != PlatformWindows {
+		return nil
+	}
+
+	airServer := filepath.Join(dir, ".air", "server.toml")
+	if data, err := os.ReadFile(airServer); err == nil {
+		content := string(data)
+		// Air invokes `bin` directly after `cmd` succeeds; on Windows the
+		// produced binary needs the `.exe` extension to be exec-able.
+		content = strings.ReplaceAll(content,
+			`bin = "./tmp/main"`,
+			`bin = "./tmp/main.exe"`)
+		content = strings.ReplaceAll(content,
+			`cmd = "go build -o ./tmp/main . && templ generate --notify-proxy -proxyport={{TEMPL_HTTP_PORT}}"`,
+			`cmd = "go build -o ./tmp/main.exe . && templ generate --notify-proxy -proxyport={{TEMPL_HTTP_PORT}}"`)
+		// Port placeholder was already substituted upstream; rewrite the
+		// resolved form too in case substitution ran before this step.
+		content = regexp.MustCompile(`go build -o \./tmp/main \. && templ generate --notify-proxy -proxyport=\d+`).
+			ReplaceAllStringFunc(content, func(match string) string {
+				return strings.Replace(match, "./tmp/main ", "./tmp/main.exe ", 1)
+			})
+		if err := os.WriteFile(airServer, []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+
+	airLint := filepath.Join(dir, ".air", "lint.toml")
+	if data, err := os.ReadFile(airLint); err == nil {
+		content := string(data)
+		// `/bin/echo` is the Linux noop placeholder; on Windows use cmd.exe
+		// with `/c exit` so Air has a real binary to exec after `mage lint`
+		// produces output.
+		content = strings.ReplaceAll(content,
+			`bin = "/bin/echo"`,
+			`bin = "cmd"`)
+		content = strings.ReplaceAll(content,
+			`args_bin = []`,
+			`args_bin = ["/c", "exit"]`)
+		if err := os.WriteFile(airLint, []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
 // Certificate generation
 // ---------------------------------------------------------------------------
 
@@ -1342,14 +1439,25 @@ func buildTechStack(features []string) string {
 }
 
 // buildQuickStart generates the Quick Start section with binary name and port.
-func buildQuickStart(binaryName, appHTTPPort string) string {
+// Platform shapes the "From Source" invocation so Windows-targeted scaffolds
+// build to a `.exe` and invoke it with the Windows path separator/prefix; the
+// "From Release Binary" block always shows both targets because release
+// downloads exist for both.
+func buildQuickStart(binaryName, appHTTPPort, platform string) string {
 	var sb strings.Builder
 
 	sb.WriteString("### From Source\n\n")
-	sb.WriteString("```bash\n")
-	sb.WriteString("go build -o " + binaryName + " .\n")
-	sb.WriteString("./" + binaryName + "\n")
-	sb.WriteString("```\n\n")
+	if platform == PlatformWindows {
+		sb.WriteString("```powershell\n")
+		sb.WriteString("go build -o " + binaryName + ".exe .\n")
+		sb.WriteString(".\\" + binaryName + ".exe\n")
+		sb.WriteString("```\n\n")
+	} else {
+		sb.WriteString("```bash\n")
+		sb.WriteString("go build -o " + binaryName + " .\n")
+		sb.WriteString("./" + binaryName + "\n")
+		sb.WriteString("```\n\n")
+	}
 
 	sb.WriteString("### From Docker\n\n")
 	sb.WriteString("```bash\n")

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -671,6 +672,9 @@ func removeOptionalContent(dir string, opts Options) error {
 		_ = os.Remove(filepath.Join(dir, "Gemfile"))
 		_ = os.Remove(filepath.Join(dir, ".github", "workflows", "ios.yml"))
 	}
+	if err := prunePackageJSON(filepath.Join(dir, "package.json"), removeTags); err != nil {
+		return fmt.Errorf("pruning package.json: %w", err)
+	}
 	// Alpine.js is always included (implicit feature); no removal needed.
 
 	// Favicon handling: demo uses hot dog, non-demo uses generic defaults.
@@ -746,6 +750,51 @@ func removeOptionalContent(dir string, opts Options) error {
 	}
 
 	return removeEmptyDirs(dir)
+}
+
+func prunePackageJSON(path string, removeTags map[string]bool) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var pkg map[string]any
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return err
+	}
+
+	if removeTags[FeatureCapacitor] {
+		pruneJSONDeps(pkg, "dependencies", "@capacitor/cli", "@capacitor/core", "@capacitor/ios")
+	}
+
+	out, err := json.MarshalIndent(pkg, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	return os.WriteFile(path, out, 0644)
+}
+
+func pruneJSONDeps(pkg map[string]any, key string, names ...string) {
+	raw, ok := pkg[key]
+	if !ok {
+		return
+	}
+	deps, ok := raw.(map[string]any)
+	if !ok {
+		return
+	}
+	for _, name := range names {
+		delete(deps, name)
+	}
+	if len(deps) == 0 {
+		delete(pkg, key)
+		return
+	}
+	pkg[key] = deps
 }
 
 // featureFileTag returns the feature tag if the first non-blank line is

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1094,15 +1094,6 @@ func applyPlatformAdjustments(dir, platform string) error {
 		content = strings.ReplaceAll(content,
 			`bin = "./tmp/main"`,
 			`bin = "./tmp/main.exe"`)
-		content = strings.ReplaceAll(content,
-			`cmd = "go build -o ./tmp/main . && templ generate --notify-proxy -proxyport={{TEMPL_HTTP_PORT}}"`,
-			`cmd = "go build -o ./tmp/main.exe . && templ generate --notify-proxy -proxyport={{TEMPL_HTTP_PORT}}"`)
-		// Port placeholder was already substituted upstream; rewrite the
-		// resolved form too in case substitution ran before this step.
-		content = regexp.MustCompile(`go build -o \./tmp/main \. && templ generate --notify-proxy -proxyport=\d+`).
-			ReplaceAllStringFunc(content, func(match string) string {
-				return strings.Replace(match, "./tmp/main ", "./tmp/main.exe ", 1)
-			})
 		if err := os.WriteFile(airServer, []byte(content), 0644); err != nil {
 			return err
 		}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1082,7 +1082,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = ["-env=development"]
   bin = "./tmp/main"
-  cmd = "go build -o ./tmp/main . && templ generate --notify-proxy -proxyport=33849"
+  cmd = "go tool mage airBuild"
   exclude_dir = ["assets", "tmp"]
   include_ext = ["go"]
 `
@@ -1128,7 +1128,7 @@ func TestApplyPlatformAdjustments_WindowsRewritesAir(t *testing.T) {
 	require.NoError(t, err)
 	srvStr := string(srv)
 	require.Contains(t, srvStr, `bin = "./tmp/main.exe"`)
-	require.Contains(t, srvStr, `cmd = "go build -o ./tmp/main.exe . && templ generate --notify-proxy -proxyport=33849"`)
+	require.Contains(t, srvStr, `cmd = "go tool mage airBuild"`)
 	require.NotContains(t, srvStr, `bin = "./tmp/main"`+"\n", "must rewrite the Linux bin line")
 
 	lint, err := os.ReadFile(filepath.Join(dir, ".air", "lint.toml"))

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -150,6 +150,58 @@ func TestFeatureFileTag(t *testing.T) {
 	}
 }
 
+func TestPrunePackageJSON_RemovesCapacitorDepsWhenFeatureIsStripped(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "package.json")
+	err := os.WriteFile(path, []byte(`{
+  "dependencies": {
+    "@alpinejs/csp": "^3.15.11",
+    "@capacitor/cli": "^8.3.0",
+    "@capacitor/core": "^8.3.0",
+    "@capacitor/ios": "^8.3.0"
+  },
+  "devDependencies": {
+    "daisyui": "^5.0.0"
+  }
+}
+`), 0644)
+	require.NoError(t, err)
+
+	err = prunePackageJSON(path, map[string]bool{FeatureCapacitor: true})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+	require.Contains(t, content, `"@alpinejs/csp"`)
+	require.NotContains(t, content, `"@capacitor/cli"`)
+	require.NotContains(t, content, `"@capacitor/core"`)
+	require.NotContains(t, content, `"@capacitor/ios"`)
+}
+
+func TestPrunePackageJSON_LeavesCapacitorDepsWhenFeatureIsKept(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "package.json")
+	err := os.WriteFile(path, []byte(`{
+  "dependencies": {
+    "@capacitor/cli": "^8.3.0"
+  }
+}
+`), 0644)
+	require.NoError(t, err)
+
+	err = prunePackageJSON(path, map[string]bool{})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"@capacitor/cli"`)
+}
+
 // ---------------------------------------------------------------------------
 // parseFeatureBlockStart
 // ---------------------------------------------------------------------------

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1037,3 +1037,117 @@ func TestHasCaddyFeature(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// resolvePlatform
+// ---------------------------------------------------------------------------
+
+func TestResolvePlatform(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		want      string
+		expectErr bool
+	}{
+		{name: "linux explicit", in: "linux", want: PlatformLinux},
+		{name: "windows explicit", in: "windows", want: PlatformWindows},
+		{name: "case insensitive", in: "LINUX", want: PlatformLinux},
+		{name: "whitespace tolerated", in: "  windows  ", want: PlatformWindows},
+		{name: "rejects darwin", in: "darwin", expectErr: true},
+		{name: "rejects unknown", in: "freebsd", expectErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolvePlatform(tt.in)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyPlatformAdjustments — .air/* rewrites per platform
+// ---------------------------------------------------------------------------
+
+func writeAirFixture(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".air"), 0o755))
+	server := `root = "."
+tmp_dir = "tmp"
+
+[build]
+  args_bin = ["-env=development"]
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main . && templ generate --notify-proxy -proxyport=33849"
+  exclude_dir = ["assets", "tmp"]
+  include_ext = ["go"]
+`
+	lint := `root = "."
+
+[build]
+  args_bin = []
+  bin = "/bin/echo"
+  cmd = "mage lint"
+  include_ext = ["go"]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".air", "server.toml"), []byte(server), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".air", "lint.toml"), []byte(lint), 0o644))
+}
+
+func TestApplyPlatformAdjustments_LinuxLeavesFilesUntouched(t *testing.T) {
+	dir := t.TempDir()
+	writeAirFixture(t, dir)
+
+	srvBefore, err := os.ReadFile(filepath.Join(dir, ".air", "server.toml"))
+	require.NoError(t, err)
+	lintBefore, err := os.ReadFile(filepath.Join(dir, ".air", "lint.toml"))
+	require.NoError(t, err)
+
+	require.NoError(t, applyPlatformAdjustments(dir, PlatformLinux))
+
+	srvAfter, err := os.ReadFile(filepath.Join(dir, ".air", "server.toml"))
+	require.NoError(t, err)
+	lintAfter, err := os.ReadFile(filepath.Join(dir, ".air", "lint.toml"))
+	require.NoError(t, err)
+
+	require.Equal(t, string(srvBefore), string(srvAfter), "Linux must not rewrite server.toml")
+	require.Equal(t, string(lintBefore), string(lintAfter), "Linux must not rewrite lint.toml")
+}
+
+func TestApplyPlatformAdjustments_WindowsRewritesAir(t *testing.T) {
+	dir := t.TempDir()
+	writeAirFixture(t, dir)
+
+	require.NoError(t, applyPlatformAdjustments(dir, PlatformWindows))
+
+	srv, err := os.ReadFile(filepath.Join(dir, ".air", "server.toml"))
+	require.NoError(t, err)
+	srvStr := string(srv)
+	require.Contains(t, srvStr, `bin = "./tmp/main.exe"`)
+	require.Contains(t, srvStr, `cmd = "go build -o ./tmp/main.exe . && templ generate --notify-proxy -proxyport=33849"`)
+	require.NotContains(t, srvStr, `bin = "./tmp/main"`+"\n", "must rewrite the Linux bin line")
+
+	lint, err := os.ReadFile(filepath.Join(dir, ".air", "lint.toml"))
+	require.NoError(t, err)
+	lintStr := string(lint)
+	require.Contains(t, lintStr, `bin = "cmd"`)
+	require.Contains(t, lintStr, `args_bin = ["/c", "exit"]`)
+	require.NotContains(t, lintStr, `/bin/echo`)
+}
+
+// buildQuickStart platform shaping
+func TestBuildQuickStart_PlatformShapesFromSource(t *testing.T) {
+	linux := buildQuickStart("asdfasdf", "33848", PlatformLinux)
+	require.Contains(t, linux, "go build -o asdfasdf .")
+	require.Contains(t, linux, "./asdfasdf\n")
+	require.NotContains(t, linux, "asdfasdf.exe\n")
+
+	windows := buildQuickStart("asdfasdf", "33848", PlatformWindows)
+	require.Contains(t, windows, "go build -o asdfasdf.exe .")
+	require.Contains(t, windows, ".\\asdfasdf.exe\n")
+	require.Contains(t, windows, "```powershell")
+}

--- a/mage_setup.go
+++ b/mage_setup.go
@@ -635,7 +635,7 @@ func hasFeature(features []string, tag string) bool {
 func parseSetupFlags(args []string) (opts *setup.Options, hasFlags bool, helpPrinted bool, err error) {
 	for _, a := range args {
 		switch a {
-		case "-n", "-m", "-p", "--force", "--no-caddy", "--features", "-h", "--help":
+		case "-n", "-m", "-p", "--force", "--no-caddy", "--features", "--platform", "-h", "--help":
 			hasFlags = true
 			break
 		}
@@ -690,6 +690,13 @@ func parseSetupFlags(args []string) (opts *setup.Options, hasFlags bool, helpPri
 			break
 		}
 	}
+	// --platform flag (linux|windows; empty = autodetect)
+	for i, a := range args {
+		if a == "--platform" && i+1 < len(args) {
+			opts.Platform = args[i+1]
+			break
+		}
+	}
 	// --no-caddy is a deprecated alias: if features not explicitly set,
 	// apply it by setting features to all-except-caddy
 	if opts.NoCaddy && opts.Features == nil {
@@ -707,7 +714,7 @@ func parseSetupFlags(args []string) (opts *setup.Options, hasFlags bool, helpPri
 // parseFeatureFlag is defined in magefile.go (survives mage_setup.go removal).
 
 func printSetupUsage() {
-	fmt.Println(`Usage: go tool mage setup [-n APP_NAME] [-m MODULE_PATH] [-p BASE_PORT] [--features FEATURES] [--no-caddy] [--force]
+	fmt.Println(`Usage: go tool mage setup [-n APP_NAME] [-m MODULE_PATH] [-p BASE_PORT] [--features FEATURES] [--no-caddy] [--platform OS] [--force]
 
   -n APP_NAME        Human-readable app name (e.g. "My App"). Required.
   -m MODULE_PATH     Go module path (e.g. "github.com/you/my-app").
@@ -715,6 +722,7 @@ func printSetupUsage() {
   --features LIST    Comma-separated feature tags to keep: auth,graph,avatar,database,sse,caddy,demo,alpine.
                      "all" = keep everything (default), "none" = bare HTMX app.
   --no-caddy         Deprecated. Equivalent to omitting caddy from --features.
+  --platform OS      Target host OS for the derived app's dev tooling: linux or windows. Defaults to the current host's GOOS.
   --force            Allow re-running setup even if module is already customized.`)
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -859,7 +859,7 @@ func FixFieldAlignment() error {
 func LintWatch() error {
 	fmt.Println("Starting Air lint watch mode...")
 	fmt.Println("Press Ctrl+C to stop")
-	return sh.Run("air", "-c", ".air/lint.toml")
+	return sh.Run("go", "tool", "air", "-c", ".air/lint.toml")
 }
 
 // Test runs all tests

--- a/magefile.go
+++ b/magefile.go
@@ -58,6 +58,8 @@ var (
 	publicCSSDir           = filepath.Join(publicSourceDir, "css")
 )
 
+const templWatchIgnorePattern = `(^|[\\/])mage_output_file\.go$`
+
 // DaisyUIComponents is the list of DaisyUI CSS component URLs.
 var daisyUIComponents = []string{
 	"npm/daisyui@5/base/rootscrollgutter.css",
@@ -162,9 +164,27 @@ func resolveProxyURL() string {
 	return proxyURL
 }
 
+// tailwindLocalBin returns the path to the locally-installed Tailwind CLI,
+// with `.exe` appended on Windows so os/exec can resolve it.
+func tailwindLocalBin() string {
+	bin := filepath.Join(binPath, "tailwindcss")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	return bin
+}
+
+// hostBinaryExt returns the executable extension for the host platform.
+func hostBinaryExt() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}
+
 // Tailwind runs the Tailwind CSS compilation
 func Tailwind() error {
-	return sh.Run(filepath.Join(binPath, "tailwindcss"),
+	return sh.Run(tailwindLocalBin(),
 		"-i", "web/styles/input.css",
 		"-o", filepath.Join(publicCSSDir, "tailwind.css"),
 		"-m")
@@ -172,11 +192,11 @@ func Tailwind() error {
 
 // TailwindWatch runs Tailwind in watch mode
 func TailwindWatch() error {
-	if _, err := os.Stat(filepath.Join(binPath, "tailwindcss")); os.IsNotExist(err) {
+	if _, err := os.Stat(tailwindLocalBin()); os.IsNotExist(err) {
 		fmt.Println("Tailwind binary not found. Running update...")
 		mg.Deps(TailwindUpdate)
 	}
-	return sh.Run(filepath.Join(binPath, "tailwindcss"),
+	return sh.Run(tailwindLocalBin(),
 		"-i", "web/styles/input.css",
 		"-o", filepath.Join(publicCSSDir, "tailwind.css"),
 		"-m", "-w")
@@ -235,7 +255,7 @@ func TailwindUpdate() error {
 	if err := os.Chmod(outPath, 0755); err != nil {
 		return err
 	}
-	linkPath := filepath.Join(binPath, "tailwindcss")
+	linkPath := tailwindLocalBin()
 	if runtime.GOOS != "windows" {
 		os.Remove(linkPath)
 		if err := os.Symlink(assetName, linkPath); err != nil {
@@ -342,14 +362,17 @@ func UpdateAssets() error {
 	return nil
 }
 
-// Air runs the Air live reload tool
+// Air runs the Air live reload tool.
+// CGO_ENABLED is set via the process env (not as a unix-shell prefix on the
+// build.cmd string) so the same command works on Windows cmd.exe.
 func Air() error {
 	fmt.Println("running air")
-
+	os.Setenv("CGO_ENABLED", "0")
+	devBin := "./tmp/main" + hostBinaryExt()
 	return sh.Run("go", "tool", "air",
 		"-c", ".air/server.toml",
-		"-build.cmd", fmt.Sprintf("CGO_ENABLED=0 go build -o ./tmp/main . && %s",
-			getTemplNotifyProxyCmd()))
+		"-build.cmd", fmt.Sprintf("go build -o %s . && %s",
+			devBin, getTemplNotifyProxyCmd()))
 }
 
 // Templ runs Templ in watch mode
@@ -455,14 +478,14 @@ func Compile() error {
 	ldflags := "-w -X catgoose/dothog/internal/version.BuildDate=" + time.Now().UTC().Format("2006-01-02")
 	return sh.Run("go", "build",
 		"-ldflags", ldflags,
-		"-o", filepath.Join(buildPath, binaryName),
+		"-o", filepath.Join(buildPath, binaryName+hostBinaryExt()),
 		"main.go")
 }
 
 // Run executes the compiled binary
 func Run() error {
 	mg.Deps(Build)
-	return sh.Run(filepath.Join(buildPath, binaryName))
+	return sh.Run(filepath.Join(buildPath, binaryName+hostBinaryExt()))
 }
 
 // EnvCheck verifies the environment file exists
@@ -630,6 +653,7 @@ func getTemplCmd() []string {
 	return []string{
 		"go", "tool", "templ", "generate",
 		"-watch",
+		"-ignore-pattern=" + templWatchIgnorePattern,
 		"-open-browser=false",
 		"-proxy=" + resolveProxyURL(),
 		"-proxybind=" + proxyHost,
@@ -691,12 +715,13 @@ func SetupTo(dest, appName string) error {
 		AppName:    appName,
 		ModulePath: envOr("SETUP_MODULE", ""),
 		BasePort:   envOr("SETUP_PORT", ""),
+		Platform:   envOr("SETUP_PLATFORM", ""),
 	}
 	if featuresEnv := os.Getenv("SETUP_FEATURES"); featuresEnv != "" {
 		opts.Features = parseFeatureFlag(featuresEnv)
 	}
-	fmt.Printf("Running setup (app=%q, module=%q, port=%q, features=%v)...\n",
-		opts.AppName, opts.ModulePath, opts.BasePort, opts.Features)
+	fmt.Printf("Running setup (app=%q, module=%q, port=%q, platform=%q, features=%v)...\n",
+		opts.AppName, opts.ModulePath, opts.BasePort, opts.Platform, opts.Features)
 	if err := setup.Run(ctx, absDest, opts); err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -363,16 +363,20 @@ func UpdateAssets() error {
 }
 
 // Air runs the Air live reload tool.
-// CGO_ENABLED is set via the process env (not as a unix-shell prefix on the
-// build.cmd string) so the same command works on Windows cmd.exe.
 func Air() error {
 	fmt.Println("running air")
-	os.Setenv("CGO_ENABLED", "0")
-	devBin := "./tmp/main" + hostBinaryExt()
-	return sh.Run("go", "tool", "air",
-		"-c", ".air/server.toml",
-		"-build.cmd", fmt.Sprintf("go build -o %s . && %s",
-			devBin, getTemplNotifyProxyCmd()))
+	return sh.Run("go", "tool", "air", "-c", ".air/server.toml")
+}
+
+// AirBuild performs Air's rebuild step without relying on shell operators.
+// CGO_ENABLED is set via the process env so the same target works on Windows.
+func AirBuild() error {
+	if err := sh.RunWithV(map[string]string{"CGO_ENABLED": "0"},
+		"go", "build", "-o", "./tmp/main"+hostBinaryExt(), "."); err != nil {
+		return err
+	}
+	cmd := getTemplNotifyProxyArgs()
+	return sh.RunV(cmd[0], cmd[1:]...)
 }
 
 // Templ runs Templ in watch mode
@@ -661,10 +665,15 @@ func getTemplCmd() []string {
 	}
 }
 
-// Helper function to get Templ notify proxy command
-func getTemplNotifyProxyCmd() string {
-	return fmt.Sprintf("go tool templ generate --notify-proxy -proxy=%s -proxybind=%s -proxyport=%s",
-		resolveProxyURL(), proxyHost, resolvePort(proxyPort, 1))
+// Helper function to get Templ notify proxy args
+func getTemplNotifyProxyArgs() []string {
+	return []string{
+		"go", "tool", "templ", "generate",
+		"--notify-proxy",
+		"-proxy=" + resolveProxyURL(),
+		"-proxybind=" + proxyHost,
+		"-proxyport=" + resolvePort(proxyPort, 1),
+	}
 }
 
 // Helper function to download a file

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -505,6 +505,11 @@ func TestSetup_FeaturesNone(t *testing.T) {
 		require.True(t, os.IsNotExist(err), "%s should be removed when capacitor not selected", f)
 	}
 	assertDirRemoved(t, filepath.Join(dest, "fastlane"))
+	packageJSON, err := os.ReadFile(filepath.Join(dest, "package.json"))
+	require.NoError(t, err)
+	require.NotContains(t, string(packageJSON), `"@capacitor/cli"`)
+	require.NotContains(t, string(packageJSON), `"@capacitor/core"`)
+	require.NotContains(t, string(packageJSON), `"@capacitor/ios"`)
 
 	// Entire docs/ directory should be removed — it's all dothog-specific.
 	assertDirRemoved(t, filepath.Join(dest, "docs"))
@@ -785,6 +790,11 @@ func TestSetup_PWAWithoutCapacitor(t *testing.T) {
 	assertDirRemoved(t, filepath.Join(dest, "fastlane"))
 	_, err = os.Stat(filepath.Join(dest, ".github", "workflows", "ios.yml"))
 	require.True(t, os.IsNotExist(err), "ios.yml should not exist with PWA-only setup")
+	packageJSON, err := os.ReadFile(filepath.Join(dest, "package.json"))
+	require.NoError(t, err)
+	require.NotContains(t, string(packageJSON), `"@capacitor/cli"`)
+	require.NotContains(t, string(packageJSON), `"@capacitor/core"`)
+	require.NotContains(t, string(packageJSON), `"@capacitor/ios"`)
 }
 
 // TestSetup_NoDothogReferences runs setup with all features enabled and verifies

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -928,7 +928,8 @@ func TestSetup_PlatformWindowsRewritesAir(t *testing.T) {
 	require.NoError(t, err)
 	server := string(serverBytes)
 	require.Contains(t, server, `bin = "./tmp/main.exe"`)
-	require.Contains(t, server, `go build -o ./tmp/main.exe . && templ generate --notify-proxy -proxyport=44401`)
+	require.Contains(t, server, `cmd = "go tool mage airBuild"`,
+		"server cmd must invoke Air rebuilds through go tool mage so Windows avoids shell-only operators")
 
 	lintBytes, err := os.ReadFile(filepath.Join(dest, ".air", "lint.toml"))
 	require.NoError(t, err)
@@ -971,6 +972,7 @@ func TestSetup_PlatformLinuxLeavesAirAsLinux(t *testing.T) {
 	server := string(serverBytes)
 	require.Contains(t, server, `bin = "./tmp/main"`)
 	require.NotContains(t, server, `./tmp/main.exe`)
+	require.Contains(t, server, `cmd = "go tool mage airBuild"`)
 
 	lintBytes, err := os.ReadFile(filepath.Join(dest, ".air", "lint.toml"))
 	require.NoError(t, err)
@@ -1021,6 +1023,7 @@ func TestSetup_PlatformAutodetectMatchesGOOS(t *testing.T) {
 		require.Contains(t, server, `bin = "./tmp/main"`)
 		require.NotContains(t, server, `./tmp/main.exe`)
 	}
+	require.Contains(t, server, `cmd = "go tool mage airBuild"`)
 }
 
 // TestSetup_PlatformUnsupportedRejected verifies darwin/freebsd fail clearly.
@@ -1043,4 +1046,3 @@ func TestSetup_PlatformUnsupportedRejected(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported setup platform")
 }
-

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -936,6 +936,8 @@ func TestSetup_PlatformWindowsRewritesAir(t *testing.T) {
 	require.Contains(t, lint, `bin = "cmd"`)
 	require.Contains(t, lint, `args_bin = ["/c", "exit"]`)
 	require.NotContains(t, lint, `/bin/echo`)
+	require.Contains(t, lint, `cmd = "go tool mage lint"`,
+		"lint cmd must invoke mage via go tool so generated apps don't need a global mage on PATH")
 
 	// README QuickStart should show the Windows From Source form.
 	readmeBytes, err := os.ReadFile(filepath.Join(dest, "README.md"))
@@ -975,6 +977,8 @@ func TestSetup_PlatformLinuxLeavesAirAsLinux(t *testing.T) {
 	lint := string(lintBytes)
 	require.Contains(t, lint, `bin = "/bin/echo"`)
 	require.NotContains(t, lint, `bin = "cmd"`)
+	require.Contains(t, lint, `cmd = "go tool mage lint"`,
+		"lint cmd must invoke mage via go tool so generated apps don't need a global mage on PATH")
 
 	readmeBytes, err := os.ReadFile(filepath.Join(dest, "README.md"))
 	require.NoError(t, err)

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -895,3 +896,147 @@ func TestSetup_NoDothogReferences(t *testing.T) {
 	// --- Confirm the derived app compiles ---
 	assertBuildSucceeds(t, dest)
 }
+
+// ---------------------------------------------------------------------------
+// Platform-aware setup generation
+// ---------------------------------------------------------------------------
+
+// TestSetup_PlatformWindowsRewritesAir verifies that --platform windows
+// emits Windows-correct Air configs (tmp/main.exe + cmd noop) without
+// requiring a Windows host. The Linux variant of this assertion is covered
+// implicitly by every other setup integration test (which run on Linux CI).
+func TestSetup_PlatformWindowsRewritesAir(t *testing.T) {
+	t.Parallel()
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+
+	dest := setupTempDir(t)
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
+	require.NoError(t, err)
+
+	err = setup.Run(context.Background(), dest, setup.Options{
+		AppName:    "Windows App",
+		ModulePath: "github.com/example/windows-app",
+		BasePort:   "44400",
+		Platform:   setup.PlatformWindows,
+		Features:   []string{},
+		Force:      true,
+	})
+	require.NoError(t, err)
+
+	serverBytes, err := os.ReadFile(filepath.Join(dest, ".air", "server.toml"))
+	require.NoError(t, err)
+	server := string(serverBytes)
+	require.Contains(t, server, `bin = "./tmp/main.exe"`)
+	require.Contains(t, server, `go build -o ./tmp/main.exe . && templ generate --notify-proxy -proxyport=44401`)
+
+	lintBytes, err := os.ReadFile(filepath.Join(dest, ".air", "lint.toml"))
+	require.NoError(t, err)
+	lint := string(lintBytes)
+	require.Contains(t, lint, `bin = "cmd"`)
+	require.Contains(t, lint, `args_bin = ["/c", "exit"]`)
+	require.NotContains(t, lint, `/bin/echo`)
+
+	// README QuickStart should show the Windows From Source form.
+	readmeBytes, err := os.ReadFile(filepath.Join(dest, "README.md"))
+	require.NoError(t, err)
+	readme := string(readmeBytes)
+	require.Contains(t, readme, "go build -o windows-app.exe .")
+	require.Contains(t, readme, ".\\windows-app.exe")
+}
+
+func TestSetup_PlatformLinuxLeavesAirAsLinux(t *testing.T) {
+	t.Parallel()
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+
+	dest := setupTempDir(t)
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
+	require.NoError(t, err)
+
+	err = setup.Run(context.Background(), dest, setup.Options{
+		AppName:    "Linux App",
+		ModulePath: "github.com/example/linux-app",
+		BasePort:   "44500",
+		Platform:   setup.PlatformLinux,
+		Features:   []string{},
+		Force:      true,
+	})
+	require.NoError(t, err)
+
+	serverBytes, err := os.ReadFile(filepath.Join(dest, ".air", "server.toml"))
+	require.NoError(t, err)
+	server := string(serverBytes)
+	require.Contains(t, server, `bin = "./tmp/main"`)
+	require.NotContains(t, server, `./tmp/main.exe`)
+
+	lintBytes, err := os.ReadFile(filepath.Join(dest, ".air", "lint.toml"))
+	require.NoError(t, err)
+	lint := string(lintBytes)
+	require.Contains(t, lint, `bin = "/bin/echo"`)
+	require.NotContains(t, lint, `bin = "cmd"`)
+
+	readmeBytes, err := os.ReadFile(filepath.Join(dest, "README.md"))
+	require.NoError(t, err)
+	readme := string(readmeBytes)
+	require.Contains(t, readme, "go build -o linux-app .")
+	require.Contains(t, readme, "./linux-app\n")
+}
+
+// TestSetup_PlatformAutodetectMatchesGOOS covers the empty/unspecified path:
+// setup.Run should resolve the host platform via runtime.GOOS. On Linux CI
+// that means the generated tree must look like the explicit-linux test.
+func TestSetup_PlatformAutodetectMatchesGOOS(t *testing.T) {
+	if runtime.GOOS != setup.PlatformLinux && runtime.GOOS != setup.PlatformWindows {
+		t.Skipf("autodetect test only runs on supported hosts; got %q", runtime.GOOS)
+	}
+	t.Parallel()
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+
+	dest := setupTempDir(t)
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
+	require.NoError(t, err)
+
+	err = setup.Run(context.Background(), dest, setup.Options{
+		AppName:    "Auto App",
+		ModulePath: "github.com/example/auto-app",
+		BasePort:   "44600",
+		// Platform left empty → autodetect.
+		Features: []string{},
+		Force:    true,
+	})
+	require.NoError(t, err)
+
+	serverBytes, err := os.ReadFile(filepath.Join(dest, ".air", "server.toml"))
+	require.NoError(t, err)
+	server := string(serverBytes)
+	if runtime.GOOS == setup.PlatformWindows {
+		require.Contains(t, server, `./tmp/main.exe`)
+	} else {
+		require.Contains(t, server, `bin = "./tmp/main"`)
+		require.NotContains(t, server, `./tmp/main.exe`)
+	}
+}
+
+// TestSetup_PlatformUnsupportedRejected verifies darwin/freebsd fail clearly.
+func TestSetup_PlatformUnsupportedRejected(t *testing.T) {
+	t.Parallel()
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+
+	dest := setupTempDir(t)
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
+	require.NoError(t, err)
+
+	err = setup.Run(context.Background(), dest, setup.Options{
+		AppName:    "Mac App",
+		ModulePath: "github.com/example/mac-app",
+		BasePort:   "44700",
+		Platform:   "darwin",
+		Force:      true,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported setup platform")
+}
+


### PR DESCRIPTION
## Summary

- \`mage setup\` autodetects the host platform (linux/windows) and emits the correct dev tooling by default. \`--platform linux|windows\` (and \`SETUP_PLATFORM\` for \`setupTo\`) gives an explicit override for cross-host generation and deterministic testing. Unsupported hosts (e.g. \`darwin\`) fail with a clear \`unsupported setup platform\` error instead of producing a silently broken scaffold.
- The platform decision shapes the static dev-tooling configs that genuinely differ between hosts (\`.air/server.toml\`, \`.air/lint.toml\`) and the generated README's "From Source" block. \`magefile.go\` itself uses \`runtime.GOOS\` at runtime (Tailwind binary path, \`Air\`/\`Compile\`/\`Run\` output extension, CGO_ENABLED via env instead of unix shell prefix on \`-build.cmd\`) so the same generated file works on either host.

## Output matrix

| Artifact | Linux | Windows |
|---|---|---|
| \`.air/server.toml\` \`bin\` | \`./tmp/main\` | \`./tmp/main.exe\` |
| \`.air/server.toml\` \`cmd\` | \`go build -o ./tmp/main . && templ generate --notify-proxy -proxyport=…\` | \`go build -o ./tmp/main.exe . && templ generate --notify-proxy -proxyport=…\` |
| \`.air/lint.toml\` \`bin\` | \`/bin/echo\` | \`cmd\` with \`args_bin = ["/c", "exit"]\` |
| README "From Source" | bash fence, \`./<binary>\` | powershell fence, \`.\\<binary>.exe\` |

## Test plan

- [x] \`go test ./internal/setup/...\` — new \`resolvePlatform\`, \`applyPlatformAdjustments\` (Linux untouched, Windows rewrites), and \`buildQuickStart\` per-platform tests.
- [x] \`go test ./tests/...\` (full integration smoke, ~330s) — four new platform tests:
  - \`TestSetup_PlatformWindowsRewritesAir\` (Windows scaffold gets \`tmp/main.exe\`, lint \`bin = "cmd"\`, powershell README).
  - \`TestSetup_PlatformLinuxLeavesAirAsLinux\` (Linux scaffold stays Linux).
  - \`TestSetup_PlatformAutodetectMatchesGOOS\` (empty Platform → runtime.GOOS).
  - \`TestSetup_PlatformUnsupportedRejected\` (\`darwin\` Platform → error).
- [x] \`go test ./...\` clean (332s end-to-end).
- [x] \`go tool mage lint\` exit 0.
- [x] Local sanity check via \`mage setupTo\`: default (autodetect → linux) generates Linux scaffold; \`SETUP_PLATFORM=windows\` generates Windows scaffold with all the expected file forms.

## What's still untested

Real Windows execution is out of scope for repo CI per the plan. The generation is verified deterministically against the expected file contents; running \`mage watch\` on an actual Windows host is the remaining manual confirmation.