### PR TITLE
fix(theme,errors): persist themes without sse and promote route 404s

### DIFF
--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -3,20 +3,20 @@ package handler
 
 import (
 	"catgoose/dothog/internal/logger"
-	"github.com/catgoose/linkwell"
 	"catgoose/dothog/internal/routes/middleware"
 	"catgoose/dothog/internal/version"
 	"catgoose/dothog/web/views"
 	"context"
 	"errors"
 	"fmt"
+	"github.com/catgoose/linkwell"
 	"net/http"
 	"strings"
 
 	corecomponents "catgoose/dothog/web/components/core"
 
-	"github.com/a-h/templ"
 	"catgoose/dothog/internal/env"
+	"github.com/a-h/templ"
 	// setup:feature:session_settings:start
 	"catgoose/dothog/internal/session"
 	// setup:feature:session_settings:end
@@ -291,12 +291,20 @@ func HandleHypermediaError(c echo.Context, statusCode int, message string, err e
 // navigation. HTMX requests return a hypermedia error with back/home/report
 // controls, rendered as an OOB banner by ErrorHandlerMiddleware.
 // Register with e.RouteNotFound.
+//
+// Both branches return a 404 error so Echo's HTTPErrorHandler runs and the
+// per-request log buffer is promoted into the error-trace store. The non-HTMX
+// branch renders the response first and relies on the handler's committed-
+// response short-circuit to avoid double-rendering.
 func HandleNotFound(c echo.Context) error {
 	if c.Request().Header.Get("HX-Request") == "true" {
 		return HandleHypermediaError(c, http.StatusNotFound, "Not Found", nil)
 	}
 	c.Response().Status = http.StatusNotFound
-	return RenderBaseLayout(c, views.NotFoundPage(c.Request().URL.Path))
+	if err := RenderBaseLayout(c, views.NotFoundPage(c.Request().URL.Path)); err != nil {
+		return err
+	}
+	return echo.NewHTTPError(http.StatusNotFound, "Not Found")
 }
 
 // HandleComponent is a handler that renders a templ component

--- a/internal/routes/handler/handler_notfound_promotion_test.go
+++ b/internal/routes/handler/handler_notfound_promotion_test.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"catgoose/dothog/internal/routes/middleware"
+	"github.com/catgoose/promolog"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingStore is a minimal promolog.Storer that records every Promote call.
+// Only Promote is exercised by the HTTP error handler; the rest are no-op stubs.
+type recordingStore struct {
+	onPromote func(promolog.TraceSummary)
+	traces    []promolog.Trace
+	mu        sync.Mutex
+}
+
+func (s *recordingStore) InitSchema() error                           { return nil }
+func (s *recordingStore) SetOnPromote(fn func(promolog.TraceSummary)) { s.onPromote = fn }
+func (s *recordingStore) PromoteAt(_ context.Context, t promolog.Trace, _ time.Time) error {
+	return s.Promote(context.Background(), t)
+}
+func (s *recordingStore) Get(_ context.Context, _ string) (*promolog.Trace, error) {
+	return nil, nil
+}
+func (s *recordingStore) ListTraces(_ context.Context, _ promolog.TraceFilter) ([]promolog.TraceSummary, int, error) {
+	return nil, 0, nil
+}
+func (s *recordingStore) AvailableFilters(_ context.Context, _ promolog.TraceFilter) (promolog.FilterOptions, error) {
+	return promolog.FilterOptions{}, nil
+}
+func (s *recordingStore) DeleteTrace(_ context.Context, _ string) error                    { return nil }
+func (s *recordingStore) StartCleanup(_ context.Context, _ time.Duration, _ time.Duration) {}
+func (s *recordingStore) CreateRule(_ context.Context, r promolog.FilterRule) (promolog.FilterRule, error) {
+	return r, nil
+}
+func (s *recordingStore) ListRules(_ context.Context) ([]promolog.FilterRule, error) { return nil, nil }
+func (s *recordingStore) UpdateRule(_ context.Context, _ promolog.FilterRule) error  { return nil }
+func (s *recordingStore) DeleteRule(_ context.Context, _ int) error                  { return nil }
+func (s *recordingStore) CreateRetentionRule(_ context.Context, r promolog.RetentionRule) (promolog.RetentionRule, error) {
+	return r, nil
+}
+func (s *recordingStore) ListRetentionRules(_ context.Context) ([]promolog.RetentionRule, error) {
+	return nil, nil
+}
+func (s *recordingStore) UpdateRetentionRule(_ context.Context, _ promolog.RetentionRule) error {
+	return nil
+}
+func (s *recordingStore) DeleteRetentionRule(_ context.Context, _ int) error { return nil }
+func (s *recordingStore) Aggregate(_ context.Context, _ promolog.AggregateFilter) ([]promolog.AggregateResult, error) {
+	return nil, nil
+}
+
+func (s *recordingStore) Promote(_ context.Context, t promolog.Trace) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.traces = append(s.traces, t)
+	return nil
+}
+
+func (s *recordingStore) snapshot() []promolog.Trace {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]promolog.Trace, len(s.traces))
+	copy(out, s.traces)
+	return out
+}
+
+var _ promolog.Storer = (*recordingStore)(nil)
+
+// newEchoWithPromotion returns an Echo configured like the production stack
+// for the 404 path: correlation middleware (so requests carry an ID), the
+// production HTTPErrorHandler (which is what calls Promote), and the
+// production RouteNotFound handler.
+func newEchoWithPromotion(store promolog.Storer) *echo.Echo {
+	e := echo.New()
+	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
+	e.HTTPErrorHandler = middleware.NewHTTPErrorHandler(store)
+	e.RouteNotFound("/*", HandleNotFound)
+	return e
+}
+
+// TestHandleNotFound_NonHTMX_PromotesTrace pins down the regression where
+// a direct unmatched-route visit rendered the 404 page but never made it
+// into the promolog error-trace store.
+func TestHandleNotFound_NonHTMX_PromotesTrace(t *testing.T) {
+	store := &recordingStore{}
+	e := newEchoWithPromotion(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/fakeroute/asdf", http.NoBody)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	traces := store.snapshot()
+	require.Len(t, traces, 1, "unmatched non-HTMX route should promote exactly one trace")
+	require.Equal(t, http.StatusNotFound, traces[0].StatusCode)
+	require.Equal(t, "/fakeroute/asdf", traces[0].Route)
+	require.Equal(t, http.MethodGet, traces[0].Method)
+	require.NotEmpty(t, traces[0].RequestID, "promoted trace should carry the correlation request ID")
+}
+
+// TestHandleNotFound_HTMX_PromotesTrace guards the pre-existing HTMX path:
+// it should still reach the promote step.
+func TestHandleNotFound_HTMX_PromotesTrace(t *testing.T) {
+	store := &recordingStore{}
+	e := newEchoWithPromotion(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/fakeroute/asdf", http.NoBody)
+	req.Header.Set("HX-Request", "true")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	traces := store.snapshot()
+	require.Len(t, traces, 1)
+	require.Equal(t, http.StatusNotFound, traces[0].StatusCode)
+	require.Equal(t, "/fakeroute/asdf", traces[0].Route)
+}
+
+// TestHandleNotFound_NonHTMX_RendersBody protects the existing UX: non-HTMX
+// 404 still emits a non-empty HTML body (not just an OOB swap).
+func TestHandleNotFound_NonHTMX_RendersBody(t *testing.T) {
+	store := &recordingStore{}
+	e := newEchoWithPromotion(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/fakeroute/asdf", http.NoBody)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.NotEmpty(t, rec.Body.String(), "non-HTMX 404 body should not be empty")
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -214,8 +214,9 @@ func (ar *appRoutes) InitRoutes() error {
 	ar.initLifelineRoutes(ar.broker)
 	// setup:feature:sse:end
 	// setup:feature:session_settings:start
+	ar.initThemeRoutes()
 	// setup:feature:sse:start
-	ar.initThemeRoutes(ar.broker)
+	ar.initThemeSSE(ar.broker)
 	// setup:feature:sse:end
 	// setup:feature:session_settings:end
 

--- a/internal/routes/routes_theme.go
+++ b/internal/routes/routes_theme.go
@@ -3,37 +3,51 @@
 package routes
 
 import (
-	"fmt"
 	"net/http"
-	"sync/atomic"
 
 	"catgoose/dothog/internal/logger"
-	// setup:feature:session_settings:start
 	"catgoose/dothog/internal/routes/handler"
-	"catgoose/dothog/web/views"
-	// setup:feature:session_settings:end
-	"github.com/catgoose/tavern"
-
-	// setup:feature:session_settings:start
 	"catgoose/dothog/internal/session"
-	// setup:feature:session_settings:end
+	"catgoose/dothog/web/views"
+
+	// setup:feature:sse:start
+	"fmt"
+	"sync/atomic"
+
+	"github.com/catgoose/tavern"
+	// setup:feature:sse:end
+
 	"github.com/labstack/echo/v4"
 )
 
-// setup:feature:session_settings:start
-
+// setup:feature:sse:start
 var themeCounter atomic.Int64
 
-func (ar *appRoutes) initThemeRoutes(broker *tavern.SSEBroker) {
-	ar.e.POST("/settings/theme", ar.handleTheme(broker))
+// setup:feature:sse:end
+
+// initThemeRoutes registers POST /settings/theme and POST /settings/layout.
+// Both persist into the session_settings row. Cross-browser broadcast is wired
+// separately by initThemeSSE when the sse feature is enabled.
+func (ar *appRoutes) initThemeRoutes() {
+	ar.e.POST("/settings/theme", ar.handleTheme())
 	ar.e.POST("/settings/layout", ar.handleLayout())
+}
+
+// setup:feature:sse:start
+
+// initThemeSSE adds the cross-browser theme-change feed and replay policy.
+// Only called when the sse feature is enabled and a broker has been built.
+func (ar *appRoutes) initThemeSSE(broker *tavern.SSEBroker) {
 	broker.SetReplayPolicy(TopicThemeChange, 1)
 	broker.SetReplayGapPolicy(TopicThemeChange, tavern.GapFallbackToSnapshot, nil)
 	ar.e.GET("/sse/theme", echo.WrapHandler(broker.SSEHandler(TopicThemeChange)))
 }
 
-// handleTheme updates the shared theme setting and broadcasts to all browsers.
-func (ar *appRoutes) handleTheme(broker *tavern.SSEBroker) echo.HandlerFunc {
+// setup:feature:sse:end
+
+// handleTheme persists the requested theme on the session_settings row.
+// In sse builds the change is also broadcast so other tabs/devices receive it.
+func (ar *appRoutes) handleTheme() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		theme := c.FormValue("theme")
 		valid := false
@@ -54,23 +68,24 @@ func (ar *appRoutes) handleTheme(broker *tavern.SSEBroker) echo.HandlerFunc {
 			}
 		}
 
-		// Broadcast theme change to all connected browsers.
-		// Always write to the replay buffer so reconnecting clients receive the change.
-		eventID := fmt.Sprintf("tc%d", themeCounter.Add(1))
-		msg := tavern.NewSSEMessage("theme-change", theme).
-			WithID(eventID).
-			String()
-		broker.PublishWithID(TopicThemeChange, eventID, msg)
+		// setup:feature:sse:start
+		if ar.broker != nil {
+			eventID := fmt.Sprintf("tc%d", themeCounter.Add(1))
+			msg := tavern.NewSSEMessage("theme-change", theme).
+				WithID(eventID).
+				String()
+			ar.broker.PublishWithID(TopicThemeChange, eventID, msg)
+		}
+		// setup:feature:sse:end
 
 		return handler.RenderComponent(c, views.ThemeChanged(theme))
 	}
 }
 
-// handleLayout updates the shared layout setting and refreshes the page.
-// Uses HX-Refresh instead of HX-Redirect so the browser reloads the current
-// page with the new layout regardless of which page the toggle lives on.
-// Returns 200 (not 204) because HTMX 2.0 responseHandling sets swap:false for
-// 204, which can prevent response headers from being processed reliably.
+// handleLayout persists the requested layout and asks the browser to reload.
+// HX-Refresh (not HX-Redirect) so the current URL reloads under the new layout.
+// 200 (not 204) because HTMX 2.0 sets swap:false for 204, which can drop
+// the response headers and skip the refresh.
 func (ar *appRoutes) handleLayout() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		layout := c.FormValue("layout")
@@ -88,6 +103,3 @@ func (ar *appRoutes) handleLayout() echo.HandlerFunc {
 		return c.String(http.StatusOK, "")
 	}
 }
-
-// setup:feature:session_settings:end
-

--- a/internal/routes/routes_theme_test.go
+++ b/internal/routes/routes_theme_test.go
@@ -1,0 +1,134 @@
+// setup:feature:session_settings
+
+package routes
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"catgoose/dothog/internal/session"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSettingsStore captures the last upsert so tests can assert persistence
+// without standing up a database. It satisfies SessionSettingsStore.
+type fakeSettingsStore struct {
+	last    *session.Settings
+	mu      sync.Mutex
+	upserts int
+}
+
+func (s *fakeSettingsStore) ListAll(_ context.Context) ([]session.Settings, error) {
+	return nil, nil
+}
+
+func (s *fakeSettingsStore) Upsert(_ context.Context, settings *session.Settings) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	clone := *settings
+	s.last = &clone
+	s.upserts++
+	return nil
+}
+
+func (s *fakeSettingsStore) lastSettings() *session.Settings {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.last == nil {
+		return nil
+	}
+	clone := *s.last
+	return &clone
+}
+
+// withSession injects a Settings into the request context so handleTheme
+// sees a session without standing up the full session middleware.
+func withSession(req *http.Request, s *session.Settings) *http.Request {
+	ctx := session.ContextWithSettings(req.Context(), s)
+	return req.WithContext(ctx)
+}
+
+// TestInitThemeRoutes_WithoutBroker_PersistsTheme is the core regression:
+// a scaffold without sse must still be able to register and serve
+// POST /settings/theme so theme changes survive a reload.
+func TestInitThemeRoutes_WithoutBroker_PersistsTheme(t *testing.T) {
+	store := &fakeSettingsStore{}
+	ar := &appRoutes{
+		e:     echo.New(),
+		repos: Repos{Settings: store},
+	}
+	ar.initThemeRoutes()
+
+	form := url.Values{}
+	form.Set("theme", "dark")
+	req := httptest.NewRequest(http.MethodPost, "/settings/theme", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = withSession(req, session.NewDefaultSettings("test-uuid"))
+
+	rec := httptest.NewRecorder()
+	ar.e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "POST /settings/theme should succeed without a broker")
+	require.Equal(t, 1, store.upserts, "theme change should upsert once")
+	last := store.lastSettings()
+	require.NotNil(t, last)
+	require.Equal(t, "dark", last.Theme, "upserted Settings should carry the new theme")
+}
+
+// TestInitThemeRoutes_WithoutBroker_RejectsInvalidTheme reuses the same shape
+// to confirm the invalid-theme fallback path still works without a broker
+// (and that persistence happens at the fallback value).
+func TestInitThemeRoutes_WithoutBroker_RejectsInvalidTheme(t *testing.T) {
+	store := &fakeSettingsStore{}
+	ar := &appRoutes{
+		e:     echo.New(),
+		repos: Repos{Settings: store},
+	}
+	ar.initThemeRoutes()
+
+	form := url.Values{}
+	form.Set("theme", "no-such-theme")
+	req := httptest.NewRequest(http.MethodPost, "/settings/theme", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = withSession(req, session.NewDefaultSettings("test-uuid"))
+
+	rec := httptest.NewRecorder()
+	ar.e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	last := store.lastSettings()
+	require.NotNil(t, last)
+	require.Equal(t, "light", last.Theme, "invalid theme should fall back to 'light' and still persist")
+}
+
+// TestInitThemeRoutes_WithoutBroker_PersistsLayout guards the layout endpoint
+// which lives on the same code path and was also previously broker-coupled.
+func TestInitThemeRoutes_WithoutBroker_PersistsLayout(t *testing.T) {
+	store := &fakeSettingsStore{}
+	ar := &appRoutes{
+		e:     echo.New(),
+		repos: Repos{Settings: store},
+	}
+	ar.initThemeRoutes()
+
+	form := url.Values{}
+	form.Set("layout", session.LayoutApp)
+	req := httptest.NewRequest(http.MethodPost, "/settings/layout", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = withSession(req, session.NewDefaultSettings("test-uuid"))
+
+	rec := httptest.NewRecorder()
+	ar.e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "true", rec.Header().Get("HX-Refresh"), "layout change should ask the browser to refresh")
+	last := store.lastSettings()
+	require.NotNil(t, last)
+	require.Equal(t, session.LayoutApp, last.Layout)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -174,6 +174,12 @@ func GetSettings(r *http.Request) *Settings {
 	return NewDefaultSettings("")
 }
 
+// ContextWithSettings returns a derived context that GetSettings can read.
+// Test code uses this to seed a session without running the full middleware.
+func ContextWithSettings(ctx context.Context, s *Settings) context.Context {
+	return context.WithValue(ctx, settingsCtxKey, s)
+}
+
 func getOrCreateSessionCookie(w http.ResponseWriter, r *http.Request, cookieName string) (string, error) {
 	if cookie, err := r.Cookie(cookieName); err == nil && cookie.Value != "" {
 		return cookie.Value, nil

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -473,7 +473,7 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	assertNoSetupMarkers(t, dest)
 	assertBuildSucceeds(t, dest)
 	assertDirRemoved(t, filepath.Join(dest, "internal", "service", "graph"))
-	assertDirExists(t, filepath.Join(dest, "internal", "database"))          // database is implicit (always kept)
+	assertDirExists(t, filepath.Join(dest, "internal", "database")) // database is implicit (always kept)
 	assertDirRemoved(t, filepath.Join(dest, "internal", "repository"))
 	assertDirRemoved(t, filepath.Join(dest, "internal", "domain"))
 	assertDirRemoved(t, filepath.Join(dest, "internal", "demo"))
@@ -640,7 +640,6 @@ func TestSetup_FeaturesDatabaseOnly(t *testing.T) {
 	assertDirRemoved(t, filepath.Join(dest, "internal", "service", "graph"))
 	assertDirExists(t, filepath.Join(dest, "internal", "database"))
 
-
 	// MSSQL files should be removed
 }
 
@@ -759,6 +758,56 @@ func TestSetup_FeaturesDemoWithoutSSE(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "htmx.ext.sse.js should be removed when sse stripped")
 }
 
+// TestSetup_SessionSettingsWithoutSSE pins down the theme-persistence
+// regression: a scaffold that keeps session_settings but omits sse must
+// still register POST /settings/theme so theme changes survive a reload.
+// Before the fix, initThemeRoutes was nested under both session_settings
+// AND sse markers, so stripping sse silently removed the registration.
+func TestSetup_SessionSettingsWithoutSSE(t *testing.T) {
+	t.Parallel()
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+
+	dest := setupTempDir(t)
+	err = copyDirExcluding(repoRoot, dest, ".git", ".claude", ".cursor", "bin", "build", "log", "node_modules", "test-results", "tmp")
+	require.NoError(t, err)
+
+	err = setup.Run(context.Background(), dest, setup.Options{
+		AppName:    "Session Settings No SSE App",
+		ModulePath: "github.com/test/session-no-sse-app",
+		BasePort:   "20660",
+		NoCaddy:    true,
+		Force:      true,
+		Features:   []string{"session_settings"},
+	})
+	require.NoError(t, err)
+
+	assertNoSetupMarkers(t, dest)
+	assertBuildSucceeds(t, dest)
+
+	// routes.go must still call initThemeRoutes (no broker arg) so
+	// POST /settings/theme is registered without sse.
+	routesBytes, err := os.ReadFile(filepath.Join(dest, "internal", "routes", "routes.go"))
+	require.NoError(t, err)
+	routesContent := string(routesBytes)
+	require.Contains(t, routesContent, "ar.initThemeRoutes()",
+		"routes.go must call ar.initThemeRoutes() without a broker when sse is stripped")
+	require.NotContains(t, routesContent, "ar.initThemeSSE",
+		"routes.go must not reference initThemeSSE when sse is stripped")
+
+	// routes_theme.go must still be present and have the POST /settings/theme
+	// registration, with no remaining tavern import (sse bits stripped).
+	themeBytes, err := os.ReadFile(filepath.Join(dest, "internal", "routes", "routes_theme.go"))
+	require.NoError(t, err)
+	themeContent := string(themeBytes)
+	require.Contains(t, themeContent, `POST("/settings/theme"`,
+		"routes_theme.go must keep the POST /settings/theme route when sse is stripped")
+	require.NotContains(t, themeContent, "github.com/catgoose/tavern",
+		"routes_theme.go must not import tavern when sse is stripped")
+	require.NotContains(t, themeContent, "ar.broker",
+		"routes_theme.go must not reference ar.broker when sse is stripped")
+}
+
 // TestSetup_PWAWithoutCapacitor verifies that selecting PWA does not pull in
 // Capacitor files (#353). PWA is a web feature; Capacitor is a separate opt-in.
 func TestSetup_PWAWithoutCapacitor(t *testing.T) {
@@ -834,12 +883,12 @@ func TestSetup_NoDothogReferences(t *testing.T) {
 
 	// Directories and file extensions to skip.
 	skipDirs := map[string]bool{
-		".git":             true,
-		".claude":          true,
-		"log":              true,
-		"node_modules":     true,
-		"_template_setup":  true,
-		"vendor":           true,
+		".git":            true,
+		".claude":         true,
+		"log":             true,
+		"node_modules":    true,
+		"_template_setup": true,
+		"vendor":          true,
 	}
 
 	var violations []string


### PR DESCRIPTION
## Summary
- persist theme and layout settings whenever session_settings is enabled, even without sse
- keep SSE theme replay/broadcast wiring only when the sse feature is enabled
- route direct 404s through the shared error promotion path and add regression coverage for both fixes

## Validation
- go build ./...
- go test -count=1 -run 'TestHandleNotFound|TestInitThemeRoutes|TestHandleTheme' ./internal/routes/... ./internal/routes/handler/...
- go test -count=1 -run 'TestSetup_SessionSettingsWithoutSSE' ./tests