### PR TITLE
feat(setup): add caddy-backed lite internal scaffold defaults

### DIFF
--- a/README.harmony.md
+++ b/README.harmony.md
@@ -769,21 +769,11 @@ Access the application at:
 
 ### HTTPS Development Setup
 
-The setup script checks for existing `localhost.crt` and `localhost.key`. If missing, it offers to generate self-signed certificates.
-
-To generate manually:
-
-```bash
-openssl req -x509 -newkey rsa:2048 -keyout localhost.key -out localhost.crt \
-    -days 365 -nodes -subj "/CN=localhost" \
-    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
-```
-
-Install the certificate in your system trust store for browser acceptance:
-
-- **Linux**: `sudo cp localhost.crt /usr/local/share/ca-certificates/ && sudo update-ca-certificates`
-- **macOS**: Open Keychain Access, drag cert to System, set Trust to Always Trust
-- **Windows**: Right-click cert, Install Certificate, Local Machine, Trusted Root CAs
+With the `caddy` feature enabled, local HTTPS uses Caddy's `tls internal`
+issuer. Setup does not generate `localhost.crt` / `localhost.key` files or
+require `openssl`. On first run, Caddy attempts to install its local CA root
+into your trust store automatically. If the browser still warns, rerun Caddy
+from an elevated shell or use `caddy trust`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -963,22 +963,11 @@ sits in front of templ and provides HTTPS/H3. Without `caddy`, the dev URL is
 
 ### HTTPS Development Setup (Caddy feature only)
 
-Only the `caddy` feature provides local HTTPS — and the cert is consumed by
-Caddy, not by Echo. Setup generates `localhost.crt` / `localhost.key` for you
-when `caddy` is selected; without `caddy`, no certificates are needed. If you
-want to regenerate them by hand:
-
-```bash
-openssl req -x509 -newkey rsa:2048 -keyout localhost.key -out localhost.crt \
-	-days 365 -nodes -subj "/CN=localhost" \
-	-addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
-```
-
-Trust the certificate on your system:
-
-- **Linux**: `sudo cp localhost.crt /usr/local/share/ca-certificates/ && sudo update-ca-certificates`
-- **macOS**: Open Keychain Access, drag cert to System, set Trust to Always Trust
-- **Windows**: Right-click cert, Install Certificate, Local Machine, Trusted Root CAs
+Only the `caddy` feature provides local HTTPS. Caddy fronts the templ proxy and
+uses `tls internal`, so setup does not generate `localhost.crt` /
+`localhost.key` files or require `openssl`. On first run, Caddy attempts to
+install its local CA root into your trust store automatically. If the browser
+still warns, rerun Caddy from an elevated shell or use `caddy trust`.
 
 ## Testing
 

--- a/_template_setup/README.template.md
+++ b/_template_setup/README.template.md
@@ -90,30 +90,11 @@ both modes — TLS lives in Caddy, not in the app.
 
 ### HTTPS Development Setup (Caddy feature only)
 
-When the `caddy` feature is selected, setup generates `localhost.crt` /
-`localhost.key` (or reuses pre-existing files) for Caddy to terminate TLS.
-Without the `caddy` feature there is no local HTTPS and no certificates are
-generated.
-
-Trust the certificate on your system:
-
-**Linux (Ubuntu/Debian):**
-
-```bash
-sudo cp localhost.crt /usr/local/share/ca-certificates/
-sudo update-ca-certificates
-```
-
-**macOS:**
-
-1. Open Keychain Access
-2. Drag `localhost.crt` to System keychain
-3. Set Trust to Always Trust
-
-**Windows:**
-
-1. Right-click `localhost.crt` > Install Certificate
-2. Choose Local Machine > Trusted Root Certification Authorities
+When the `caddy` feature is selected, local HTTPS uses Caddy's `tls internal`
+issuer. Setup does not generate `localhost.crt` / `localhost.key` files or
+require `openssl`. On first run, Caddy attempts to install its local CA root
+into your trust store automatically. If the browser still warns, rerun Caddy
+from an elevated shell or use `caddy trust`.
 
 ## Testing
 

--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -2,8 +2,8 @@
 	auto_https disable_redirects
 }
 
-:{{CADDY_TLS_PORT}} {
-	tls localhost.crt localhost.key
+localhost:{{CADDY_TLS_PORT}} {
+	tls internal
 	@sse path /sse/*
 	reverse_proxy @sse localhost:{{TEMPL_HTTP_PORT}} {
 		header_up Host {host}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -140,7 +140,7 @@ No explicit request body size limits. Echo's default is 4MB. For file upload end
 
 ### TLS at the Application
 
-Dev mode runs the Echo origin as plain HTTP. When `mage watch` is used with the `caddy` feature, Caddy fronts the templ proxy chain with local self-signed certificates and provides HTTPS/H3. Production assumes deployment behind a TLS-terminating proxy. The app itself does not manage certificates or ACME.
+Dev mode runs the Echo origin as plain HTTP. When `mage watch` is used with the `caddy` feature, Caddy fronts the templ proxy chain with locally-issued certificates from its internal CA and provides HTTPS/H3. Production assumes deployment behind a TLS-terminating proxy. The app itself does not manage certificates or ACME.
 
 ### Session Cookie Secure Flag
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -45,7 +45,7 @@ file works on either host.
 3. **Sets app name** — updates binary name in `magefile.go`, Dockerfile, logger, package.json
 4. **Strips features** — removes code blocks and files for features you didn't select
 5. **Generates README** — from `_template_setup/README.template.md` with your app name and ports
-6. **Ensures certificates** — generates self-signed TLS certs if Caddy is selected
+6. **Uses Caddy's internal CA** — local HTTPS comes from `tls internal` when Caddy is selected; no `openssl` prerequisite or scaffolded cert files
 7. **Runs `go mod tidy`** — cleans up unused dependencies after stripping
 
 ## Feature Flags

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -502,10 +502,6 @@ func Run(ctx context.Context, dir string, opts Options) error {
 		return fmt.Errorf("removing optional content: %w", err)
 	}
 
-	if err := ensureCerts(ctx, absDir, opts); err != nil {
-		return fmt.Errorf("ensuring certificates: %w", err)
-	}
-
 	if err := cleanOrphanedImports(dir, modulePath); err != nil {
 		return fmt.Errorf("cleaning orphaned imports: %w", err)
 	}
@@ -1157,92 +1153,6 @@ func applyPlatformAdjustments(dir, platform string) error {
 }
 
 // ---------------------------------------------------------------------------
-// Certificate generation
-// ---------------------------------------------------------------------------
-
-// ensureCerts checks whether localhost certificates already exist in dir.
-// If found, they are kept as-is.  If missing and the caddy feature is
-// selected, the user is prompted (via opts.ConfirmFunc) to generate new
-// self-signed certificates.  When ConfirmFunc is nil (programmatic / test
-// usage) generation happens silently.
-func ensureCerts(ctx context.Context, dir string, opts Options) error {
-	certPath := filepath.Join(dir, "localhost.crt")
-	keyPath := filepath.Join(dir, "localhost.key")
-
-	// If both files already exist locally, use them.
-	if _, err := os.Stat(certPath); err == nil {
-		if _, err := os.Stat(keyPath); err == nil {
-			fmt.Println("Using existing localhost certificates.")
-			return nil
-		}
-	}
-
-	// Only generate certificates when caddy is selected.
-	if !hasCaddyFeature(opts) {
-		return nil
-	}
-
-	// Prompt the user when an interactive confirm is available.
-	if opts.ConfirmFunc != nil {
-		generate, err := opts.ConfirmFunc("No localhost certificates found. Generate self-signed certificates?")
-		if err != nil {
-			return err
-		}
-		if !generate {
-			fmt.Println("Skipping certificate generation.")
-			fmt.Println("You will need to provide localhost.crt and localhost.key for HTTPS to work.")
-			return nil
-		}
-	}
-
-	fmt.Println("Generating self-signed localhost certificates...")
-	if err := generateCerts(ctx, dir); err != nil {
-		return err
-	}
-	fmt.Println("NOTE: You will need to install these certificates in your system trust store.")
-	fmt.Println("See the HTTPS Development Setup section in README.md for instructions.")
-	return nil
-}
-
-// hasCaddyFeature reports whether the caddy feature is selected.
-func hasCaddyFeature(opts Options) bool {
-	if opts.Features == nil {
-		return !opts.NoCaddy // legacy mode: caddy unless --no-caddy
-	}
-	for _, f := range opts.Features {
-		if f == FeatureCaddy {
-			return true
-		}
-	}
-	return false
-}
-
-// generateCerts creates a self-signed localhost TLS certificate and key in dir
-// using openssl. The generated files are localhost.crt and localhost.key.
-func generateCerts(ctx context.Context, dir string) error {
-	certPath := filepath.Join(dir, "localhost.crt")
-	keyPath := filepath.Join(dir, "localhost.key")
-
-	cmd := exec.CommandContext(ctx, "openssl", "req",
-		"-x509",
-		"-newkey", "rsa:2048",
-		"-keyout", keyPath,
-		"-out", certPath,
-		"-days", "365",
-		"-nodes",
-		"-subj", "/CN=localhost",
-		"-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1",
-	)
-	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("openssl: %w", err)
-	}
-	fmt.Printf("Generated development certificates:\n  %s\n  %s\n", certPath, keyPath)
-	return nil
-}
-
 // versionSuffixRe matches Go major-version path segments like "v2", "v3", etc.
 var versionSuffixRe = regexp.MustCompile(`^v\d+$`)
 
@@ -1390,7 +1300,7 @@ Real-time event broker with topic-based publish/subscribe. HTMX SSE extension is
 	if keep[FeatureCaddy] {
 		sb.WriteString(`### Caddy (HTTPS/H3 front-proxy)
 
-Caddy sits in front of the templ watcher and provides HTTPS/H3 for local development. The Echo origin remains plain HTTP. Without the ` + "`caddy`" + ` feature, ` + "`mage watch`" + ` exposes the templ HTTP proxy directly with no TLS in the chain. Certificates are generated during setup (only when ` + "`caddy`" + ` is selected) or can be provided manually. See the HTTPS Development Setup section for trust store installation.
+Caddy sits in front of the templ watcher and provides HTTPS/H3 for local development. The Echo origin remains plain HTTP. Without the ` + "`caddy`" + ` feature, ` + "`mage watch`" + ` exposes the templ HTTP proxy directly with no TLS in the chain. Local HTTPS uses Caddy's internal CA via ` + "`tls internal`" + `, so setup does not generate ` + "`localhost.crt`" + ` / ` + "`localhost.key`" + ` files or require ` + "`openssl`" + `. On first run Caddy attempts to trust its local CA automatically; if your browser still warns, rerun Caddy from an elevated shell or use ` + "`caddy trust`" + `.
 
 `)
 	}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,9 +1,7 @@
 package setup
 
 import (
-	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1032,62 +1030,6 @@ func TestCopyRepoToExcludesLocalhostCerts(t *testing.T) {
 	gotKeep, err := os.ReadFile(filepath.Join(dest, "keep", "keep.txt"))
 	require.NoError(t, err)
 	require.Equal(t, "keep me\n", string(gotKeep))
-}
-
-// ---------------------------------------------------------------------------
-// ensureCerts — caddy gating
-// ---------------------------------------------------------------------------
-
-func TestEnsureCertsNoCaddyCreatesNothing(t *testing.T) {
-	dir := t.TempDir()
-	opts := Options{Features: []string{FeatureDatabase, FeatureCSRF, FeatureLinkRelations}}
-
-	require.NoError(t, ensureCerts(context.Background(), dir, opts))
-
-	_, err := os.Stat(filepath.Join(dir, "localhost.crt"))
-	require.True(t, os.IsNotExist(err), "no caddy → no localhost.crt: %v", err)
-	_, err = os.Stat(filepath.Join(dir, "localhost.key"))
-	require.True(t, os.IsNotExist(err), "no caddy → no localhost.key: %v", err)
-}
-
-func TestEnsureCertsCaddyGenerates(t *testing.T) {
-	if _, err := exec.LookPath("openssl"); err != nil {
-		t.Skip("openssl not available")
-	}
-	dir := t.TempDir()
-	opts := Options{Features: []string{FeatureCaddy}}
-
-	require.NoError(t, ensureCerts(context.Background(), dir, opts))
-
-	info, err := os.Stat(filepath.Join(dir, "localhost.crt"))
-	require.NoError(t, err)
-	require.Greater(t, info.Size(), int64(0), "localhost.crt should be non-empty")
-	info, err = os.Stat(filepath.Join(dir, "localhost.key"))
-	require.NoError(t, err)
-	require.Greater(t, info.Size(), int64(0), "localhost.key should be non-empty")
-}
-
-// ---------------------------------------------------------------------------
-// hasCaddyFeature
-// ---------------------------------------------------------------------------
-
-func TestHasCaddyFeature(t *testing.T) {
-	tests := []struct {
-		name string
-		opts Options
-		want bool
-	}{
-		{name: "nil features defaults to caddy", opts: Options{}, want: true},
-		{name: "nil features with NoCaddy", opts: Options{NoCaddy: true}, want: false},
-		{name: "features without caddy", opts: Options{Features: []string{FeatureAuth, FeatureDatabase}}, want: false},
-		{name: "features with caddy", opts: Options{Features: []string{FeatureAuth, FeatureCaddy}}, want: true},
-		{name: "empty features explicit", opts: Options{Features: []string{}}, want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, hasCaddyFeature(tt.opts))
-		})
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/mage_setup.go
+++ b/mage_setup.go
@@ -211,7 +211,7 @@ func Setup() error {
 // presets maps preset names to their default feature sets.
 var presets = map[string][]string{
 	"internal": {setup.FeatureAuth, setup.FeatureCSRF, setup.FeatureDatabase, setup.FeatureSessionSettings, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards},
-	"microsoft-lite-internal": {setup.FeatureSessionSettings, setup.FeatureCSRF, setup.FeatureAuth, setup.FeatureGraph, setup.FeatureAvatar, setup.FeatureDatabase, setup.FeatureMSSQL, setup.FeatureLinkRelations, setup.FeatureWebStandards},
+	"microsoft-lite-internal": {setup.FeatureSessionSettings, setup.FeatureCSRF, setup.FeatureAuth, setup.FeatureGraph, setup.FeatureAvatar, setup.FeatureDatabase, setup.FeatureMSSQL, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards},
 	"public":   {setup.FeatureSessionSettings, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards, setup.FeatureBrowserAPIs},
 	"microsoft-full-internal": {setup.FeatureSessionSettings, setup.FeatureCSRF, setup.FeatureAuth, setup.FeatureGraph, setup.FeatureAvatar, setup.FeatureDatabase, setup.FeatureMSSQL, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards, setup.FeatureBrowserAPIs, setup.FeatureOffline, setup.FeatureSync, setup.FeaturePWA},
 	"demo":     setup.AllFeatures,
@@ -296,7 +296,7 @@ func runWizard() (*setup.Options, error) {
 				Title("What are you building?").
 				Options(
 					huh.NewOption("Internal tool — auth, database, sessions, SSE, link relations, web standards", "internal"),
-					huh.NewOption("Microsoft Lite Internal — auth, Graph, avatar, MSSQL, link relations, web standards", "microsoft-lite-internal"),
+					huh.NewOption("Microsoft Lite Internal — auth, Graph, avatar, MSSQL, SSE + Caddy, link relations, web standards", "microsoft-lite-internal"),
 					huh.NewOption("Microsoft Full Internal — auth, Graph, MSSQL, SSE, offline + sync + PWA", "microsoft-full-internal"),
 					huh.NewOption("Public site — sessions, link relations, web standards, browser APIs", "public"),
 					huh.NewOption("Demo/playground — everything enabled", "demo"),

--- a/mage_setup.go
+++ b/mage_setup.go
@@ -103,6 +103,9 @@ func Setup() error {
 
 	if hasFlags && parsed != nil {
 		fmt.Println("Running template setup...")
+		if err := maybeInstallCaddyForSetup(".", parsed); err != nil {
+			return err
+		}
 		if err := setup.Run(context.Background(), ".", *parsed); err != nil {
 			return err
 		}
@@ -174,6 +177,9 @@ func Setup() error {
 		_ = os.RemoveAll(filepath.Join(absTarget, setup.TemplateSetupDir))
 		_ = os.RemoveAll(filepath.Join(absTarget, "internal", "setup"))
 		_ = os.Remove(filepath.Join(absTarget, "mage_setup.go"))
+		if err := maybeInstallCaddyForSetup(absTarget, opts); err != nil {
+			return err
+		}
 		if err := setup.Run(context.Background(), absTarget, *opts); err != nil {
 			return err
 		}
@@ -189,6 +195,9 @@ func Setup() error {
 		return nil
 	}
 	fmt.Println("Running template setup...")
+	if err := maybeInstallCaddyForSetup(".", opts); err != nil {
+		return err
+	}
 	if err := setup.Run(context.Background(), ".", *opts); err != nil {
 		return err
 	}
@@ -630,6 +639,32 @@ func hasFeature(features []string, tag string) bool {
 		}
 	}
 	return false
+}
+
+func setupUsesCaddy(opts *setup.Options) bool {
+	if opts == nil {
+		return false
+	}
+	if opts.Features == nil {
+		return !opts.NoCaddy
+	}
+	return hasFeature(setup.ExpandFeatureDeps(opts.Features), setup.FeatureCaddy)
+}
+
+func maybeInstallCaddyForSetup(projectDir string, opts *setup.Options) error {
+	if !setupUsesCaddy(opts) {
+		return nil
+	}
+	install, err := huhConfirm("Caddy is required for local HTTPS in this scaffold. Install repo-local Caddy now?")
+	if err != nil {
+		return err
+	}
+	if !install {
+		fmt.Println("Skipping Caddy install. `mage watch` will require repo-local Caddy or a global `caddy` binary later.")
+		return nil
+	}
+	fmt.Println("Installing repo-local Caddy...")
+	return installRepoLocalCaddy(projectDir)
 }
 
 func parseSetupFlags(args []string) (opts *setup.Options, hasFlags bool, helpPrinted bool, err error) {

--- a/magefile.go
+++ b/magefile.go
@@ -59,6 +59,7 @@ var (
 )
 
 const templWatchIgnorePattern = `(^|[\\/])mage_output_file\.go$`
+const caddyModuleVersion = "v2.11.3"
 
 // DaisyUIComponents is the list of DaisyUI CSS component URLs.
 var daisyUIComponents = []string{
@@ -180,6 +181,34 @@ func hostBinaryExt() string {
 		return ".exe"
 	}
 	return ""
+}
+
+func caddyLocalBin() string {
+	return filepath.Join(binPath, "caddy"+hostBinaryExt())
+}
+
+func installRepoLocalCaddy(projectDir string) error {
+	absBinDir, err := filepath.Abs(filepath.Join(projectDir, binPath))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(absBinDir, 0755); err != nil {
+		return err
+	}
+	return sh.RunWithV(
+		map[string]string{"GOBIN": absBinDir},
+		"go", "install", "github.com/caddyserver/caddy/v2/cmd/caddy@"+caddyModuleVersion,
+	)
+}
+
+func resolveCaddyBinary() (string, error) {
+	if _, err := os.Stat(caddyLocalBin()); err == nil {
+		return caddyLocalBin(), nil
+	}
+	if path, err := exec.LookPath("caddy"); err == nil {
+		return path, nil
+	}
+	return "", fmt.Errorf("caddy binary not found; run `go tool mage caddyinstall` or rerun setup and choose Caddy install")
 }
 
 // Tailwind runs the Tailwind CSS compilation
@@ -957,7 +986,7 @@ func TestWatch() error {
 // CaddyInstall installs Caddy for local development
 func CaddyInstall() error {
 	fmt.Println("Installing Caddy...")
-	return sh.Run("go", "install", "github.com/caddyserver/caddy/v2/cmd/caddy@latest")
+	return installRepoLocalCaddy(".")
 }
 
 // CaddyStart starts Caddy with the local Caddyfile.
@@ -970,6 +999,10 @@ func CaddyStart() error {
 	if _, err := os.Stat(caddyfile); os.IsNotExist(err) {
 		fmt.Println("Caddyfile not found, skipping Caddy.")
 		return nil
+	}
+	caddyBin, err := resolveCaddyBinary()
+	if err != nil {
+		return err
 	}
 	resolvedCaddyPort := resolvePort(caddyTLSPort, 2)
 	resolvedTemplPort := resolvePort(proxyPort, 1)
@@ -993,7 +1026,7 @@ func CaddyStart() error {
 		return fmt.Errorf("write tmp Caddyfile: %w", err)
 	}
 
-	return sh.Run("caddy", "run", "--config", tmpCaddyfile)
+	return sh.Run(caddyBin, "run", "--config", tmpCaddyfile)
 }
 
 // setup:feature:caddy:end

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -205,6 +205,8 @@ func copyDirExcluding(src, dst string, excludeDirs ...string) error {
 	for _, d := range excludeDirs {
 		excludeSet[d] = true
 	}
+	excludeSet["localhost.crt"] = true
+	excludeSet["localhost.key"] = true
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -216,8 +218,11 @@ func copyDirExcluding(src, dst string, excludeDirs ...string) error {
 		if rel == "." {
 			return nil
 		}
-		if info.IsDir() && excludeSet[filepath.Base(path)] {
-			return filepath.SkipDir
+		if excludeSet[filepath.Base(path)] {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		// Skip symlinks — they may point to directories or external paths.
 		linfo, lErr := os.Lstat(path)
@@ -693,6 +698,10 @@ func TestSetup_FeaturesSSECaddy(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(dest, "config", "Caddyfile"))
 	require.NoError(t, err, "Caddyfile should exist when caddy is selected")
+	_, err = os.Stat(filepath.Join(dest, "localhost.crt"))
+	require.True(t, os.IsNotExist(err), "Caddy internal CA should not emit localhost.crt during setup: %v", err)
+	_, err = os.Stat(filepath.Join(dest, "localhost.key"))
+	require.True(t, os.IsNotExist(err), "Caddy internal CA should not emit localhost.key during setup: %v", err)
 
 	assertDirExists(t, filepath.Join(dest, "internal", "database")) // database is implicit
 	assertDirRemoved(t, filepath.Join(dest, "internal", "service", "graph"))


### PR DESCRIPTION
## Summary
- add `sse` and `caddy` to the Microsoft Lite Internal preset
- switch local HTTPS to Caddy `tls internal` instead of generated cert files
- prompt during `mage setup` to install repo-local Caddy when the scaffold needs it

## Validation
- go tool mage -l
- go test ./internal/setup/... ./tests/... -run 'TestSetup_FeaturesSSECaddy|TestCopyRepoToExcludesLocalhostCerts' -count=1\n- git diff --check