### PR TITLE
chore: tighten repo-owned Go comments

### DIFF
--- a/internal/admininfo/types.go
+++ b/internal/admininfo/types.go
@@ -3,7 +3,7 @@
 // Package admininfo provides types for admin dashboard pages.
 package admininfo
 
-// SystemInfo holds runtime stats for the admin system page.
+// SystemInfo aggregates runtime, GC, and process stats shown on the admin status page.
 type SystemInfo struct {
 	TotalAllocMB    string
 	SysMB           string
@@ -25,7 +25,7 @@ type SystemInfo struct {
 	GCCycles        uint32
 }
 
-// ConfigEntry is a single key/value pair for display, with optional masking.
+// ConfigEntry is a single key/value pair rendered in the admin config table.
 type ConfigEntry struct {
 	Key   string
 	Value string
@@ -44,7 +44,7 @@ type UserPreferences struct {
 	HighContrast         bool
 }
 
-// DefaultUserPreferences returns sensible defaults.
+// DefaultUserPreferences seeds PageSize=20 and DateFormat="relative"; other fields are zero.
 func DefaultUserPreferences() UserPreferences {
 	return UserPreferences{
 		PageSize:   20,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,13 +150,12 @@ func getEnvVar(key string, description string) (string, error) {
 
 var getConfig = sync.OnceValues(buildConfig)
 
-// GetConfig returns the singleton configuration instance.
+// GetConfig is the sync.OnceValues-cached AppConfig; first call builds, later calls reuse.
 func GetConfig() (*AppConfig, error) {
 	return getConfig()
 }
 
-// MustGetConfig returns the singleton configuration instance.
-// Panics if configuration cannot be loaded.
+// MustGetConfig is the singleton AppConfig; panics on load failure (use only at startup).
 func MustGetConfig() *AppConfig {
 	config, err := GetConfig()
 	if err != nil {
@@ -165,7 +164,7 @@ func MustGetConfig() *AppConfig {
 	return config
 }
 
-// ResetForTesting resets the singleton for testing purposes.
+// ResetForTesting clears the cached config singleton so the next GetConfig rebuilds it; tests only.
 func ResetForTesting() {
 	getConfig = sync.OnceValues(buildConfig)
 }

--- a/internal/database/repository/health.go
+++ b/internal/database/repository/health.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// HealthCheck pings the database to check connectivity
+// HealthCheck pings the database and wraps any failure with a healthcheck context.
 func HealthCheck(ctx context.Context, db *sqlx.DB) error {
 	if err := db.PingContext(ctx); err != nil {
 		return fmt.Errorf("database health check failed: %w", err)
@@ -17,8 +17,8 @@ func HealthCheck(ctx context.Context, db *sqlx.DB) error {
 	return nil
 }
 
-// CheckConnection checks if the database connection is alive
-// Returns true if connection is healthy, false otherwise
+// CheckConnection is the (bool, error) variant of HealthCheck for callers
+// (eg. /health) that want to render a status without unwrapping the error.
 func CheckConnection(ctx context.Context, db *sqlx.DB) (bool, error) {
 	if err := db.PingContext(ctx); err != nil {
 		return false, fmt.Errorf("database connection check failed: %w", err)

--- a/internal/database/repository/repository.go
+++ b/internal/database/repository/repository.go
@@ -11,22 +11,21 @@ import (
 	"strings"
 	"time"
 
-	dialect "github.com/catgoose/chuck"
 	"catgoose/dothog/internal/database/schema"
 	"catgoose/dothog/internal/logger"
+	dialect "github.com/catgoose/chuck"
 
 	"github.com/jmoiron/sqlx"
 )
 
-// RepoManager manages all repository access to the database.
+// RepoManager owns the DB handle, dialect, and the registered table set used by InitSchema and ValidateSchema.
 type RepoManager struct {
 	db      *sqlx.DB
 	dialect dialect.Dialect
 	tables  []*schema.TableDef
 }
 
-// NewManager creates a new RepoManager instance.
-// Tables are registered for use by InitSchema and EnsureSchema.
+// NewManager binds the DB pool, dialect, and the table set used by Init/Ensure/Validate.
 func NewManager(db *sqlx.DB, d dialect.Dialect, tables ...*schema.TableDef) *RepoManager {
 	return &RepoManager{
 		db:      db,
@@ -35,12 +34,12 @@ func NewManager(db *sqlx.DB, d dialect.Dialect, tables ...*schema.TableDef) *Rep
 	}
 }
 
-// GetDB returns the database connection
+// GetDB exposes the underlying sqlx pool for code that needs to bypass the manager's helpers.
 func (r *RepoManager) GetDB() *sqlx.DB {
 	return r.db
 }
 
-// Dialect returns the dialect for engine-specific SQL fragments.
+// Dialect exposes engine-specific SQL fragment helpers for callers building ad-hoc queries.
 func (r *RepoManager) Dialect() dialect.Dialect {
 	return r.dialect
 }
@@ -51,8 +50,7 @@ type GetExecer interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
-// Exec returns the transaction if non-nil, otherwise the manager's DB connection.
-// This eliminates the repeated pattern of choosing between db and tx in repository methods.
+// Exec picks tx when non-nil, otherwise the manager's DB pool — used by repo methods that take an optional transaction.
 func (r *RepoManager) Exec(tx *sqlx.Tx) GetExecer {
 	if tx != nil {
 		return tx
@@ -60,7 +58,7 @@ func (r *RepoManager) Exec(tx *sqlx.Tx) GetExecer {
 	return r.db
 }
 
-// WithTransaction runs fn inside a transaction. On success the transaction is committed; on error it is rolled back.
+// WithTransaction commits on fn's success, rolls back on error; the inner context has a 30s timeout.
 func (r *RepoManager) WithTransaction(ctx context.Context, fn func(ctx context.Context, tx *sqlx.Tx) error) error {
 	txCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -78,7 +76,7 @@ func (r *RepoManager) WithTransaction(ctx context.Context, fn func(ctx context.C
 	return nil
 }
 
-// Close closes the database connection
+// Close closes the underlying connection pool; safe when the manager was constructed without a DB.
 func (r *RepoManager) Close() error {
 	if r.db != nil {
 		return r.db.Close()
@@ -109,7 +107,7 @@ func (r *RepoManager) InitSchema(ctx context.Context) error {
 	return nil
 }
 
-// EnsureSchema creates registered tables if they do not already exist. Non-destructive.
+// EnsureSchema is the non-destructive counterpart to InitSchema; existing tables are left intact.
 func (r *RepoManager) EnsureSchema(ctx context.Context) error {
 	log := logger.WithContext(ctx)
 	log.Info("Ensuring database schema")
@@ -126,8 +124,7 @@ func (r *RepoManager) EnsureSchema(ctx context.Context) error {
 	return nil
 }
 
-// SeedSchema inserts seed data declared on registered tables via WithSeedRows.
-// Uses INSERT OR IGNORE to be idempotent — safe to run on every startup.
+// SeedSchema applies WithSeedRows data via INSERT OR IGNORE; idempotent and safe on every startup.
 func (r *RepoManager) SeedSchema(ctx context.Context) error {
 	log := logger.WithContext(ctx)
 
@@ -147,7 +144,7 @@ func (r *RepoManager) SeedSchema(ctx context.Context) error {
 	return nil
 }
 
-// SchemaError describes a single schema validation failure.
+// SchemaError describes a single schema mismatch; one or more are wrapped by SchemaValidationError.
 type SchemaError struct {
 	Table   string
 	Column  string
@@ -174,8 +171,8 @@ func (e *SchemaValidationError) Error() string {
 	return fmt.Sprintf("schema validation failed (%d errors): %s", len(e.Errors), strings.Join(msgs, "; "))
 }
 
-// ValidateSchema checks that every registered table exists and contains all expected columns.
-// Returns a *SchemaValidationError if the database schema does not match, nil if valid.
+// ValidateSchema confirms every registered table exists with all expected columns;
+// returns *SchemaValidationError on mismatch, nil when valid.
 func (r *RepoManager) ValidateSchema(ctx context.Context) error {
 	log := logger.WithContext(ctx)
 	log.Info("Validating database schema")

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -8,8 +8,8 @@ import (
 
 	"catgoose/dothog/internal/logger"
 
-	"github.com/jmoiron/sqlx"
 	_ "github.com/catgoose/chuck/driver/sqlite" // Register SQLite driver
+	"github.com/jmoiron/sqlx"
 )
 
 const userCacheSchema = `
@@ -35,21 +35,19 @@ const userCacheSchema = `
 	CREATE INDEX IF NOT EXISTS idx_users_updatedat ON Users(UpdatedAt);
 `
 
-// OpenSQLiteInMemory opens an in-memory SQLite database connection and initializes the schema
+// OpenSQLiteInMemory is a single-connection in-memory SQLite handle with WAL, a 30s busy timeout, and the user-cache schema applied.
 func OpenSQLiteInMemory() (*sqlx.DB, error) {
 	db, err := sqlx.Open("sqlite3", ":memory:")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open in-memory SQLite database: %w", err)
 	}
 
-	// Configure connection pool for SQLite concurrency
-	// SQLite has limited concurrency, so we use conservative settings
-	db.SetMaxOpenConns(1) // Only one connection to prevent locking issues
-	db.SetMaxIdleConns(1) // Keep one idle connection
+	// Single connection avoids SQLite write-locking contention.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	db.SetConnMaxLifetime(10 * time.Minute)
 	db.SetConnMaxIdleTime(5 * time.Minute)
 
-	// Configure SQLite for better performance and concurrency
 	if err := configureSQLitePerformance(db); err != nil {
 		if closeErr := db.Close(); closeErr != nil {
 			logger.Get().Error("Failed to close database connection after performance configuration error", "close_error", closeErr, "config_error", err)
@@ -67,14 +65,12 @@ func OpenSQLiteInMemory() (*sqlx.DB, error) {
 	return db, nil
 }
 
-// configureSQLitePerformance sets up SQLite for optimal performance and concurrency
+// configureSQLitePerformance enables WAL journal mode and a 30s busy timeout.
 func configureSQLitePerformance(db *sqlx.DB) error {
-	// Enable WAL mode for better concurrency (multiple readers, single writer)
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		return fmt.Errorf("failed to enable WAL mode: %w", err)
 	}
 
-	// Set busy timeout to 30 seconds for better concurrency handling
 	if _, err := db.Exec("PRAGMA busy_timeout=30000"); err != nil {
 		return fmt.Errorf("failed to set busy timeout: %w", err)
 	}
@@ -82,7 +78,7 @@ func configureSQLitePerformance(db *sqlx.DB) error {
 	return nil
 }
 
-// InitSQLiteUserCacheSchema initializes the SQLite database schema for user cache
+// InitSQLiteUserCacheSchema applies the Users-table schema (idempotent via IF NOT EXISTS).
 func InitSQLiteUserCacheSchema(db *sqlx.DB) error {
 	_, err := db.Exec(userCacheSchema)
 	if err != nil {

--- a/internal/demo/activity.go
+++ b/internal/demo/activity.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// ActivityEvent represents a recorded action in the system.
+// ActivityEvent is a single audit entry; ID is monotonic per log and used by Since for incremental polling.
 type ActivityEvent struct {
 	Timestamp  time.Time
 	Action     string
@@ -26,12 +26,12 @@ type ActivityLog struct {
 	mu     sync.RWMutex
 }
 
-// NewActivityLog creates a log that retains at most maxLen events.
+// NewActivityLog caps retention at maxLen events; older entries are dropped on Record.
 func NewActivityLog(maxLen int) *ActivityLog {
 	return &ActivityLog{maxLen: maxLen}
 }
 
-// Record adds an event and returns it.
+// Record appends an event with a fresh monotonic ID, evicting the oldest when the cap is exceeded.
 func (l *ActivityLog) Record(action, resource string, resourceID int, name, detail string) ActivityEvent {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -52,7 +52,7 @@ func (l *ActivityLog) Record(action, resource string, resourceID int, name, deta
 	return e
 }
 
-// Recent returns the last n events, newest first.
+// Recent yields up to the last n events, newest first; n is clamped to the log size.
 func (l *ActivityLog) Recent(n int) []ActivityEvent {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -66,7 +66,7 @@ func (l *ActivityLog) Recent(n int) []ActivityEvent {
 	return result
 }
 
-// Since returns all events after the given ID, oldest first.
+// Since yields events with ID > afterID in insertion order; designed for incremental polling.
 func (l *ActivityLog) Since(afterID int) []ActivityEvent {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -79,7 +79,7 @@ func (l *ActivityLog) Since(afterID int) []ActivityEvent {
 	return result
 }
 
-// Len returns the current number of stored events.
+// Len is the current event count (bounded by maxLen).
 func (l *ActivityLog) Len() int {
 	l.mu.RLock()
 	defer l.mu.RUnlock()

--- a/internal/demo/approvals.go
+++ b/internal/demo/approvals.go
@@ -7,13 +7,13 @@ import (
 	"time"
 )
 
-// ApprovalStatuses lists every status an approval request can be in.
+// ApprovalStatuses enumerates the lifecycle states of an ApprovalRequest in transition order.
 var ApprovalStatuses = []string{"pending", "approved", "rejected", "escalated"}
 
-// ApprovalCategories lists the valid spend categories.
+// ApprovalCategories enumerates the spend categories shown in the submission form.
 var ApprovalCategories = []string{"Travel", "Equipment", "Software", "Training", "Contractor", "Other"}
 
-// ApprovalRequest represents a single approval workflow item.
+// ApprovalRequest is a single spend request driven through the HATEOAS state machine in AllowedActions.
 type ApprovalRequest struct {
 	SubmittedAt time.Time
 	ReviewedAt  *time.Time
@@ -34,8 +34,7 @@ type ApprovalQueue struct {
 	mu       sync.RWMutex
 }
 
-// AllowedActions returns the valid actions for a given status based on the
-// HATEOAS state machine.
+// AllowedActions lists actions per status from the HATEOAS state machine; "approved" is terminal.
 func AllowedActions(status string) []string {
 	switch status {
 	case "pending":
@@ -51,7 +50,7 @@ func AllowedActions(status string) []string {
 	}
 }
 
-// NewApprovalQueue creates an ApprovalQueue seeded with sample requests.
+// NewApprovalQueue pre-seeds nine sample requests spanning all four lifecycle statuses.
 func NewApprovalQueue() *ApprovalQueue {
 	now := time.Now()
 	reviewed := now.Add(-2 * time.Hour)
@@ -160,7 +159,7 @@ func NewApprovalQueue() *ApprovalQueue {
 	return q
 }
 
-// AllRequests returns a copy of all approval requests.
+// AllRequests is a defensive copy; safe to mutate independently of the queue.
 func (q *ApprovalQueue) AllRequests() []ApprovalRequest {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
@@ -169,7 +168,7 @@ func (q *ApprovalQueue) AllRequests() []ApprovalRequest {
 	return result
 }
 
-// GetRequest returns the request with the given ID, if it exists.
+// GetRequest looks up by ID; ok is false when the request is not found.
 func (q *ApprovalQueue) GetRequest(id int) (ApprovalRequest, bool) {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
@@ -181,7 +180,7 @@ func (q *ApprovalQueue) GetRequest(id int) (ApprovalRequest, bool) {
 	return ApprovalRequest{}, false
 }
 
-// SubmitRequest creates a new approval request in "pending" status.
+// SubmitRequest starts a request in "pending" status with a freshly assigned ID.
 func (q *ApprovalQueue) SubmitRequest(title, requester string, amount float64, category, notes string) ApprovalRequest {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/internal/demo/auction.go
+++ b/internal/demo/auction.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// AuctionItem represents a single item in the auction house.
+// AuctionItem holds a single lot's bid state; prices are stored in cents to avoid float drift.
 type AuctionItem struct {
 	EndsAt      time.Time
 	Name        string
@@ -21,18 +21,18 @@ type AuctionItem struct {
 	BidCount    int
 }
 
-// AuctionHouse manages the state of all auction items.
+// AuctionHouse is a thread-safe in-memory catalog of AuctionItems indexed by ID.
 type AuctionHouse struct {
 	items map[int]*AuctionItem
 	mu    sync.RWMutex
 }
 
-// FormatPrice returns the price in dollars with two decimal places.
+// FormatPrice renders cents as "$D.CC"; integer math avoids float drift.
 func FormatPrice(cents int) string {
 	return fmt.Sprintf("$%d.%02d", cents/100, cents%100)
 }
 
-// NewAuctionHouse creates an auction house with 8 items.
+// NewAuctionHouse pre-seeds 8 items with staggered end times across the next few hours.
 func NewAuctionHouse() *AuctionHouse {
 	now := time.Now()
 	items := []*AuctionItem{
@@ -52,7 +52,7 @@ func NewAuctionHouse() *AuctionHouse {
 	return &AuctionHouse{items: m}
 }
 
-// Items returns a snapshot of all auction items sorted by ID.
+// Items is a value-copy snapshot sorted by ID; safe to mutate independently of the house.
 func (h *AuctionHouse) Items() []AuctionItem {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -65,7 +65,7 @@ func (h *AuctionHouse) Items() []AuctionItem {
 	return out
 }
 
-// Item returns a copy of a single auction item.
+// Item returns a copy; mutations don't reach the house.
 func (h *AuctionHouse) Item(id int) (AuctionItem, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -93,12 +93,12 @@ func (h *AuctionHouse) PlaceBid(id int, bidder string, amount int) (AuctionItem,
 	return *item, nil
 }
 
-// Topic returns the SSE topic for an auction item.
+// Topic is the SSE channel name for the given auction item ID ("auction/item-N").
 func (h *AuctionHouse) Topic(id int) string {
 	return fmt.Sprintf("auction/item-%d", id)
 }
 
-// AllTopics returns all auction topics.
+// AllTopics is the per-item SSE topic list in ID order, for pre-seeding subscribers.
 func (h *AuctionHouse) AllTopics() []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/internal/demo/calendar.go
+++ b/internal/demo/calendar.go
@@ -22,12 +22,12 @@ const (
 	CalCatDeadline    CalendarEventCategory = "deadline"
 )
 
-// AllCalendarCategories lists every category in display order.
+// AllCalendarCategories is the canonical category list in display order.
 var AllCalendarCategories = []CalendarEventCategory{
 	CalCatMaintenance, CalCatAppointment, CalCatReminder, CalCatDeadline,
 }
 
-// CalendarEvent is a single scheduled item.
+// CalendarEvent is a single calendar entry; Date is truncated to midnight UTC for stable day grouping.
 type CalendarEvent struct {
 	Date     time.Time
 	Title    string
@@ -36,22 +36,21 @@ type CalendarEvent struct {
 	ID       int64
 }
 
-// CalendarStore is an in-memory store of demo calendar events.
+// CalendarStore is the thread-safe in-memory event store backing the calendar lab.
 type CalendarStore struct {
 	events  []CalendarEvent
 	counter atomic.Int64
 	mu      sync.RWMutex
 }
 
-// NewCalendarStore creates a new store seeded with sample events for the
-// current month so the demo always has something to show.
+// NewCalendarStore pre-seeds eight sample events in the current UTC month so the demo isn't empty.
 func NewCalendarStore() *CalendarStore {
 	s := &CalendarStore{}
 	s.seedCurrentMonth()
 	return s
 }
 
-// AddEvent adds an event and returns the assigned ID.
+// AddEvent stamps date at UTC midnight and assigns a fresh monotonic ID.
 func (s *CalendarStore) AddEvent(date time.Time, title, assignee string, cat CalendarEventCategory) int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -79,8 +78,7 @@ func (s *CalendarStore) RemoveEvent(id int64) bool {
 	return false
 }
 
-// EventsForMonth returns all events whose Date falls in the given year/month,
-// sorted by date then by ID for stable display order.
+// EventsForMonth filters by year/month and sorts by Date then ID for stable display.
 func (s *CalendarStore) EventsForMonth(year int, month time.Month) []CalendarEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -99,7 +97,7 @@ func (s *CalendarStore) EventsForMonth(year int, month time.Month) []CalendarEve
 	return out
 }
 
-// EventsForDay returns all events on the given day.
+// EventsForDay matches on UTC midnight and orders by insertion ID.
 func (s *CalendarStore) EventsForDay(day time.Time) []CalendarEvent {
 	target := truncateToDay(day)
 	s.mu.RLock()
@@ -118,7 +116,7 @@ func (s *CalendarStore) EventsForDay(day time.Time) []CalendarEvent {
 // month-grid renderer to draw indicator dots.
 type DayCounts map[CalendarEventCategory]int
 
-// DayCountsForMonth returns a map keyed by day-of-month with category counts.
+// DayCountsForMonth groups by day-of-month for the indicator-dot renderer.
 func (s *CalendarStore) DayCountsForMonth(year int, month time.Month) map[int]DayCounts {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/demo/calendar_lab.go
+++ b/internal/demo/calendar_lab.go
@@ -23,7 +23,7 @@ type CalendarLabSettings struct {
 	HighlightWeekends bool
 }
 
-// CalendarLabPreset is a named set of simulator defaults.
+// CalendarLabPreset names a density/speed combo selectable from the lab toolbar.
 type CalendarLabPreset struct {
 	Name      string
 	Density   int
@@ -31,7 +31,7 @@ type CalendarLabPreset struct {
 	BurstSize int
 }
 
-// CalendarLabPresets lists the available simulation presets.
+// CalendarLabPresets enumerates the lab's stress presets in ascending intensity order.
 var CalendarLabPresets = []CalendarLabPreset{
 	{Name: "Calm", Density: 2, SimSpeed: 4000, BurstSize: 1},
 	{Name: "Steady", Density: 4, SimSpeed: 2000, BurstSize: 2},
@@ -40,15 +40,14 @@ var CalendarLabPresets = []CalendarLabPreset{
 	{Name: "Hell", Density: 12, SimSpeed: 50, BurstSize: 8},
 }
 
-// CalendarLabActivity records one simulator or user action for the activity log.
+// CalendarLabActivity is a single entry in the lab's rolling 50-event activity feed.
 type CalendarLabActivity struct {
 	Timestamp time.Time
 	Action    string
 }
 
-// CalendarLab wraps a CalendarStore with shared demo state: view settings,
-// simulator counters, selected day, and an activity log. All methods are
-// goroutine-safe.
+// CalendarLab is a CalendarStore plus shared demo state: view settings,
+// simulator counters, selected day, and activity log. Methods are goroutine-safe.
 type CalendarLab struct {
 	selectedDay time.Time
 	Store       *CalendarStore
@@ -60,8 +59,7 @@ type CalendarLab struct {
 	paused      bool
 }
 
-// NewCalendarLab creates a new lab backed by a fresh CalendarStore, initialised
-// to the current month with default settings.
+// NewCalendarLab opens on the current UTC month with all categories visible and density=8.
 func NewCalendarLab() *CalendarLab {
 	now := time.Now().UTC()
 	cats := make(map[CalendarEventCategory]bool, len(AllCalendarCategories))
@@ -81,14 +79,14 @@ func NewCalendarLab() *CalendarLab {
 	}
 }
 
-// Year returns the current visible year.
+// Year is the visible year under read lock.
 func (l *CalendarLab) Year() int {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	return l.year
 }
 
-// Month returns the current visible month.
+// Month is the visible month under read lock.
 func (l *CalendarLab) Month() time.Month {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -108,21 +106,21 @@ func (l *CalendarLab) SetMonth(year int, month time.Month) {
 	}
 }
 
-// SelectedDay returns the currently selected day (zero if none).
+// SelectedDay is the zero time when nothing is selected.
 func (l *CalendarLab) SelectedDay() time.Time {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	return l.selectedDay
 }
 
-// SelectDay sets the currently inspected day.
+// SelectDay truncates to UTC midnight; pass the zero time to clear the selection.
 func (l *CalendarLab) SelectDay(day time.Time) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.selectedDay = truncateToDay(day)
 }
 
-// Settings returns a snapshot of the current control state.
+// Settings is a deep-copied snapshot; the VisibleCategories map is safe to iterate.
 func (l *CalendarLab) Settings() CalendarLabSettings {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -143,14 +141,14 @@ func (l *CalendarLab) UpdateSettings(fn func(s *CalendarLabSettings)) {
 	fn(&l.settings)
 }
 
-// Paused returns whether the simulator is paused.
+// Paused reports whether SimTick should be skipped this round.
 func (l *CalendarLab) Paused() bool {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	return l.paused
 }
 
-// TogglePause flips the paused state and returns the new value.
+// TogglePause flips the pause flag and returns the new value.
 func (l *CalendarLab) TogglePause() bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -171,7 +169,7 @@ func (l *CalendarLab) RecordActivity(action string) {
 	}
 }
 
-// Activity returns the recent activity log (newest last).
+// Activity is a defensive copy of the rolling 50-entry log, newest last.
 func (l *CalendarLab) Activity() []CalendarLabActivity {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -180,9 +178,8 @@ func (l *CalendarLab) Activity() []CalendarLabActivity {
 	return out
 }
 
-// SimTick runs one simulator tick: adds BurstSize random events to the
-// current month, prunes back to a budget, and returns descriptions of
-// what happened. The caller is responsible for publishing.
+// SimTick advances one step: adds BurstSize random events to the current month,
+// prunes back to a 60-event budget by oldest ID, and returns human-readable actions; caller publishes.
 func (l *CalendarLab) SimTick() []string {
 	l.mu.RLock()
 	year, month := l.year, l.month
@@ -225,7 +222,7 @@ func (l *CalendarLab) SimTick() []string {
 	return actions
 }
 
-// EventCount returns the total number of events in the current visible month.
+// EventCount totals every event in the visible month (no filters applied).
 func (l *CalendarLab) EventCount() int {
 	l.mu.RLock()
 	year, month := l.year, l.month
@@ -233,8 +230,7 @@ func (l *CalendarLab) EventCount() int {
 	return len(l.Store.EventsForMonth(year, month))
 }
 
-// FilteredEventCount returns the number of events in the current visible month
-// that match the active visibility and assignee filters.
+// FilteredEventCount counts visible-month events passing the active category and assignee filters.
 func (l *CalendarLab) FilteredEventCount() int {
 	l.mu.RLock()
 	year, month := l.year, l.month
@@ -248,9 +244,8 @@ func (l *CalendarLab) FilteredEventCount() int {
 	return len(FilterEvents(l.Store.EventsForMonth(year, month), settings))
 }
 
-// FilterEvents returns the subset of events that match the given settings'
-// visibility and assignee filters. It is a pure function safe to call from
-// any goroutine.
+// FilterEvents is pure: drops events failing the settings' category or assignee filters.
+// The output reuses events' backing array, so callers must not retain both.
 func FilterEvents(events []CalendarEvent, settings CalendarLabSettings) []CalendarEvent {
 	out := events[:0:0]
 	for _, e := range events {
@@ -261,8 +256,7 @@ func FilterEvents(events []CalendarEvent, settings CalendarLabSettings) []Calend
 	return out
 }
 
-// DayEventsMap builds a map of day-of-month to event slice for the current
-// visible month. The returned map is safe to read (not share with writes).
+// DayEventsMap groups visible-month events by day-of-month; the map is read-only.
 func (l *CalendarLab) DayEventsMap() map[int][]CalendarEvent {
 	l.mu.RLock()
 	year, month := l.year, l.month

--- a/internal/demo/canvas.go
+++ b/internal/demo/canvas.go
@@ -11,7 +11,7 @@ import (
 // CanvasSize is the grid dimension (CanvasSize x CanvasSize).
 const CanvasSize = 64
 
-// CanvasPalette is the set of colors players can choose from.
+// CanvasPalette enumerates the ten hex colors offered by the pixel-canvas demo's color picker.
 var CanvasPalette = []string{
 	"#ef4444", // red
 	"#f97316", // orange
@@ -25,7 +25,7 @@ var CanvasPalette = []string{
 	"#ffffff", // white
 }
 
-// CanvasClient tracks a connected client.
+// CanvasClient tracks a single live participant's selected color and last-seen timestamp.
 type CanvasClient struct {
 	LastSeen time.Time `json:"-"`
 	Color    string    `json:"color"`
@@ -38,14 +38,14 @@ type PixelCanvas struct {
 	mu      sync.RWMutex
 }
 
-// NewPixelCanvas creates an empty canvas.
+// NewPixelCanvas starts with every cell empty and no clients tracked.
 func NewPixelCanvas() *PixelCanvas {
 	return &PixelCanvas{
 		clients: make(map[string]*CanvasClient),
 	}
 }
 
-// PlaceColor sets a cell's color.
+// PlaceColor writes color at (x,y); returns an error when coordinates fall outside the grid.
 func (pc *PixelCanvas) PlaceColor(x, y int, color string) error {
 	if x < 0 || x >= CanvasSize || y < 0 || y >= CanvasSize {
 		return fmt.Errorf("coordinates out of range")
@@ -56,21 +56,21 @@ func (pc *PixelCanvas) PlaceColor(x, y int, color string) error {
 	return nil
 }
 
-// Snapshot returns a copy of the grid.
+// Snapshot is a value copy; safe to mutate independently.
 func (pc *PixelCanvas) Snapshot() [CanvasSize * CanvasSize]string {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
 	return pc.Cells
 }
 
-// Reset clears the entire canvas.
+// Reset clears every cell back to the empty string without disturbing tracked clients.
 func (pc *PixelCanvas) Reset() {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 	pc.Cells = [CanvasSize * CanvasSize]string{}
 }
 
-// TouchClient registers or refreshes a client with their current color.
+// TouchClient stamps LastSeen now and upserts the client's color.
 func (pc *PixelCanvas) TouchClient(clientID, color string) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
@@ -83,7 +83,7 @@ func (pc *PixelCanvas) TouchClient(clientID, color string) {
 	cl.LastSeen = time.Now()
 }
 
-// ActiveClients returns the count and colors of clients seen in the last 30 seconds.
+// ActiveClients counts clients seen in the last 30 seconds.
 func (pc *PixelCanvas) ActiveClients() []CanvasClient {
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()

--- a/internal/demo/db.go
+++ b/internal/demo/db.go
@@ -13,7 +13,7 @@ import (
 	_ "github.com/catgoose/chuck/driver/sqlite" // register sqlite3 driver with database/sql
 )
 
-// Item represents one inventory row returned from the demo database.
+// Item is one row of the demo items table; CreatedAt is stored as an ISO date string for SQLite.
 type Item struct {
 	Name      string
 	Category  string
@@ -24,10 +24,10 @@ type Item struct {
 	Active    bool
 }
 
-// DB wraps a sqlite3 connection.
+// DB is the demo SQLite handle backing the typed CRUD helpers used across the /demo routes.
 type DB struct{ db *sql.DB }
 
-// ItemCategories is the list of available item categories for filters.
+// ItemCategories enumerates the category values allowed in the items table and the filter dropdown.
 var ItemCategories = []string{
 	"Electronics", "Clothing", "Food", "Books", "Sports",
 }
@@ -61,12 +61,12 @@ func Open(path string) (*DB, error) {
 	return d, nil
 }
 
-// RawDB returns the underlying *sql.DB connection.
+// RawDB exposes the underlying *sql.DB for code that needs ATTACH or raw migrations.
 func (d *DB) RawDB() *sql.DB {
 	return d.db
 }
 
-// Close closes the underlying database connection.
+// Close closes the underlying SQLite connection.
 func (d *DB) Close() error {
 	return d.db.Close()
 }
@@ -87,20 +87,20 @@ func (d *DB) Reset() error {
 	return d.initSchema(ctx)
 }
 
-// TableMeta describes a single table in the database.
+// TableMeta is one row of the demo's schema-info panel: table name with row and column counts.
 type TableMeta struct {
-	Name       string
-	RowCount   int
+	Name        string
+	RowCount    int
 	ColumnCount int
 }
 
-// SchemaInfo describes the current state of the database.
+// SchemaInfo is the aggregated table list plus the database-wide index count.
 type SchemaInfo struct {
 	Tables  []TableMeta
 	Indexes int
 }
 
-// GetSchemaInfo returns metadata about all tables and indexes in the database.
+// GetSchemaInfo enumerates user tables (with row and column counts) plus the database-wide index count.
 func (d *DB) GetSchemaInfo(ctx context.Context) (SchemaInfo, error) {
 	var info SchemaInfo
 
@@ -306,7 +306,7 @@ func seedBulk(db *sql.DB, query string, count int, argsFn func(i int) []any) err
 	return tx.Commit()
 }
 
-// CreateItem inserts a new item and returns it with the assigned ID.
+// CreateItem stamps created_at via SQLite's date('now') and returns the row populated with the new ID.
 func (d *DB) CreateItem(ctx context.Context, item Item) (Item, error) {
 	res, err := d.db.ExecContext(ctx,
 		`INSERT INTO items (name, category, price, stock, active, created_at) VALUES (@Name, @Category, @Price, @Stock, @Active, date('now'))`,
@@ -322,7 +322,7 @@ func (d *DB) CreateItem(ctx context.Context, item Item) (Item, error) {
 	return item, nil
 }
 
-// GetItem returns a single Item by ID.
+// GetItem looks up by primary key; sql.ErrNoRows is wrapped in a contextual error.
 func (d *DB) GetItem(ctx context.Context, id int) (Item, error) {
 	var item Item
 	var activeInt int
@@ -336,7 +336,7 @@ func (d *DB) GetItem(ctx context.Context, id int) (Item, error) {
 	return item, nil
 }
 
-// UpdateItem updates name, category, price, stock, and active for the given item.
+// UpdateItem writes name, category, price, stock, and active; created_at is left untouched.
 func (d *DB) UpdateItem(ctx context.Context, item Item) error {
 	res, err := d.db.ExecContext(ctx,
 		"UPDATE items SET name=@Name, category=@Category, price=@Price, stock=@Stock, active=@Active WHERE id=@ID",
@@ -354,7 +354,7 @@ func (d *DB) UpdateItem(ctx context.Context, item Item) error {
 	return nil
 }
 
-// DeleteItem deletes an item by ID.
+// DeleteItem removes the item by ID; returns an error if no row was affected.
 func (d *DB) DeleteItem(ctx context.Context, id int) error {
 	res, err := d.db.ExecContext(ctx, "DELETE FROM items WHERE id=@ID", sql.Named("ID", id))
 	if err != nil {

--- a/internal/demo/doc.go
+++ b/internal/demo/doc.go
@@ -18,7 +18,7 @@ type SharedDocument struct {
 	mu        sync.RWMutex
 }
 
-// DocRevision records a single edit event.
+// DocRevision is a single entry in the rolling revision log; WordDelta is signed against the prior word count.
 type DocRevision struct {
 	Timestamp time.Time
 	Summary   string
@@ -26,7 +26,7 @@ type DocRevision struct {
 	WordDelta int
 }
 
-// NewSharedDocument returns a document pre-populated with starter content.
+// NewSharedDocument pre-populates with a sample paragraph and an initial revision entry.
 func NewSharedDocument() *SharedDocument {
 	initial := "The quick brown fox jumps over the lazy dog. " +
 		"This shared document demonstrates how a single mutation signal " +
@@ -58,14 +58,14 @@ func (d *SharedDocument) Update(content string) {
 	d.nextID++
 }
 
-// Content returns the current document text.
+// Content is safe for concurrent reads.
 func (d *SharedDocument) Content() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.content
 }
 
-// Revisions returns up to the last 20 revision entries (newest first).
+// Revisions returns up to 20 entries, newest first.
 func (d *SharedDocument) Revisions() []DocRevision {
 	d.mu.RLock()
 	defer d.mu.RUnlock()

--- a/internal/demo/error_reports.go
+++ b/internal/demo/error_reports.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// ErrorReportStatus represents the lifecycle state of an error report.
+// ErrorReportStatus is the lifecycle state of a captured error report.
 type ErrorReportStatus string
 
 // Error report status constants.
@@ -20,7 +20,7 @@ const (
 	ErrorReportStatusDismissed ErrorReportStatus = "dismissed"
 )
 
-// ErrorReport represents a user-submitted error report stored in the demo DB.
+// ErrorReport is one captured runtime error row; CreatedAt is stored as RFC3339 on disk.
 type ErrorReport struct {
 	CreatedAt   time.Time
 	ResolvedAt  sql.NullTime
@@ -34,12 +34,12 @@ type ErrorReport struct {
 	StatusCode  int
 }
 
-// CreatedAtFormatted returns the created_at timestamp in a human-readable format.
+// CreatedAtFormatted is CreatedAt rendered as "YYYY-MM-DD HH:MM:SS".
 func (r ErrorReport) CreatedAtFormatted() string {
 	return r.CreatedAt.Format("2006-01-02 15:04:05")
 }
 
-// ResolvedAtFormatted returns the resolved_at timestamp formatted, or "" if null.
+// ResolvedAtFormatted is the timestamp rendered as "YYYY-MM-DD HH:MM:SS", or "" when null.
 func (r ErrorReport) ResolvedAtFormatted() string {
 	if !r.ResolvedAt.Valid {
 		return ""
@@ -47,7 +47,7 @@ func (r ErrorReport) ResolvedAtFormatted() string {
 	return r.ResolvedAt.Time.Format("2006-01-02 15:04:05")
 }
 
-// DescriptionPreview returns a truncated description for table display.
+// DescriptionPreview caps Description at 80 chars; longer values get a trailing ellipsis.
 func (r ErrorReport) DescriptionPreview() string {
 	if len(r.Description) <= 80 {
 		return r.Description
@@ -55,7 +55,7 @@ func (r ErrorReport) DescriptionPreview() string {
 	return r.Description[:77] + "..."
 }
 
-// UserAgentSnippet returns a truncated user agent string for table display.
+// UserAgentSnippet caps UserAgent at 40 chars; longer values get a trailing ellipsis.
 func (r ErrorReport) UserAgentSnippet() string {
 	if len(r.UserAgent) <= 40 {
 		return r.UserAgent
@@ -63,7 +63,7 @@ func (r ErrorReport) UserAgentSnippet() string {
 	return r.UserAgent[:37] + "..."
 }
 
-// ErrorReportStatuses is the list of valid statuses for filters.
+// ErrorReportStatuses is the string form of every ErrorReportStatus, ordered for filter dropdowns.
 var ErrorReportStatuses = []string{
 	string(ErrorReportStatusPending),
 	string(ErrorReportStatusResolved),
@@ -78,7 +78,7 @@ var allowedErrorReportSort = map[string]string{
 	"route":       "route",
 }
 
-// InsertErrorReport stores a new error report and returns it with the assigned ID.
+// InsertErrorReport persists r as a pending report; CreatedAt is overwritten with the current UTC time.
 func (d *DB) InsertErrorReport(ctx context.Context, r ErrorReport) (ErrorReport, error) {
 	res, err := d.db.ExecContext(ctx,
 		`INSERT INTO error_reports (request_id, description, route, status_code, user_agent, log_entries, status, created_at)
@@ -104,7 +104,7 @@ func (d *DB) InsertErrorReport(ctx context.Context, r ErrorReport) (ErrorReport,
 	return r, nil
 }
 
-// GetErrorReport returns a single error report by ID.
+// GetErrorReport parses RFC3339 timestamps back into time.Time; unparseable values fall back to time.Now.
 func (d *DB) GetErrorReport(ctx context.Context, id int) (ErrorReport, error) {
 	var r ErrorReport
 	var status string
@@ -134,7 +134,7 @@ func (d *DB) GetErrorReport(ctx context.Context, id int) (ErrorReport, error) {
 	return r, nil
 }
 
-// ListErrorReports queries error reports with optional filters, sort, and pagination.
+// ListErrorReports paginates over filter/sort criteria and also reports the unpaginated total.
 func (d *DB) ListErrorReports(ctx context.Context, search, status, sortBy, sortDir string, page, perPage int) ([]ErrorReport, int, error) {
 	col, ok := allowedErrorReportSort[sortBy]
 	if !ok {
@@ -210,7 +210,7 @@ func (d *DB) ListErrorReports(ctx context.Context, search, status, sortBy, sortD
 	return reports, total, rows.Err()
 }
 
-// UpdateErrorReportStatus changes the status of an error report.
+// UpdateErrorReportStatus transitions a report's status; resolved and dismissed also stamp resolved_at.
 func (d *DB) UpdateErrorReportStatus(ctx context.Context, id int, status ErrorReportStatus) error {
 	var resolvedAt any
 	if status == ErrorReportStatusResolved || status == ErrorReportStatusDismissed {
@@ -235,7 +235,6 @@ func (d *DB) UpdateErrorReportStatus(ctx context.Context, id int, status ErrorRe
 	return nil
 }
 
-// initErrorReports creates the error_reports table if it does not exist.
 func (d *DB) initErrorReports() error {
 	_, err := d.db.Exec(`CREATE TABLE IF NOT EXISTS error_reports (
 		id          INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/demo/hotzone_lab.go
+++ b/internal/demo/hotzone_lab.go
@@ -13,12 +13,13 @@ import (
 // HotZoneMode describes how a region handles user commands.
 type HotZoneMode string
 
+// HotZoneMode values: hx-post routes via plain HTMX, tavern-command via the Tavern broker.
 const (
 	HotZoneModeHXPost HotZoneMode = "hx-post"
 	HotZoneModeTavern HotZoneMode = "tavern-command"
 )
 
-// HotZoneCell represents one cell in a region's text grid.
+// HotZoneCell is one tile in a region's grid: a glyph paired with a palette index into HotZonePalette.
 type HotZoneCell struct {
 	Glyph   string
 	Palette int // index into the color palette (0–7)
@@ -37,14 +38,16 @@ type HotZoneRegion struct {
 // HotZoneSwapScope controls the granularity of SSE replacement.
 type HotZoneSwapScope string
 
+// HotZoneSwapScope values: inner swaps the cell grid; card replaces the entire region card.
 const (
 	HotZoneSwapInner HotZoneSwapScope = "inner"
 	HotZoneSwapCard  HotZoneSwapScope = "card"
 )
 
-// HotZonePreset is a named pressure profile.
+// HotZonePreset names a stress profile applied by ApplyPreset.
 type HotZonePreset string
 
+// HotZonePreset values in ascending intensity (region count and update rate).
 const (
 	HotZonePresetNormal HotZonePreset = "normal"
 	HotZonePresetHot    HotZonePreset = "hot"
@@ -68,7 +71,7 @@ var HotZonePalette = [8][2]string{
 
 var glyphs = []string{"█", "■", "●", "+", "▓", "◆", "▲", "◉"}
 
-// HotZoneSettings holds operator-controlled simulation parameters.
+// HotZoneSettings holds the lab's tunable state; ApplyPreset rewrites timing fields, never persists across rebuilds.
 type HotZoneSettings struct {
 	Preset           HotZonePreset
 	CommandMode      HotZoneMode
@@ -91,12 +94,12 @@ type HotZoneSettings struct {
 	HeatEnabled      bool
 }
 
-// DefaultHeatSettings returns sensible heat-map defaults.
+// DefaultHeatSettings is window(ms), 3 ascending thresholds, then 3 stage colors plus base.
 func DefaultHeatSettings() (int, int, int, int, string, string, string, string) {
 	return 1000, 8, 16, 32, "#22c55e", "#ef4444", "#a855f7", "#1e293b"
 }
 
-// ApplyPreset sets fields to the named preset's values.
+// ApplyPreset rewrites the timing, region, and heat fields to match the named preset and re-enables heat.
 func (s *HotZoneSettings) ApplyPreset(p HotZonePreset) {
 	s.Preset = p
 	s.HeatWindowMS, s.HeatThreshold1, s.HeatThreshold2, s.HeatThreshold3,
@@ -147,7 +150,7 @@ type HotZoneCommandStat struct {
 	Failed     int64
 }
 
-// HotZoneLab wraps the shared state for the hot-zone stress surface.
+// HotZoneLab is the shared state for the hot-zone stress surface (regions, settings, command counters).
 type HotZoneLab struct {
 	activity         []HotZoneActivity
 	regions          []HotZoneRegion
@@ -164,13 +167,13 @@ type HotZoneLab struct {
 	paused           bool
 }
 
-// HotZoneActivity records one action in the activity log.
+// HotZoneActivity is a single entry in the lab's rolling 30-action audit log.
 type HotZoneActivity struct {
 	Timestamp time.Time
 	Action    string
 }
 
-// NewHotZoneLab creates a lab with default settings.
+// NewHotZoneLab pre-allocates 64 regions; only the first RegionCount are active.
 func NewHotZoneLab() *HotZoneLab {
 	wMS, t1, t2, t3, c1, c2, c3, base := DefaultHeatSettings()
 	lab := &HotZoneLab{
@@ -219,7 +222,7 @@ func generateCells(gridSize int) []HotZoneCell {
 	return cells
 }
 
-// Settings returns a snapshot of the current settings.
+// Settings is a snapshot under read lock; safe to inspect without further locking.
 func (l *HotZoneLab) Settings() HotZoneSettings {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -233,14 +236,14 @@ func (l *HotZoneLab) UpdateSettings(fn func(s *HotZoneSettings)) {
 	fn(&l.settings)
 }
 
-// Paused returns whether the simulator is paused.
+// Paused reports whether SimTick should be skipped this round.
 func (l *HotZoneLab) Paused() bool {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	return l.paused
 }
 
-// TogglePause flips pause state and returns the new value.
+// TogglePause flips the pause flag and returns the new value.
 func (l *HotZoneLab) TogglePause() bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -248,7 +251,7 @@ func (l *HotZoneLab) TogglePause() bool {
 	return l.paused
 }
 
-// Region returns a snapshot of a single region (1-indexed).
+// Region snapshots a single region (1-indexed); out-of-range ids return the zero value.
 func (l *HotZoneLab) Region(id int) HotZoneRegion {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -258,7 +261,7 @@ func (l *HotZoneLab) Region(id int) HotZoneRegion {
 	return l.regions[id-1]
 }
 
-// Regions returns snapshots of the active regions.
+// Regions snapshots only the first RegionCount entries, in order.
 func (l *HotZoneLab) Regions() []HotZoneRegion {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -268,7 +271,7 @@ func (l *HotZoneLab) Regions() []HotZoneRegion {
 	return out
 }
 
-// ToggleLock flips the lock state of a region and returns the new state.
+// ToggleLock flips the locked flag on region id (1-indexed); locked regions are skipped by SimTick.
 func (l *HotZoneLab) ToggleLock(id int) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -279,7 +282,7 @@ func (l *HotZoneLab) ToggleLock(id int) bool {
 	return l.regions[id-1].Locked
 }
 
-// SimTick runs one simulation tick.
+// SimTick advances regions per BurstMode/FocusedRegion settings and returns the 1-indexed IDs that changed.
 func (l *HotZoneLab) SimTick() []int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -320,7 +323,7 @@ func (l *HotZoneLab) SimTick() []int {
 	return updated
 }
 
-// JitteredInterval returns the next tick duration with random jitter.
+// JitteredInterval is UpdateIntervalMS plus a uniform jitter in [JitterMinMS, JitterMaxMS].
 func (l *HotZoneLab) JitteredInterval() time.Duration {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -349,7 +352,7 @@ func (l *HotZoneLab) RecordActivity(action string) {
 	}
 }
 
-// Activity returns the recent activity log.
+// Activity is a defensive copy of the rolling 30-entry log, oldest first.
 func (l *HotZoneLab) Activity() []HotZoneActivity {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -392,7 +395,7 @@ func (l *HotZoneLab) RecordLifecycle(mode HotZoneMode, action string) {
 	}
 }
 
-// CommandStats returns delivery stats for both modes.
+// CommandStats is delivery stats for both modes; per-counter atomic reads are not consistent across fields.
 func (l *HotZoneLab) CommandStats() [2]HotZoneCommandStat {
 	return [2]HotZoneCommandStat{
 		{Mode: HotZoneModeHXPost, Dispatched: l.hxDispatched.Load(), Received: l.hxReceived.Load(), Succeeded: l.hxOK.Load(), Failed: l.hxFail.Load()},
@@ -400,7 +403,7 @@ func (l *HotZoneLab) CommandStats() [2]HotZoneCommandStat {
 	}
 }
 
-// ResetStats zeroes all command counters.
+// ResetStats zeroes every dispatched/received/succeeded/failed counter across both command modes.
 func (l *HotZoneLab) ResetStats() {
 	l.hxDispatched.Store(0)
 	l.hxReceived.Store(0)

--- a/internal/demo/kanban.go
+++ b/internal/demo/kanban.go
@@ -4,13 +4,13 @@ package demo
 
 import "sync"
 
-// KanbanStatuses enumerates the valid board columns.
+// KanbanStatuses enumerates board columns left-to-right.
 var KanbanStatuses = []string{"backlog", "todo", "in_progress", "review", "done"}
 
-// KanbanPriorities enumerates the valid priority levels.
+// KanbanPriorities enumerates priority levels in ascending urgency.
 var KanbanPriorities = []string{"low", "medium", "high", "critical"}
 
-// KanbanTask represents a single task on the board.
+// KanbanTask is one card on the board; Status must be one of KanbanStatuses.
 type KanbanTask struct {
 	Title       string
 	Description string
@@ -27,7 +27,7 @@ type KanbanBoard struct {
 	mu     sync.RWMutex
 }
 
-// NewKanbanBoard creates a board seeded with sample tasks.
+// NewKanbanBoard pre-seeds 9 sample cards spread across all five status columns.
 func NewKanbanBoard() *KanbanBoard {
 	b := &KanbanBoard{}
 	seed := []KanbanTask{
@@ -49,7 +49,7 @@ func NewKanbanBoard() *KanbanBoard {
 	return b
 }
 
-// AllTasks returns a copy of every task on the board.
+// AllTasks is a defensive copy; safe to mutate independently of the board.
 func (b *KanbanBoard) AllTasks() []KanbanTask {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -58,7 +58,7 @@ func (b *KanbanBoard) AllTasks() []KanbanTask {
 	return out
 }
 
-// TasksByStatus returns tasks that match the given status.
+// TasksByStatus filters by column, preserving insertion order.
 func (b *KanbanBoard) TasksByStatus(status string) []KanbanTask {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -71,7 +71,7 @@ func (b *KanbanBoard) TasksByStatus(status string) []KanbanTask {
 	return out
 }
 
-// GetTask returns a task by ID and a boolean indicating whether it was found.
+// GetTask looks up by ID; ok is false when the task is not found.
 func (b *KanbanBoard) GetTask(id int) (KanbanTask, bool) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -83,7 +83,7 @@ func (b *KanbanBoard) GetTask(id int) (KanbanTask, bool) {
 	return KanbanTask{}, false
 }
 
-// MoveTask changes a task's status and returns the updated task.
+// MoveTask reassigns Status only; ok is false if id is unknown.
 func (b *KanbanBoard) MoveTask(id int, newStatus string) (KanbanTask, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -96,7 +96,7 @@ func (b *KanbanBoard) MoveTask(id int, newStatus string) (KanbanTask, bool) {
 	return KanbanTask{}, false
 }
 
-// UpdateTask modifies a task's fields and returns the updated task.
+// UpdateTask overwrites the card's editable fields in-place; Status is preserved (use MoveTask to change it).
 func (b *KanbanBoard) UpdateTask(id int, title, description, priority, assignee string) (KanbanTask, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/demo/link_relations.go
+++ b/internal/demo/link_relations.go
@@ -31,7 +31,7 @@ func (d *DB) initLinkRelations() error {
 	return err
 }
 
-// ListStoredLinks returns all admin-created link relations.
+// ListStoredLinks enumerates every relation, ordered by (source, rel, target) for stable display.
 func (d *DB) ListStoredLinks() ([]StoredLinkRelation, error) {
 	rows, err := d.db.Query(
 		"SELECT id, source, rel, target, title, group_name, created_at FROM link_relations ORDER BY source, rel, target")
@@ -51,7 +51,7 @@ func (d *DB) ListStoredLinks() ([]StoredLinkRelation, error) {
 	return links, rows.Err()
 }
 
-// InsertLink creates a new admin link relation.
+// InsertLink persists a new relation; the (source, rel, target) unique constraint prevents duplicates.
 func (d *DB) InsertLink(source, rel, target, title, groupName string) error {
 	_, err := d.db.Exec(
 		"INSERT INTO link_relations (source, rel, target, title, group_name) VALUES (?, ?, ?, ?, ?)",
@@ -62,7 +62,7 @@ func (d *DB) InsertLink(source, rel, target, title, groupName string) error {
 	return nil
 }
 
-// DeleteLink removes an admin-created link relation by ID.
+// DeleteLink removes a relation by ID; errors when no row was affected.
 func (d *DB) DeleteLink(id int) error {
 	res, err := d.db.Exec("DELETE FROM link_relations WHERE id = ?", id)
 	if err != nil {
@@ -78,8 +78,7 @@ func (d *DB) DeleteLink(id int) error {
 	return nil
 }
 
-// StoredLinkIDs returns the set of (source, rel, target) tuples that are admin-created,
-// keyed for quick lookup.
+// StoredLinkIDs is a set of existing relation IDs for membership checks in templates.
 func (d *DB) StoredLinkIDs() (map[int]bool, error) {
 	rows, err := d.db.Query("SELECT id FROM link_relations")
 	if err != nil {

--- a/internal/demo/notifications.go
+++ b/internal/demo/notifications.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 )
 
-// NotificationIdentity represents a user identity for the notifications demo.
+// NotificationIdentity is one entry in the visitor identity pool; Color drives avatar tint.
 type NotificationIdentity struct {
 	ID    string
 	Name  string
@@ -33,7 +33,7 @@ var notificationIdentityPool = []NotificationIdentity{
 	{ID: "u12", Name: "Syntax Error", Color: "#64748b"},
 }
 
-// NotificationCategory defines the notification types.
+// NotificationCategory groups outbound notifications for per-category filtering.
 type NotificationCategory string
 
 // Notification category constants.
@@ -44,7 +44,7 @@ const (
 	CatSystem  NotificationCategory = "system"
 )
 
-// AllNotificationCategories lists every category.
+// AllNotificationCategories is the canonical category list in toolbar display order.
 var AllNotificationCategories = []NotificationCategory{
 	CatOrder, CatMention, CatAlert, CatSystem,
 }
@@ -87,14 +87,14 @@ type NotificationFilters struct {
 	mu      sync.RWMutex
 }
 
-// NewNotificationFilters creates a new filter store.
+// NewNotificationFilters starts empty; per-user defaults materialise on the first SetFilter call.
 func NewNotificationFilters() *NotificationFilters {
 	return &NotificationFilters{
 		filters: make(map[string]map[NotificationCategory]bool),
 	}
 }
 
-// SetFilter enables or disables a category for a user.
+// SetFilter persists a category preference for the user, seeding all categories enabled on first touch.
 func (nf *NotificationFilters) SetFilter(userID string, cat NotificationCategory, enabled bool) {
 	nf.mu.Lock()
 	defer nf.mu.Unlock()
@@ -107,7 +107,7 @@ func (nf *NotificationFilters) SetFilter(userID string, cat NotificationCategory
 	nf.filters[userID][cat] = enabled
 }
 
-// IsEnabled checks if a category is enabled for a user. Defaults to true.
+// IsEnabled defaults to true when the user has no recorded preference for the category.
 func (nf *NotificationFilters) IsEnabled(userID string, cat NotificationCategory) bool {
 	nf.mu.RLock()
 	defer nf.mu.RUnlock()
@@ -119,7 +119,7 @@ func (nf *NotificationFilters) IsEnabled(userID string, cat NotificationCategory
 	return true
 }
 
-// EnabledCategories returns all enabled categories for a user.
+// EnabledCategories materialises every category, defaulting unset entries to true.
 func (nf *NotificationFilters) EnabledCategories(userID string) map[NotificationCategory]bool {
 	nf.mu.RLock()
 	defer nf.mu.RUnlock()
@@ -135,19 +135,19 @@ func (nf *NotificationFilters) EnabledCategories(userID string) map[Notification
 	return result
 }
 
-// AssignIdentity returns an identity for a given index (wraps around the pool).
+// AssignIdentity wraps index modulo the identity pool, so any int is valid.
 func AssignIdentity(index int) NotificationIdentity {
 	return notificationIdentityPool[index%len(notificationIdentityPool)]
 }
 
-// AllNotificationIdentities returns the full identity pool.
+// AllNotificationIdentities is a defensive copy of the fixed pool; safe to mutate independently.
 func AllNotificationIdentities() []NotificationIdentity {
 	out := make([]NotificationIdentity, len(notificationIdentityPool))
 	copy(out, notificationIdentityPool)
 	return out
 }
 
-// IdentityIndexByID returns the pool index for a given identity ID, or -1.
+// IdentityIndexByID is the pool index for id, or -1 when not found.
 func IdentityIndexByID(id string) int {
 	for i, ident := range notificationIdentityPool {
 		if ident.ID == id {
@@ -157,20 +157,20 @@ func IdentityIndexByID(id string) int {
 	return -1
 }
 
-// RandomIdentityIndex returns a random index into the identity pool.
+// RandomIdentityIndex is a crypto/rand index into the identity pool.
 func RandomIdentityIndex() int {
 	n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(notificationIdentityPool))))
 	return int(n.Int64())
 }
 
-// GenerateNotifID returns a short random ID for a notification.
+// GenerateNotifID is a hex-encoded 4-byte random ID (8 chars).
 func GenerateNotifID() string {
 	b := make([]byte, 4)
 	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
 }
 
-// FormatNotification renders a random message for the given category.
+// FormatNotification picks a random template from NotificationMessages[cat] and fills in a random 1000-9999 token.
 func FormatNotification(cat NotificationCategory) string {
 	msgs := NotificationMessages[cat]
 	n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(msgs))))

--- a/internal/demo/observatory.go
+++ b/internal/demo/observatory.go
@@ -21,7 +21,7 @@ type TierChangeEvent struct {
 	Tier         int
 }
 
-// ObservatoryState manages demo-broker observation state for the observatory page.
+// ObservatoryState holds the observatory page's tier-change ring buffer, subscriber cap, and stress-test handle.
 type ObservatoryState struct {
 	stressCancel context.CancelFunc
 	tierChanges  []TierChangeEvent
@@ -30,7 +30,7 @@ type ObservatoryState struct {
 	maxPerTopic  atomic.Int32
 }
 
-// NewObservatoryState returns an initialised ObservatoryState.
+// NewObservatoryState starts empty with the per-topic subscriber cap at 10.
 func NewObservatoryState() *ObservatoryState {
 	s := &ObservatoryState{
 		tierChanges: make([]TierChangeEvent, 0, maxTierChanges),
@@ -57,7 +57,7 @@ func (s *ObservatoryState) RecordTierChange(topic, subID string, tier int) {
 	s.mu.Unlock()
 }
 
-// RecentTierChanges returns a copy of the tier change log, newest first.
+// RecentTierChanges is a copy of the ring buffer, reversed so the newest entry is index 0.
 func (s *ObservatoryState) RecentTierChanges() []TierChangeEvent {
 	s.mu.RLock()
 	out := make([]TierChangeEvent, len(s.tierChanges))
@@ -70,13 +70,12 @@ func (s *ObservatoryState) RecentTierChanges() []TierChangeEvent {
 	return out
 }
 
-// MaxPerTopic returns the current per-topic subscriber cap.
+// MaxPerTopic is the current per-topic subscriber cap (atomic read).
 func (s *ObservatoryState) MaxPerTopic() int {
 	return int(s.maxPerTopic.Load())
 }
 
-// SetMaxPerTopic updates the per-topic subscriber cap. The cap takes effect
-// for new subscriptions on the next admission check.
+// SetMaxPerTopic updates the cap; takes effect on the next admission check. Negative values clamp to 0.
 func (s *ObservatoryState) SetMaxPerTopic(n int) {
 	if n < 0 {
 		n = 0
@@ -84,12 +83,12 @@ func (s *ObservatoryState) SetMaxPerTopic(n int) {
 	s.maxPerTopic.Store(int32(n))
 }
 
-// StressActive reports whether the stress test is running.
+// StressActive reports whether a stress-test goroutine is currently running.
 func (s *ObservatoryState) StressActive() bool {
 	return s.stressActive.Load()
 }
 
-// SetStress stores stress-test lifecycle state.
+// SetStress stores the cancel function for a running stress test and toggles the active flag.
 func (s *ObservatoryState) SetStress(active bool, cancel context.CancelFunc) {
 	s.mu.Lock()
 	s.stressCancel = cancel

--- a/internal/demo/people.go
+++ b/internal/demo/people.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// Person represents a person in the directory.
+// Person is one row of the demo people directory; CreatedAt is stored as a date-formatted string.
 type Person struct {
 	FirstName  string
 	LastName   string
@@ -24,10 +24,10 @@ type Person struct {
 	ID         int
 }
 
-// FullName returns "First Last".
+// FullName joins FirstName and LastName with a single space.
 func (p Person) FullName() string { return p.FirstName + " " + p.LastName }
 
-// Departments is the list of available departments for filters.
+// Departments enumerates the seed department values used by the people filter dropdown.
 var Departments = []string{
 	"Engineering", "Sales", "Marketing", "Finance", "Human Resources",
 	"Operations", "Legal", "Customer Support", "Product", "Design",
@@ -40,7 +40,7 @@ var allowedPeopleSort = map[string]string{
 	"title":      "job_title",
 }
 
-// ListPeople returns a paginated list of people matching optional search and department filters.
+// ListPeople paginates over optional search/department filters and reports the unpaginated total.
 func (d *DB) ListPeople(ctx context.Context, search, department, sortBy, sortDir string, page, perPage int) ([]Person, int, error) {
 	col, ok := allowedPeopleSort[sortBy]
 	if !ok {
@@ -99,7 +99,7 @@ func (d *DB) ListPeople(ctx context.Context, search, department, sortBy, sortDir
 	return people, total, rows.Err()
 }
 
-// GetPerson returns a single person by ID.
+// GetPerson looks up by ID; sql.ErrNoRows is wrapped in a contextual error.
 func (d *DB) GetPerson(ctx context.Context, id int) (Person, error) {
 	var p Person
 	err := d.db.QueryRowContext(ctx,
@@ -111,7 +111,7 @@ func (d *DB) GetPerson(ctx context.Context, id int) (Person, error) {
 	return p, nil
 }
 
-// UpdatePerson updates a person row.
+// UpdatePerson writes p's mutable fields; CreatedAt is not modified and missing IDs return an error.
 func (d *DB) UpdatePerson(ctx context.Context, p Person) error {
 	res, err := d.db.ExecContext(ctx,
 		"UPDATE people SET first_name=@FirstName, last_name=@LastName, email=@Email, phone=@Phone, city=@City, state=@State, department=@Department, job_title=@JobTitle, bio=@Bio WHERE id=@ID",

--- a/internal/demo/publish_stats.go
+++ b/internal/demo/publish_stats.go
@@ -21,7 +21,7 @@ func (s *PublishStats) Add(bytes int) {
 	s.bytes.Add(int64(bytes))
 }
 
-// Snapshot returns the current count and total byte total.
+// Snapshot is the count/byte pair; the two atomic reads are not consistent across fields.
 func (s *PublishStats) Snapshot() (count, bytes int64) {
 	return s.count.Load(), s.bytes.Load()
 }

--- a/internal/demo/recovery.go
+++ b/internal/demo/recovery.go
@@ -26,32 +26,31 @@ type RecoveryLab struct {
 	mu            sync.RWMutex
 }
 
-// NewRecoveryLab returns a new RecoveryLab seeded with a starting snapshot.
+// NewRecoveryLab pre-seeds the snapshot with "initial value" and both counters at 0.
 func NewRecoveryLab() *RecoveryLab {
 	return &RecoveryLab{snapshotValue: "initial value"}
 }
 
-// NextReplayEvent returns a fresh sequence number and ID for the replay
-// region. The ID is intended to be passed to PublishWithID so the broker's
-// replay cache picks it up.
+// NextReplayEvent emits a fresh "rep-N" ID plus seq for PublishWithID, so
+// the broker's replay cache picks the event up.
 func (rl *RecoveryLab) NextReplayEvent() (id string, seq int64, ts time.Time) {
 	n := rl.replaySeq.Add(1)
 	return formatRecoveryID("rep", n), n, time.Now()
 }
 
-// NextLiveEvent returns a sequence number for the live-only region.
+// NextLiveEvent advances the live-only counter; no replay ID is emitted.
 func (rl *RecoveryLab) NextLiveEvent() (seq int64, ts time.Time) {
 	return rl.liveSeq.Add(1), time.Now()
 }
 
-// SetSnapshot updates the in-place snapshot value.
+// SetSnapshot replaces the current snapshot value broadcast to new subscribers on connect.
 func (rl *RecoveryLab) SetSnapshot(v string) {
 	rl.mu.Lock()
 	rl.snapshotValue = v
 	rl.mu.Unlock()
 }
 
-// Snapshot returns the current snapshot value.
+// Snapshot is safe for concurrent reads alongside SetSnapshot writers.
 func (rl *RecoveryLab) Snapshot() string {
 	rl.mu.RLock()
 	defer rl.mu.RUnlock()

--- a/internal/demo/seed.go
+++ b/internal/demo/seed.go
@@ -15,13 +15,13 @@ type SeedDB struct {
 	attached bool
 }
 
-// SeedTableInfo describes a table in the seed database.
+// SeedTableInfo summarises one table in the attached seed schema or the main DB.
 type SeedTableInfo struct {
 	Name     string
 	RowCount int
 }
 
-// NewSeedDB wraps an existing in-memory database connection for seed operations.
+// NewSeedDB binds db (typically the demo in-memory pool) for ATTACH-based seed operations.
 func NewSeedDB(db *sql.DB) *SeedDB {
 	return &SeedDB{db: db}
 }
@@ -39,7 +39,7 @@ func (s *SeedDB) Attach(ctx context.Context, seedPath string) error {
 	return nil
 }
 
-// Detach detaches the seed schema.
+// Detach drops the "seed" schema attachment; no-op when not attached.
 func (s *SeedDB) Detach(ctx context.Context) error {
 	if !s.attached {
 		return nil
@@ -52,12 +52,12 @@ func (s *SeedDB) Detach(ctx context.Context) error {
 	return nil
 }
 
-// IsAttached reports whether seed.db is currently attached.
+// IsAttached reports whether seed.db is currently attached as the "seed" schema.
 func (s *SeedDB) IsAttached() bool {
 	return s.attached
 }
 
-// SeedTables returns information about all tables in the seed database.
+// SeedTables enumerates tables in the attached seed schema with row counts; errors when not attached.
 func (s *SeedDB) SeedTables(ctx context.Context) ([]SeedTableInfo, error) {
 	if !s.attached {
 		return nil, fmt.Errorf("seed.db not attached")
@@ -69,8 +69,8 @@ func (s *SeedDB) SeedTables(ctx context.Context) ([]SeedTableInfo, error) {
 	return s.countTables(ctx, "seed", names)
 }
 
-// CopyTable copies a table from the seed schema into the main database.
-// It creates the table in the main schema if it doesn't exist, then inserts all rows.
+// CopyTable copies a table from the seed schema into the main database,
+// creating the main-schema table when missing and using INSERT OR IGNORE for rows.
 func (s *SeedDB) CopyTable(ctx context.Context, tableName string) (int64, error) {
 	if !s.attached {
 		return 0, fmt.Errorf("seed.db not attached")
@@ -110,7 +110,6 @@ func (s *SeedDB) CopyTable(ctx context.Context, tableName string) (int64, error)
 	return result.RowsAffected()
 }
 
-// tableColumns returns the column names for a table in the given schema.
 func (s *SeedDB) tableColumns(ctx context.Context, schema, table string) ([]string, error) {
 	rows, err := s.db.QueryContext(ctx, fmt.Sprintf("PRAGMA %s.table_info(%s)", schema, table))
 	if err != nil {
@@ -133,7 +132,7 @@ func (s *SeedDB) tableColumns(ctx context.Context, schema, table string) ([]stri
 	return cols, rows.Err()
 }
 
-// MainTables returns information about all user tables in the main database.
+// MainTables enumerates user tables in the main schema with row counts (sqlite_* tables excluded).
 func (s *SeedDB) MainTables(ctx context.Context) ([]SeedTableInfo, error) {
 	names, err := s.listTableNames(ctx, "main")
 	if err != nil {
@@ -178,7 +177,7 @@ func (s *SeedDB) countTables(ctx context.Context, schema string, names []string)
 	return tables, nil
 }
 
-// DropMainTable drops a table from the main database.
+// DropMainTable issues DROP TABLE IF EXISTS against the main schema; never errors on missing tables.
 func (s *SeedDB) DropMainTable(ctx context.Context, tableName string) error {
 	_, err := s.db.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS main.%s", tableName))
 	if err != nil {

--- a/internal/demo/sensors.go
+++ b/internal/demo/sensors.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// SensorType identifies the kind of measurement a sensor produces.
+// SensorType is the kind of reading produced by a sensor; ranges and units are looked up in sensorSpecs.
 type SensorType string
 
 // Sensor type constants.
@@ -23,10 +23,10 @@ const (
 	SensorLight    SensorType = "light"
 )
 
-// AllSensorTypes lists every sensor type in grid order.
+// AllSensorTypes is the canonical sensor-type list in grid order.
 var AllSensorTypes = []SensorType{SensorTemp, SensorHumidity, SensorPressure, SensorLight}
 
-// SensorReading holds the latest value for a single sensor.
+// SensorReading is a single measurement; Topic is "sensors/floor{N}/{Type}" matching AllTopics order.
 type SensorReading struct {
 	Timestamp time.Time
 	Topic     string
@@ -62,7 +62,7 @@ type sensorState struct {
 	reading SensorReading
 }
 
-// NewSensorGrid creates a 4x4 sensor grid with initial random values.
+// NewSensorGrid pre-seeds 16 sensors (4 floors x 4 types) with random values inside each spec range.
 func NewSensorGrid() *SensorGrid {
 	g := &SensorGrid{
 		sensors: make(map[string]*sensorState, 16),
@@ -90,7 +90,7 @@ func NewSensorGrid() *SensorGrid {
 	return g
 }
 
-// AllTopics returns all 16 sensor topics in deterministic order.
+// AllTopics is the 16 sensor topics emitted in floor-then-type order (deterministic).
 func (g *SensorGrid) AllTopics() []string {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -133,13 +133,12 @@ func (g *SensorGrid) SetFloodMode(on bool) {
 	g.flooding.Store(on)
 }
 
-// IsFlooding returns whether flood mode is active.
+// IsFlooding reports whether high-frequency publish mode is currently enabled.
 func (g *SensorGrid) IsFlooding() bool {
 	return g.flooding.Load()
 }
 
-// Snapshot returns current readings for all topics matching the glob-style
-// pattern. It performs simple prefix/suffix matching with * and ** wildcards.
+// Snapshot picks topics matching a glob: * is one segment, ** is any path tail.
 func (g *SensorGrid) Snapshot(pattern string) map[string]SensorReading {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -152,7 +151,7 @@ func (g *SensorGrid) Snapshot(pattern string) map[string]SensorReading {
 	return result
 }
 
-// Reading returns the current reading for a specific topic.
+// Reading looks up topic; ok is false when it isn't one of the 16 known sensors.
 func (g *SensorGrid) Reading(topic string) (SensorReading, bool) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -163,7 +162,7 @@ func (g *SensorGrid) Reading(topic string) (SensorReading, bool) {
 	return s.reading, true
 }
 
-// History returns the last 10 values for a topic's sparkline.
+// History is up to the last 10 values for a topic's sparkline; nil if topic is unknown.
 func (g *SensorGrid) History(topic string) []float64 {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
@@ -176,7 +175,7 @@ func (g *SensorGrid) History(topic string) []float64 {
 	return out
 }
 
-// AllReadings returns every sensor reading in grid order.
+// AllReadings emits every sensor reading in floor-then-type order.
 func (g *SensorGrid) AllReadings() []SensorReading {
 	g.mu.RLock()
 	defer g.mu.RUnlock()

--- a/internal/demo/settings.go
+++ b/internal/demo/settings.go
@@ -4,7 +4,7 @@ package demo
 
 import "sync"
 
-// SettingField represents a single configurable field within a settings section.
+// SettingField is one editable control in a settings form; Options is used only when Kind is "select".
 type SettingField struct {
 	Key     string
 	Label   string
@@ -13,7 +13,7 @@ type SettingField struct {
 	Options []string // used when Kind is "select"
 }
 
-// SettingsSection groups related settings fields together.
+// SettingsSection groups related SettingField entries into a tab/panel rendered by the settings page.
 type SettingsSection struct {
 	ID          string
 	Title       string
@@ -27,7 +27,7 @@ type SettingsStore struct {
 	mu       sync.RWMutex
 }
 
-// NewSettingsStore creates a SettingsStore seeded with default sections.
+// NewSettingsStore pre-seeds the four standard sections: general, notifications, security, appearance.
 func NewSettingsStore() *SettingsStore {
 	return &SettingsStore{
 		sections: []SettingsSection{
@@ -75,7 +75,7 @@ func NewSettingsStore() *SettingsStore {
 	}
 }
 
-// GetSection returns the section with the given ID and true, or a zero value and false if not found.
+// GetSection looks up by ID; ok is false (and the section is zero) when not found.
 func (s *SettingsStore) GetSection(id string) (SettingsSection, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -87,7 +87,7 @@ func (s *SettingsStore) GetSection(id string) (SettingsSection, bool) {
 	return SettingsSection{}, false
 }
 
-// AllSections returns a copy of every settings section.
+// AllSections is a defensive copy; safe to mutate independently.
 func (s *SettingsStore) AllSections() []SettingsSection {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/demo/tasks.go
+++ b/internal/demo/tasks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/catgoose/chuck/dbrepo"
 )
 
-// TaskStatuses is the list of valid task statuses.
+// TaskStatuses enumerates the lifecycle states stored in the Tasks.Status column.
 var TaskStatuses = []string{"draft", "active", "done"}
 
 // TasksTable defines the tasks table schema using the full repository pattern.
@@ -62,18 +62,18 @@ type Task struct {
 	Version     int            `db:"Version"`
 }
 
-// TaskStore provides CRUD operations on the Tasks table using the repository pattern.
+// TaskStore is the repository-pattern accessor for the Tasks table.
 type TaskStore struct {
 	db      *sql.DB
 	dialect dialect.Dialect
 }
 
-// NewTaskStore creates a TaskStore.
+// NewTaskStore binds db and the SQLite dialect; pass a different dialect by constructing TaskStore directly.
 func NewTaskStore(db *sql.DB) *TaskStore {
 	return &TaskStore{db: db, dialect: dialect.SQLiteDialect{}}
 }
 
-// ListTasks queries tasks with optional filters, sort, and pagination.
+// ListTasks paginates over filter/sort criteria; soft-deleted and archived rows are hidden unless explicitly requested.
 func (s *TaskStore) ListTasks(ctx context.Context, search, status, showArchived, showDeleted, sortBy, sortDir string, page, perPage int) ([]Task, int, error) {
 	w := dbrepo.NewWhere()
 
@@ -145,7 +145,7 @@ func (s *TaskStore) ListTasks(ctx context.Context, search, status, showArchived,
 	return tasks, total, rows.Err()
 }
 
-// GetTask returns a single task by ID.
+// GetTask bypasses soft-delete and archive filters; useful for admin views.
 func (s *TaskStore) GetTask(ctx context.Context, id int) (Task, error) {
 	cols := dbrepo.Columns(TasksTable.SelectColumns()...)
 	query := fmt.Sprintf("SELECT %s FROM %s WHERE ID = @ID", cols, TasksTable.Name)
@@ -163,7 +163,7 @@ func (s *TaskStore) GetTask(ctx context.Context, id int) (Task, error) {
 	return t, nil
 }
 
-// CreateTask inserts a new task using repository helpers.
+// CreateTask stamps timestamps and Version=1, defaulting Status to "draft" when empty.
 func (s *TaskStore) CreateTask(ctx context.Context, t *Task) error {
 	dbrepo.SetCreateTimestamps(&t.CreatedAt, &t.UpdatedAt)
 	dbrepo.InitVersion(&t.Version)
@@ -198,7 +198,7 @@ func (s *TaskStore) CreateTask(ctx context.Context, t *Task) error {
 	return nil
 }
 
-// UpdateTask updates a task using repository helpers.
+// UpdateTask increments Version and enforces optimistic concurrency via WHERE Version=prev.
 func (s *TaskStore) UpdateTask(ctx context.Context, t *Task) error {
 	dbrepo.SetUpdateTimestamp(&t.UpdatedAt)
 	dbrepo.IncrementVersion(&t.Version)
@@ -250,7 +250,7 @@ func (s *TaskStore) execUpdate(ctx context.Context, op string, id int, query str
 	return nil
 }
 
-// SoftDeleteTask marks a task as deleted using SetSoftDelete.
+// SoftDeleteTask stamps DeletedAt; rows are then hidden from ListTasks by default.
 func (s *TaskStore) SoftDeleteTask(ctx context.Context, id int) error {
 	now := dbrepo.GetNow()
 	return s.execUpdate(ctx, "soft delete", id,
@@ -267,7 +267,7 @@ func (s *TaskStore) RestoreTask(ctx context.Context, id int) error {
 	)
 }
 
-// ArchiveTask sets ArchivedAt using the archive helper.
+// ArchiveTask stamps ArchivedAt; archived rows are hidden from ListTasks by default.
 func (s *TaskStore) ArchiveTask(ctx context.Context, id int) error {
 	now := dbrepo.GetNow()
 	return s.execUpdate(ctx, "archive", id,

--- a/internal/demo/tavern.go
+++ b/internal/demo/tavern.go
@@ -9,31 +9,31 @@ import (
 	"time"
 )
 
-// ReplayLab tracks numbered events for the replay demo.
+// ReplayLab owns the monotonic event sequence and tunable replay window for the replay demo.
 type ReplayLab struct {
 	counter      atomic.Int64
 	replayWindow atomic.Int64
 }
 
-// NewReplayLab creates a new replay lab with the given initial window.
+// NewReplayLab starts with the counter at 0 and the given replay window.
 func NewReplayLab(window int) *ReplayLab {
 	rl := &ReplayLab{}
 	rl.replayWindow.Store(int64(window))
 	return rl
 }
 
-// NextEvent returns the next event ID and sequence number.
+// NextEvent advances the counter and returns "replay-N" plus the new sequence number.
 func (rl *ReplayLab) NextEvent() (id string, seq int64) {
 	n := rl.counter.Add(1)
 	return fmt.Sprintf("replay-%d", n), n
 }
 
-// ReplayWindow returns the current replay window size.
+// ReplayWindow is the current size honoured by Last-Event-ID reconnects (atomic read).
 func (rl *ReplayLab) ReplayWindow() int {
 	return int(rl.replayWindow.Load())
 }
 
-// SetReplayWindow updates the replay window size.
+// SetReplayWindow stores n atomically; takes effect on the next reconnect.
 func (rl *ReplayLab) SetReplayWindow(n int) {
 	rl.replayWindow.Store(int64(n))
 }
@@ -43,7 +43,7 @@ func (rl *ReplayLab) Reset() {
 	rl.counter.Store(0)
 }
 
-// BackpressureLab tracks stress presets and tier changes.
+// BackpressureLab tracks live subscriber tiers per (topic, subID) and a rolling 30-event tier-change log.
 type BackpressureLab struct {
 	currentTiers map[string]liveTier
 	activePreset string
@@ -65,7 +65,7 @@ type TierChange struct {
 	NewTier   int
 }
 
-// NewBackpressureLab creates a new backpressure lab in calm state.
+// NewBackpressureLab starts in the "calm" preset (2s publish interval).
 func NewBackpressureLab() *BackpressureLab {
 	return &BackpressureLab{
 		activePreset: "calm",
@@ -81,14 +81,14 @@ var BackpressurePresets = map[string]time.Duration{
 	"overwhelming": 5 * time.Millisecond,
 }
 
-// ActivePreset returns the current stress preset name.
+// ActivePreset is the current stress-preset name under read lock.
 func (bl *BackpressureLab) ActivePreset() string {
 	bl.mu.RLock()
 	defer bl.mu.RUnlock()
 	return bl.activePreset
 }
 
-// SetPreset changes the active stress preset.
+// SetPreset switches the publish interval; unknown names are silently ignored.
 func (bl *BackpressureLab) SetPreset(name string) {
 	bl.mu.Lock()
 	defer bl.mu.Unlock()
@@ -120,9 +120,8 @@ func (bl *BackpressureLab) RecordTierChange(topic, subID string, oldTier, newTie
 	}
 }
 
-// HighestTier returns the highest tier among live subscribers, or 0 (normal)
-// if no subscribers are in an elevated tier. Entries older than 10s are
-// treated as stale (subscriber left without a tier-change callback).
+// HighestTier is the max tier across live subscribers (0 = normal); entries
+// older than 10s are pruned as stale.
 func (bl *BackpressureLab) HighestTier() int {
 	bl.mu.Lock()
 	defer bl.mu.Unlock()
@@ -140,7 +139,7 @@ func (bl *BackpressureLab) HighestTier() int {
 	return highest
 }
 
-// TierChanges returns a copy of recent tier change events.
+// TierChanges is a defensive copy of the rolling 30-entry tier-change log.
 func (bl *BackpressureLab) TierChanges() []TierChange {
 	bl.mu.RLock()
 	defer bl.mu.RUnlock()
@@ -157,12 +156,12 @@ type PublishLab struct {
 	IfChangedCount atomic.Int64
 }
 
-// NewPublishLab creates a new publish lab.
+// NewPublishLab starts with all four counters at zero.
 func NewPublishLab() *PublishLab {
 	return &PublishLab{}
 }
 
-// Reset zeroes all counters.
+// Reset zeroes every raw/debounced/throttled/if-changed counter.
 func (pl *PublishLab) Reset() {
 	pl.RawCount.Store(0)
 	pl.DebouncedCount.Store(0)
@@ -170,7 +169,7 @@ func (pl *PublishLab) Reset() {
 	pl.IfChangedCount.Store(0)
 }
 
-// HooksLab tracks mutation source and hook events.
+// HooksLab holds the editable source, a rolling 20-entry hook log, and publish-stats counters.
 type HooksLab struct {
 	source   string
 	hookLog  []HookEvent
@@ -178,33 +177,33 @@ type HooksLab struct {
 	mu       sync.RWMutex
 }
 
-// HookEvent records a hook firing.
+// HookEvent records one hook firing; HookType is one of "before", "after", "on-mutate".
 type HookEvent struct {
 	Timestamp time.Time
 	HookType  string // "before", "after", "on-mutate"
 	Detail    string
 }
 
-// NewHooksLab creates a new hooks lab.
+// NewHooksLab pre-populates Source with a starter greeting.
 func NewHooksLab() *HooksLab {
 	return &HooksLab{source: "Hello from the Hooks Lab!"}
 }
 
-// Source returns the current source text.
+// Source is safe for concurrent reads.
 func (hl *HooksLab) Source() string {
 	hl.mu.RLock()
 	defer hl.mu.RUnlock()
 	return hl.source
 }
 
-// Update sets the source text.
+// Update replaces the editable source; the new value is broadcast to hooks on next publish.
 func (hl *HooksLab) Update(text string) {
 	hl.mu.Lock()
 	defer hl.mu.Unlock()
 	hl.source = text
 }
 
-// RecordHook logs a hook event.
+// RecordHook appends a hook event, evicting the oldest once the 20-entry cap is exceeded.
 func (hl *HooksLab) RecordHook(hookType, detail string) {
 	hl.mu.Lock()
 	defer hl.mu.Unlock()
@@ -218,7 +217,7 @@ func (hl *HooksLab) RecordHook(hookType, detail string) {
 	}
 }
 
-// HookLog returns a copy of recent hook events.
+// HookLog is a defensive copy of the rolling 20-entry hook log.
 func (hl *HooksLab) HookLog() []HookEvent {
 	hl.mu.RLock()
 	defer hl.mu.RUnlock()
@@ -232,7 +231,7 @@ func (hl *HooksLab) AddPublishStats(bytes int) {
 	hl.pubStats.Add(bytes)
 }
 
-// PublishStats returns total publish count and bytes.
+// PublishStats is the running count and byte total; the two atomic reads are not consistent.
 func (hl *HooksLab) PublishStats() (count, bytes int64) {
 	return hl.pubStats.Snapshot()
 }

--- a/internal/demo/toast_lab.go
+++ b/internal/demo/toast_lab.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// ToastSeverity is the visual severity of a toast event.
+// ToastSeverity is the visual severity tier used by templates and the severity-mix simulator.
 type ToastSeverity string
 
 // Toast severity levels.
@@ -20,7 +20,7 @@ const (
 	ToastError   ToastSeverity = "error"
 )
 
-// AllToastSeverities lists the available severities in display order.
+// AllToastSeverities is the canonical severity list in display order.
 var AllToastSeverities = []ToastSeverity{ToastSuccess, ToastInfo, ToastWarning, ToastError}
 
 // ToastSeverityMix names a preset distribution of severities.
@@ -47,17 +47,17 @@ type ToastEvent struct {
 	Sticky     bool          `json:"sticky"`
 }
 
-// ToastLabSettings holds operator-controlled simulation parameters.
+// ToastLabSettings holds tunable knobs for the toast simulator; numeric ranges are documented per field.
 type ToastLabSettings struct {
-	SeverityMix    ToastSeverityMix // severity distribution
-	RateMS         int              // ms between ticks (100–5000)
-	DismissDurMS   int              // auto-dismiss ms (1000–30000)
-	StackSize      int              // max visible toasts (3–20)
-	BurstSize      int              // toasts per burst (1–10)
-	ReplayRecent   bool             // replay recent toasts on reconnect
+	SeverityMix  ToastSeverityMix // severity distribution
+	RateMS       int              // ms between ticks (100–5000)
+	DismissDurMS int              // auto-dismiss ms (1000–30000)
+	StackSize    int              // max visible toasts (3–20)
+	BurstSize    int              // toasts per burst (1–10)
+	ReplayRecent bool             // replay recent toasts on reconnect
 }
 
-// ToastLabStats tracks aggregate counters.
+// ToastLabStats counts lifecycle outcomes for the toast simulator; values are cumulative until ResetStats.
 type ToastLabStats struct {
 	Published int64
 	Displayed int64
@@ -72,7 +72,7 @@ type ToastLabLogEntry struct {
 	Action    string
 }
 
-// ToastLab wraps the shared state for the toast lab demo.
+// ToastLab owns the simulator's settings, stats, and capped event/lifecycle logs (50 entries each).
 type ToastLab struct {
 	eventLog []ToastEvent
 	lifeLog  []ToastLabLogEntry
@@ -83,7 +83,7 @@ type ToastLab struct {
 	paused   bool
 }
 
-// NewToastLab creates a lab with default settings.
+// NewToastLab opens with the balanced severity mix, 2s ticks, and a stack cap of 8.
 func NewToastLab() *ToastLab {
 	return &ToastLab{
 		settings: ToastLabSettings{
@@ -97,7 +97,7 @@ func NewToastLab() *ToastLab {
 	}
 }
 
-// Settings returns a snapshot of current settings.
+// Settings is a value snapshot under read lock.
 func (l *ToastLab) Settings() ToastLabSettings {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -111,49 +111,49 @@ func (l *ToastLab) UpdateSettings(fn func(s *ToastLabSettings)) {
 	fn(&l.settings)
 }
 
-// Stats returns a snapshot of counters.
+// Stats is a value snapshot of cumulative counters under read lock.
 func (l *ToastLab) Stats() ToastLabStats {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	return l.stats
 }
 
-// IncrDisplayed increments the displayed counter.
+// IncrDisplayed bumps the displayed-toast counter (called from the client lifecycle callback).
 func (l *ToastLab) IncrDisplayed() {
 	l.mu.Lock()
 	l.stats.Displayed++
 	l.mu.Unlock()
 }
 
-// IncrDismissed increments the dismissed counter.
+// IncrDismissed bumps the dismissed-toast counter (manual or auto-dismiss).
 func (l *ToastLab) IncrDismissed() {
 	l.mu.Lock()
 	l.stats.Dismissed++
 	l.mu.Unlock()
 }
 
-// IncrDropped increments the dropped counter.
+// IncrDropped bumps the dropped-toast counter (stack-full evictions).
 func (l *ToastLab) IncrDropped() {
 	l.mu.Lock()
 	l.stats.Dropped++
 	l.mu.Unlock()
 }
 
-// IncrReplayed increments the replayed counter.
+// IncrReplayed bumps the replayed-toast counter (toasts re-emitted on reconnect).
 func (l *ToastLab) IncrReplayed() {
 	l.mu.Lock()
 	l.stats.Replayed++
 	l.mu.Unlock()
 }
 
-// Paused returns whether the simulator is paused.
+// Paused reports whether SimTick should be skipped this round.
 func (l *ToastLab) Paused() bool {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	return l.paused
 }
 
-// TogglePause flips pause state and returns the new value.
+// TogglePause flips the pause flag and returns the new value.
 func (l *ToastLab) TogglePause() bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -281,7 +281,7 @@ func (l *ToastLab) RecordLifecycle(action string) {
 	}
 }
 
-// LifecycleLog returns the recent lifecycle log.
+// LifecycleLog is a defensive copy of the rolling 50-entry lifecycle log.
 func (l *ToastLab) LifecycleLog() []ToastLabLogEntry {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -290,7 +290,7 @@ func (l *ToastLab) LifecycleLog() []ToastLabLogEntry {
 	return out
 }
 
-// EventLog returns the recent event log.
+// EventLog is a defensive copy of the rolling 50-entry simulated-toast log.
 func (l *ToastLab) EventLog() []ToastEvent {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
@@ -299,7 +299,7 @@ func (l *ToastLab) EventLog() []ToastEvent {
 	return out
 }
 
-// ResetStats zeroes all counters.
+// ResetStats zeroes every counter without clearing the event or lifecycle logs.
 func (l *ToastLab) ResetStats() {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/demo/vendor_contact.go
+++ b/internal/demo/vendor_contact.go
@@ -9,14 +9,14 @@ import (
 	"strings"
 )
 
-// Vendor represents a vendor in the demo dataset.
+// Vendor is one row of the vendors table; Category must be one of VendorCategories.
 type Vendor struct {
 	Name     string
 	Category string
 	ID       int
 }
 
-// Contact represents a vendor contact in the demo dataset.
+// Contact is one contact for a Vendor; VendorID is a foreign key into vendors.
 type Contact struct {
 	Name     string
 	Email    string
@@ -26,7 +26,7 @@ type Contact struct {
 	VendorID int
 }
 
-// ListVendors returns vendors matching the optional search and category filters.
+// ListVendors filters by optional name search and category; ordered by name.
 func (d *DB) ListVendors(ctx context.Context, search, category string) ([]Vendor, error) {
 	var conds []string
 	var args []any
@@ -58,14 +58,14 @@ func (d *DB) ListVendors(ctx context.Context, search, category string) ([]Vendor
 	return vendors, rows.Err()
 }
 
-// GetVendor returns a single vendor by ID.
+// GetVendor passes sql.ErrNoRows through unwrapped on missing rows.
 func (d *DB) GetVendor(ctx context.Context, id int) (Vendor, error) {
 	var v Vendor
 	err := d.db.QueryRowContext(ctx, "SELECT id,name,category FROM vendors WHERE id = @ID", sql.Named("ID", id)).Scan(&v.ID, &v.Name, &v.Category)
 	return v, err
 }
 
-// ListContacts returns all contacts for a vendor.
+// ListContacts pulls all contacts for vendorID, ordered by name.
 func (d *DB) ListContacts(ctx context.Context, vendorID int) ([]Contact, error) {
 	rows, err := d.db.QueryContext(ctx, "SELECT id,vendor_id,name,email,phone,role FROM contacts WHERE vendor_id = @VendorID ORDER BY name", sql.Named("VendorID", vendorID))
 	if err != nil {
@@ -83,14 +83,14 @@ func (d *DB) ListContacts(ctx context.Context, vendorID int) ([]Contact, error) 
 	return contacts, rows.Err()
 }
 
-// GetContact returns a single contact by ID.
+// GetContact passes sql.ErrNoRows through unwrapped on missing rows.
 func (d *DB) GetContact(ctx context.Context, id int) (Contact, error) {
 	var c Contact
 	err := d.db.QueryRowContext(ctx, "SELECT id,vendor_id,name,email,phone,role FROM contacts WHERE id = @ID", sql.Named("ID", id)).Scan(&c.ID, &c.VendorID, &c.Name, &c.Email, &c.Phone, &c.Role)
 	return c, err
 }
 
-// UpdateContact updates a contact row.
+// UpdateContact writes c's editable fields; VendorID is not modified and missing IDs return an error.
 func (d *DB) UpdateContact(ctx context.Context, c Contact) error {
 	res, err := d.db.ExecContext(ctx, "UPDATE contacts SET name=@Name, email=@Email, phone=@Phone, role=@Role WHERE id=@ID",
 		sql.Named("Name", c.Name), sql.Named("Email", c.Email), sql.Named("Phone", c.Phone), sql.Named("Role", c.Role), sql.Named("ID", c.ID))
@@ -107,7 +107,7 @@ func (d *DB) UpdateContact(ctx context.Context, c Contact) error {
 	return nil
 }
 
-// VendorCategories for filter dropdowns.
+// VendorCategories enumerates the seeded category values used by the vendor filter dropdown.
 var VendorCategories = []string{
 	"General", "Technology", "Agriculture", "Manufacturing",
 	"Consulting", "Research", "Security", "Food & Beverage",

--- a/internal/domain/graph_user.go
+++ b/internal/domain/graph_user.go
@@ -2,7 +2,7 @@
 
 package domain
 
-// GraphUser represents a user from Microsoft Graph API
+// GraphUser mirrors the Microsoft Graph /users payload with extra db tags for local persistence.
 type GraphUser struct {
 	AzureID           string `json:"id" db:"AzureId"`
 	GivenName         string `json:"givenName" db:"GivenName"`

--- a/internal/domain/traits.go
+++ b/internal/domain/traits.go
@@ -7,50 +7,51 @@ import (
 	"time"
 )
 
-// Timestamps provides CreatedAt and UpdatedAt fields for embedding in domain models.
+// Timestamps embeds the standard CreatedAt/UpdatedAt audit timestamps.
 type Timestamps struct {
 	CreatedAt time.Time `db:"CreatedAt" json:"createdAt"`
 	UpdatedAt time.Time `db:"UpdatedAt" json:"updatedAt"`
 }
 
-// SoftDelete provides a nullable DeletedAt field for embedding in domain models.
+// SoftDelete embeds a nullable DeletedAt; non-zero means the row is hidden
+// from default queries but recoverable.
 type SoftDelete struct {
 	DeletedAt sql.NullTime `db:"DeletedAt" json:"deletedAt,omitzero"`
 }
 
-// Version provides an optimistic concurrency control field for embedding in domain models.
+// Version embeds an int incremented on every write for optimistic-concurrency checks.
 type Version struct {
 	Version int `db:"Version" json:"version"`
 }
 
-// SortOrder provides a manual ordering field for embedding in domain models.
+// SortOrder embeds a manual ordering integer; lower values render first.
 type SortOrder struct {
 	SortOrder int `db:"SortOrder" json:"sortOrder"`
 }
 
-// Status provides a status field for embedding in domain models.
+// Status embeds a short string state machine column.
 type Status struct {
 	Status string `db:"Status" json:"status"`
 }
 
-// Notes provides a nullable notes field for embedding in domain models.
+// Notes embeds a nullable free-form text field.
 type Notes struct {
 	Notes sql.NullString `db:"Notes" json:"notes,omitzero"`
 }
 
-// Archive provides a nullable ArchivedAt timestamp for embedding in domain models.
-// Semantically softer than SoftDelete — archived records are hidden from default views
-// but remain accessible and restorable.
+// Archive is semantically softer than SoftDelete — archived records are hidden
+// from default views but remain accessible and restorable.
 type Archive struct {
 	ArchivedAt sql.NullTime `db:"ArchivedAt" json:"archivedAt,omitzero"`
 }
 
-// Replacement provides a nullable reference to the entity that replaced this one.
+// Replacement embeds an optional pointer to the row that supersedes this one,
+// preserving entity lineage when a record is logically replaced.
 type Replacement struct {
 	ReplacedByID sql.NullInt64 `db:"ReplacedByID" json:"replacedById,omitzero"`
 }
 
-// ToNullString converts a string to sql.NullString. Empty strings are treated as null.
+// ToNullString treats an empty string as NULL.
 func ToNullString(s string) sql.NullString {
 	if s == "" {
 		return sql.NullString{}

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -7,7 +7,8 @@ import (
 	"time"
 )
 
-// User represents a user in the system, storing Azure user information
+// User is the persisted row for an Azure-cached user; nullable Graph
+// attributes use sql.Null* so JSON omitzero suppresses unset values.
 type User struct {
 	UpdatedAt         time.Time      `db:"UpdatedAt" json:"updatedAt"`
 	CreatedAt         time.Time      `db:"CreatedAt" json:"createdAt"`
@@ -26,7 +27,7 @@ type User struct {
 	ID                int            `db:"ID" json:"id"`
 }
 
-// FromGraphUser creates a User from a GraphUser
+// FromGraphUser copies fields from graphUser into u, wrapping strings as NullString.
 func (u *User) FromGraphUser(graphUser *GraphUser) {
 	u.AzureID = graphUser.AzureID
 	u.UserPrincipalName = graphUser.UserPrincipalName

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -15,10 +15,8 @@ var envFlag = flag.String("env", "development", "application environment (reads 
 
 var mode string
 
-// Init loads environment variables from the .env.{mode} file. The mode is
-// determined by: the env parameter if non-empty, otherwise the -env flag
-// (default "development"). Returns an error if the env file is missing;
-// callers may choose to continue with OS environment variables.
+// Init resolves the mode from env (or the -env flag, default "development") and loads
+// .env.{mode} via godotenv; a missing file errors, but callers may proceed with the OS env.
 func Init(env string) error {
 	if env == "" {
 		env = *envFlag
@@ -31,7 +29,7 @@ func Init(env string) error {
 	return nil
 }
 
-// Get returns the value of the environment variable or an error if not set.
+// Get errors when key is unset; use GetDefault for optional values.
 func Get(key string) (string, error) {
 	v := os.Getenv(key)
 	if v == "" {
@@ -40,7 +38,7 @@ func Get(key string) (string, error) {
 	return v, nil
 }
 
-// GetDefault returns the value of the environment variable or fallback if not set.
+// GetDefault treats an unset key as fallback; never returns an error.
 func GetDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
@@ -51,7 +49,7 @@ func GetDefault(key, fallback string) string {
 // Dev reports whether the current mode is "development".
 func Dev() bool { return mode == "development" }
 
-// Name returns the current environment mode.
+// Name is the canonical mode string ("development", "production", …) after normalisation.
 func Name() string { return mode }
 
 func normalize(s string) string {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -18,8 +18,7 @@ type Response struct {
 	Database string `json:"database,omitempty"`
 }
 
-// StatsFunc returns app-specific metrics for the health response.
-// Derived apps implement this to add their own stats (counts, queue depths, etc.).
+// StatsFunc is the app-specific stats hook embedded in the health payload's "stats" field.
 type StatsFunc func(ctx context.Context) any
 
 // Pinger is satisfied by *sql.DB and *sqlx.DB.
@@ -36,8 +35,8 @@ type Config struct {
 	Version   string
 }
 
-// Check builds a health response by pinging the database (if configured)
-// and collecting app-specific stats.
+// Check pings cfg.DB (if any) and downgrades status to "degraded" on ping failure;
+// cfg.Stats output is folded into the response when non-nil.
 func Check(ctx context.Context, cfg Config) Response {
 	h := Response{
 		Name:    cfg.Name,
@@ -64,7 +63,7 @@ func Check(ctx context.Context, cfg Config) Response {
 	return h
 }
 
-// NewPingerFromDB wraps a *sql.DB as a Pinger.
+// NewPingerFromDB adapts a *sql.DB to the Pinger interface via its PingContext.
 func NewPingerFromDB(db *sql.DB) Pinger {
 	return db
 }

--- a/internal/health/stats.go
+++ b/internal/health/stats.go
@@ -7,7 +7,8 @@ import (
 	"time"
 )
 
-// SystemStats holds a point-in-time snapshot of Go runtime metrics.
+// SystemStats is the runtime snapshot reported by /health for the demo
+// dashboards; memory figures are in megabytes, Uptime is a duration string.
 type SystemStats struct {
 	Timestamp       string
 	GoVersion       string

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -29,8 +29,8 @@ var (
 	handlerWrapper HandlerWrapper
 )
 
-// SetHandlerWrapper registers a function that will wrap the slog.Handler
-// during Init. Must be called before Init (or Get).
+// SetHandlerWrapper installs a wrapper applied to the slog.Handler during Init;
+// must be called before Init (or Get).
 func SetHandlerWrapper(w HandlerWrapper) {
 	mu.Lock()
 	defer mu.Unlock()
@@ -39,19 +39,16 @@ func SetHandlerWrapper(w HandlerWrapper) {
 
 const appLogFile = "dothog.log"
 
-// Init initializes the global logger with appropriate configuration
+// Init wires a JSON slog logger to log/dothog.log (monthly lumberjack rotation) plus stdout/stderr; idempotent via sync.Once.
 func Init() {
 	once.Do(func() {
-		// Ensure log directory exists
 		logDir := "log"
 		if err := os.MkdirAll(logDir, 0o755); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to create log directory: %v\n", err)
 		}
 
-		// Get log level from environment or use default
 		logLevel := getLogLevel()
 
-		// Create lumberjack rotator for log file with rotation
 		logPath := filepath.Join(logDir, appLogFile)
 		rotator := &lumberjack.Logger{
 			Filename:   logPath,
@@ -61,7 +58,6 @@ func Init() {
 			Compress:   true, // Compress rotated files
 		}
 
-		// Create multi-writer for both file and console output
 		var logWriter io.Writer
 		if env.Dev() {
 			logWriter = io.MultiWriter(os.Stdout, rotator)
@@ -69,7 +65,6 @@ func Init() {
 			logWriter = io.MultiWriter(os.Stderr, rotator)
 		}
 
-		// Create handler with multi-writer
 		opts := &slog.HandlerOptions{
 			Level:     logLevel,
 			AddSource: env.Dev(),
@@ -86,7 +81,7 @@ func Init() {
 	})
 }
 
-// getLogLevel returns the log level based on environment variable
+// getLogLevel reads LOG_LEVEL; falls back to Debug in dev and Info otherwise.
 func getLogLevel() slog.Level {
 	levelStr, err := env.Get("LOG_LEVEL")
 	if err != nil {
@@ -106,7 +101,6 @@ func getLogLevel() slog.Level {
 	case "ERROR":
 		return slog.LevelError
 	default:
-		// Log invalid level and use default
 		if env.Dev() {
 			return slog.LevelDebug
 		}
@@ -114,7 +108,7 @@ func getLogLevel() slog.Level {
 	}
 }
 
-// Get returns the global logger instance
+// Get is the global logger, triggering Init on first use.
 func Get() *slog.Logger {
 	mu.RLock()
 	if logger != nil {
@@ -130,52 +124,48 @@ func Get() *slog.Logger {
 	return logger
 }
 
-// Debug logs a debug message
+// Debug logs at Debug level on the package logger.
 func Debug(msg string, args ...any) {
 	Get().Debug(msg, args...)
 }
 
-// Info logs an info message
+// Info logs at Info level on the package logger.
 func Info(msg string, args ...any) {
 	Get().Info(msg, args...)
 }
 
-// Warn logs a warning message
+// Warn logs at Warn level on the package logger.
 func Warn(msg string, args ...any) {
 	Get().Warn(msg, args...)
 }
 
-// Error logs an error message
+// Error logs at Error level on the package logger.
 func Error(msg string, args ...any) {
 	Get().Error(msg, args...)
 }
 
-// Fatal logs a fatal message and exits the application
+// Fatal logs at Error level and then calls os.Exit(1).
 func Fatal(msg string, args ...any) {
 	Get().Error(msg, args...)
 	os.Exit(1)
 }
 
-// WithContext returns a logger with context values
+// WithContext attaches request_id, context_id, and context_description from ctx when present.
 func WithContext(ctx context.Context) *slog.Logger {
 	if ctx == nil {
 		return Get()
 	}
 
-	// Extract common context values
 	args := make([]any, 0)
 
-	// Add request ID if available
 	if requestID := ctx.Value(promolog.RequestIDKey); requestID != nil {
 		args = append(args, "request_id", requestID)
 	}
 
-	// Add context ID if available
 	if contextID := ctx.Value(shared.ContextIDKeyValue); contextID != nil {
 		args = append(args, "context_id", contextID)
 	}
 
-	// Add context description if available
 	if contextDescription := ctx.Value(shared.ContextDescriptionKeyValue); contextDescription != nil {
 		args = append(args, "context_description", contextDescription)
 	}
@@ -187,41 +177,40 @@ func WithContext(ctx context.Context) *slog.Logger {
 	return Get()
 }
 
-// With returns a logger with the given attributes
+// With derives a logger carrying args as default attributes.
 func With(args ...any) *slog.Logger {
 	return Get().With(args...)
 }
 
-// WithGroup returns a logger with the given group
+// WithGroup nests all subsequent attributes under a group of the given name.
 func WithGroup(name string) *slog.Logger {
 	return Get().WithGroup(name)
 }
 
-// LogAndReturnError logs an error and returns a formatted error
-// This is useful for functions that need to log errors and return them
+// LogAndReturnError logs at Error and returns fmt.Errorf("%s: %w", message, err).
 func LogAndReturnError(message string, err error) error {
 	Get().Error(message, "error", err)
 	return fmt.Errorf("%s: %w", message, err)
 }
 
-// LogAndReturnErrorf logs an error and returns a formatted error with additional context
+// LogAndReturnErrorf is LogAndReturnError with Printf-style formatting of message.
 func LogAndReturnErrorf(message string, err error, args ...any) error {
 	Get().Error(fmt.Sprintf(message, args...), "error", err)
 	return fmt.Errorf("%s: %w", fmt.Sprintf(message, args...), err)
 }
 
-// LogError logs an error without returning it
-// This is useful for functions that handle errors internally
+// LogError records err at Error level with message; use when the caller does
+// not want to wrap and rethrow.
 func LogError(message string, err error) {
 	Get().Error(message, "error", err)
 }
 
-// LogErrorf logs an error with formatted message without returning it
+// LogErrorf is LogError with Printf-style formatting of message.
 func LogErrorf(message string, err error, args ...any) {
 	Get().Error(fmt.Sprintf(message, args...), "error", err)
 }
 
-// LogErrorWithFields logs an error with additional structured fields
+// LogErrorWithFields logs at Error and flattens fields into key/value attribute pairs.
 func LogErrorWithFields(message string, err error, fields map[string]any) {
 	args := make([]any, 0, len(fields)*2+2)
 	args = append(args, "error", err)

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -10,7 +10,8 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// UserRepository defines operations for user data access
+// UserRepository is the persistence contract for the Users table; every
+// method accepts a *sqlx.Tx and may be nil to run on the underlying DB.
 type UserRepository interface {
 	CreateOrUpdate(ctx context.Context, user *domain.User, tx *sqlx.Tx) error
 	GetByID(ctx context.Context, id int) (*domain.User, error)

--- a/internal/repository/session_settings_repository.go
+++ b/internal/repository/session_settings_repository.go
@@ -15,14 +15,15 @@ import (
 	"catgoose/dothog/internal/session"
 )
 
-// SessionSettingsRepository provides session settings data access.
+// SessionSettingsRepository persists session.Settings rows; it satisfies
+// both session.SettingsProvider and routes.SessionSettingsStore via
+// implicit interface satisfaction.
 type SessionSettingsRepository struct {
 	repo *dbrepoManager.RepoManager
 }
 
-// NewSessionSettingsRepository creates a new session settings repository.
-// The returned value satisfies both session.SettingsProvider and
-// routes.SessionSettingsStore via Go's implicit interface satisfaction.
+// NewSessionSettingsRepository binds repo; the result satisfies session.SettingsProvider
+// and routes.SessionSettingsStore via implicit interface satisfaction.
 func NewSessionSettingsRepository(repo *dbrepoManager.RepoManager) *SessionSettingsRepository {
 	return &SessionSettingsRepository{repo: repo}
 }
@@ -34,7 +35,7 @@ var selectCols = dbrepo.Columns("Id", "SessionUUID", "Theme", "Layout", "Updated
 
 var tableName = schema.SessionSettingsTable.Name
 
-// GetByUUID returns settings for the given session UUID, or nil if not found.
+// GetByUUID maps sql.ErrNoRows to (nil, nil); other errors are wrapped.
 func (r *SessionSettingsRepository) GetByUUID(ctx context.Context, uuid string) (*session.Settings, error) {
 	w := dbrepo.NewWhere().And("SessionUUID = @SessionUUID", sql.Named("SessionUUID", uuid))
 	query, args := dbrepo.NewSelect(tableName, selectCols).Where(w).Build()
@@ -50,7 +51,7 @@ func (r *SessionSettingsRepository) GetByUUID(ctx context.Context, uuid string) 
 	return &s, nil
 }
 
-// Upsert inserts or updates session settings by SessionUUID.
+// Upsert keys on SessionUUID; UpdatedAt is bumped on every call.
 func (r *SessionSettingsRepository) Upsert(ctx context.Context, s *session.Settings) error {
 	existing, err := r.GetByUUID(ctx, s.SessionUUID)
 	if err != nil {
@@ -91,7 +92,7 @@ func (r *SessionSettingsRepository) Upsert(ctx context.Context, s *session.Setti
 	return nil
 }
 
-// Touch updates UpdatedAt for the given session UUID.
+// Touch bumps UpdatedAt only; other fields are untouched. No-op if uuid is unknown.
 func (r *SessionSettingsRepository) Touch(ctx context.Context, uuid string) error {
 	query := fmt.Sprintf("UPDATE %s SET %s WHERE SessionUUID = @SessionUUID",
 		tableName,
@@ -108,7 +109,7 @@ func (r *SessionSettingsRepository) Touch(ctx context.Context, uuid string) erro
 	return nil
 }
 
-// ListAll returns all session settings rows ordered by most recently updated.
+// ListAll enumerates every row, ordered by UpdatedAt DESC.
 func (r *SessionSettingsRepository) ListAll(ctx context.Context) ([]session.Settings, error) {
 	query, args := dbrepo.NewSelect(tableName, selectCols).OrderBy("UpdatedAt DESC").Build()
 	var rows []session.Settings
@@ -118,4 +119,3 @@ func (r *SessionSettingsRepository) ListAll(ctx context.Context) ([]session.Sett
 	}
 	return rows, nil
 }
-

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -16,20 +16,19 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// ErrUserNotFound is returned when a user cannot be found.
+// ErrUserNotFound is returned when an Update/UpdateLastLogin affects zero rows.
 var ErrUserNotFound = fmt.Errorf("user not found")
 
-// userRepository implements UserRepository
 type userRepository struct {
 	repo *repository.RepoManager
 }
 
-// NewUserRepository creates a new UserRepository instance
+// NewUserRepository binds repo and hides the concrete type so callers depend on UserRepository.
 func NewUserRepository(repo *repository.RepoManager) UserRepository {
 	return &userRepository{repo: repo}
 }
 
-// CreateOrUpdate creates a new user or updates an existing one based on AzureID
+// CreateOrUpdate upserts user keyed by AzureID, stamping LastLoginAt to now.
 func (r *userRepository) CreateOrUpdate(ctx context.Context, user *domain.User, tx *sqlx.Tx) error {
 	existing, err := r.getByAzureIDInternal(ctx, user.AzureID, tx)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -80,7 +79,6 @@ func (r *userRepository) CreateOrUpdate(ctx context.Context, user *domain.User, 
 	return nil
 }
 
-// GetByID retrieves a user by its ID
 func (r *userRepository) GetByID(ctx context.Context, id int) (*domain.User, error) {
 	cols := dbrepo.Columns(schema.UsersTable.SelectColumns()...)
 	w := dbrepo.NewWhere().And("ID = @ID", sql.Named("ID", id))
@@ -97,7 +95,7 @@ func (r *userRepository) GetByID(ctx context.Context, id int) (*domain.User, err
 	return &user, nil
 }
 
-// getByAzureIDInternal retrieves a user by their Azure ID (internal method that returns sql.ErrNoRows)
+// getByAzureIDInternal surfaces sql.ErrNoRows so callers can distinguish "missing" from other errors.
 func (r *userRepository) getByAzureIDInternal(ctx context.Context, azureID string, tx *sqlx.Tx) (*domain.User, error) {
 	cols := dbrepo.Columns(schema.UsersTable.SelectColumns()...)
 	w := dbrepo.NewWhere().And("AzureId = @AzureId", sql.Named("AzureId", azureID))
@@ -111,7 +109,6 @@ func (r *userRepository) getByAzureIDInternal(ctx context.Context, azureID strin
 	return &user, nil
 }
 
-// GetByAzureID retrieves a user by their Azure ID
 func (r *userRepository) GetByAzureID(ctx context.Context, azureID string) (*domain.User, error) {
 	user, err := r.getByAzureIDInternal(ctx, azureID, nil)
 	if err != nil {
@@ -123,7 +120,7 @@ func (r *userRepository) GetByAzureID(ctx context.Context, azureID string) (*dom
 	return user, nil
 }
 
-// Update updates an existing user
+// Update yields ErrUserNotFound when no row matches user.ID.
 func (r *userRepository) Update(ctx context.Context, user *domain.User, tx *sqlx.Tx) error {
 	exec := r.repo.Exec(tx)
 
@@ -167,7 +164,7 @@ func (r *userRepository) Update(ctx context.Context, user *domain.User, tx *sqlx
 	return nil
 }
 
-// UpdateLastLogin updates only the LastLoginAt timestamp for a user
+// UpdateLastLogin yields ErrUserNotFound when no row matches id.
 func (r *userRepository) UpdateLastLogin(ctx context.Context, id int, tx *sqlx.Tx) error {
 	exec := r.repo.Exec(tx)
 

--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -1,4 +1,3 @@
-// Package handler provides HTTP request handlers and utility functions for rendering components.
 package handler
 
 import (
@@ -25,15 +24,13 @@ import (
 
 const pageLabel = "pageLabel"
 
-// SetPageLabel sets a human-readable label for the current page, used as the
-// terminal breadcrumb. Call before RenderBaseLayout.
+// SetPageLabel overrides the terminal breadcrumb for this request; call before RenderBaseLayout.
 func SetPageLabel(c echo.Context, label string) {
 	c.Set(pageLabel, label)
 }
 
-// LayoutFunc renders a page component into a full HTML page.
-// The default layout uses the dothog Index template with nav, breadcrumbs, and theme.
-// Derived apps can override this via SetLayout to use their own page wrapper.
+// LayoutFunc wraps a page component in the full HTML chrome (nav, breadcrumbs, theme);
+// derived apps swap their own implementation via SetLayout.
 type LayoutFunc func(c echo.Context, cmp templ.Component) error
 
 var customLayout LayoutFunc
@@ -44,8 +41,8 @@ func SetLayout(fn LayoutFunc) {
 	customLayout = fn
 }
 
-// RenderBaseLayout wraps the component in a page layout and renders it.
-// If a custom layout was set via SetLayout, it is used instead of the default.
+// RenderBaseLayout delegates to the custom LayoutFunc set via SetLayout,
+// falling back to the dothog AppNavLayout.
 func RenderBaseLayout(c echo.Context, cmp templ.Component) error {
 	if customLayout != nil {
 		return customLayout(c, cmp)
@@ -53,7 +50,6 @@ func RenderBaseLayout(c echo.Context, cmp templ.Component) error {
 	return renderDefaultLayout(c, cmp)
 }
 
-// layoutCtx holds common layout state extracted from the request context.
 type layoutCtx struct {
 	csrfToken string
 	theme     string
@@ -63,7 +59,6 @@ type layoutCtx struct {
 	hubs      []linkwell.HubEntry
 }
 
-// getLayoutCtx extracts CSRF token, theme, and breadcrumbs from the request.
 func getLayoutCtx(c echo.Context) layoutCtx {
 	var csrfToken string
 	// setup:feature:csrf:start
@@ -160,8 +155,8 @@ func renderDefaultLayout(c echo.Context, cmp templ.Component) error {
 	))
 }
 
-// AppNavLayoutFunc returns a LayoutFunc that uses the responsive app-nav layout.
-// The NavConfig defines navigation structure and optional custom slots.
+// AppNavLayoutFunc binds a NavConfig (with optional custom slots) and emits a LayoutFunc
+// targeting the responsive app-nav shell.
 func AppNavLayoutFunc(cfg linkwell.NavConfig) LayoutFunc {
 	return func(c echo.Context, cmp templ.Component) error {
 		path := c.Request().URL.Path
@@ -187,9 +182,8 @@ var (
 	appName   string
 )
 
-// InitRouteSet builds the set of GET-routable paths from the Echo router and
-// stores the app name for use in page titles. Call once after all routes are
-// registered, before the server starts.
+// InitRouteSet caches every GET path from e and the app name for page titles;
+// call once after route registration, before serving.
 func InitRouteSet(e *echo.Echo, name string) {
 	appName = name
 	getRoutes = make(map[string]bool)
@@ -241,7 +235,8 @@ func buildPathCrumbs(path, from string, routes map[string]bool) []linkwell.Bread
 	return crumbs
 }
 
-// RenderComponent renders a templ component to the response
+// RenderComponent writes cmp directly to the response and converts any
+// templ render error into a 500 hypermedia response via HandleError.
 func RenderComponent(c echo.Context, cmp templ.Component) error {
 	if err := cmp.Render(c.Request().Context(), c.Response()); err != nil {
 		return HandleError(c, http.StatusInternalServerError, "Failed to render component", err)
@@ -287,15 +282,9 @@ func HandleHypermediaError(c echo.Context, statusCode int, message string, err e
 	return linkwell.NewHTTPError(ec)
 }
 
-// HandleNotFound renders a full-page 404 within the base layout for direct
-// navigation. HTMX requests return a hypermedia error with back/home/report
-// controls, rendered as an OOB banner by ErrorHandlerMiddleware.
-// Register with e.RouteNotFound.
-//
-// Both branches return a 404 error so Echo's HTTPErrorHandler runs and the
-// per-request log buffer is promoted into the error-trace store. The non-HTMX
-// branch renders the response first and relies on the handler's committed-
-// response short-circuit to avoid double-rendering.
+// HandleNotFound is the e.RouteNotFound target: full-page 404 for direct nav,
+// hypermedia error with back/home/report controls for HTMX. Both branches return a 404
+// so Echo's HTTPErrorHandler runs and the log buffer reaches the error-trace store.
 func HandleNotFound(c echo.Context) error {
 	if c.Request().Header.Get("HX-Request") == "true" {
 		return HandleHypermediaError(c, http.StatusNotFound, "Not Found", nil)
@@ -307,7 +296,8 @@ func HandleNotFound(c echo.Context) error {
 	return echo.NewHTTPError(http.StatusNotFound, "Not Found")
 }
 
-// HandleComponent is a handler that renders a templ component
+// HandleComponent adapts a templ.Component into an echo.HandlerFunc that
+// renders the component inside the active base layout.
 func HandleComponent(cmp templ.Component) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		return RenderBaseLayout(c, cmp)

--- a/internal/routes/middleware/error_handler.go
+++ b/internal/routes/middleware/error_handler.go
@@ -9,9 +9,9 @@ import (
 	// setup:feature:session_settings:start
 	"catgoose/dothog/internal/session"
 	// setup:feature:session_settings:end
-	"github.com/catgoose/promolog"
-	"github.com/catgoose/linkwell"
 	corecomponents "catgoose/dothog/web/components/core"
+	"github.com/catgoose/linkwell"
+	"github.com/catgoose/promolog"
 
 	"github.com/labstack/echo/v4"
 )
@@ -106,10 +106,9 @@ func handleErrorWithContext(c echo.Context, ec linkwell.ErrorContext) error {
 	return corecomponents.ErrorStatusFromContext(ec).Render(c.Request().Context(), c.Response())
 }
 
-// NewHTTPErrorHandler returns an echo.HTTPErrorHandler that renders errors as
-// hypermedia responses. Assign it to e.HTTPErrorHandler in place of the default.
-// When reqLogStore is non-nil, the per-request log buffer is promoted to the
-// shared store on error so it can be retrieved for issue reports.
+// NewHTTPErrorHandler is the e.HTTPErrorHandler replacement that renders errors as
+// hypermedia responses; non-nil reqLogStore promotes the per-request log buffer
+// to the shared store so issue reports can retrieve it.
 func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Context) {
 	return func(err error, c echo.Context) {
 		// Restore the raw response writer saved before the compression

--- a/internal/routes/middleware/errors.go
+++ b/internal/routes/middleware/errors.go
@@ -8,9 +8,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// Errors middleware package provides helper methods for returning HTTP respones
-// from echo contexts
-
 // errorOpts returns the default ErrorControlOpts for convenience error helpers.
 func errorOpts() linkwell.ErrorControlOpts {
 	return linkwell.ErrorControlOpts{HomeURL: "/", LoginURL: "/login"}
@@ -35,46 +32,38 @@ func newError(c echo.Context, statusCode int, message string) error {
 	return linkwell.NewHTTPError(ec)
 }
 
-// BadRequest returns a 400 Bad Request error
-// Use for invalid input, missing required parameters, or malformed requests
+// BadRequest is a 400 for invalid input, missing required parameters, or malformed requests.
 func BadRequest(c echo.Context, message string) error {
 	return newError(c, http.StatusBadRequest, message)
 }
 
-// Unauthorized returns a 401 Unauthorized error
-// Use when authentication is required but not provided or invalid
+// Unauthorized is a 401 when authentication is required but missing or invalid.
 func Unauthorized(c echo.Context, message string) error {
 	return newError(c, http.StatusUnauthorized, message)
 }
 
-// Forbidden returns a 403 Forbidden error
-// Use when authentication is valid but the user lacks permission for the resource
+// Forbidden is a 403 when authentication is valid but lacks permission for the resource.
 func Forbidden(c echo.Context, message string) error {
 	return newError(c, http.StatusForbidden, message)
 }
 
-// NotFound returns a 404 Not Found error
-// Use when the requested resource doesn't exist
+// NotFound is a 404 when the requested resource doesn't exist.
 func NotFound(c echo.Context, message string) error {
 	return newError(c, http.StatusNotFound, message)
 }
 
-// InternalServerError returns a 500 Internal Server Error
-// Use for unexpected server errors, database failures, or unhandled exceptions
+// InternalServerError is a 500 for unexpected server errors, database failures, or unhandled exceptions.
 func InternalServerError(c echo.Context, message string) error {
 	return newError(c, http.StatusInternalServerError, message)
 }
 
-// ServiceUnavailable returns a 503 Service Unavailable error
-// Use when the service is temporarily unavailable or overloaded
+// ServiceUnavailable is a 503 when the service is temporarily unavailable or overloaded.
 func ServiceUnavailable(c echo.Context, message string) error {
 	return newError(c, http.StatusServiceUnavailable, message)
 }
 
-// HypermediaError builds a linkwell.ErrorContext populated with request metadata
-// (route, requestID) from the echo context. Pass the result to linkwell.NewHTTPError
-// to return it from a handler, or render the error component directly alongside
-// a primary component via OOB swap.
+// HypermediaError stamps route and requestID from c into a linkwell.ErrorContext;
+// pass to linkwell.NewHTTPError for handler returns, or render alongside OOB swaps.
 func HypermediaError(c echo.Context, statusCode int, message string, err error, controls ...linkwell.Control) linkwell.ErrorContext {
 	return linkwell.ErrorContext{
 		StatusCode: statusCode,

--- a/internal/routes/middleware/links.go
+++ b/internal/routes/middleware/links.go
@@ -25,7 +25,8 @@ func LinkRelationsMiddleware() echo.MiddlewareFunc {
 	}
 }
 
-// GetLinkRelations retrieves link relations from the echo context.
+// GetLinkRelations reads the per-request rel list set by LinkRelationsMiddleware;
+// returns nil when the middleware is absent.
 func GetLinkRelations(c echo.Context) []linkwell.LinkRelation {
 	if v := c.Get("link_relations"); v != nil {
 		if links, ok := v.([]linkwell.LinkRelation); ok {

--- a/internal/routes/middleware/middleware.go
+++ b/internal/routes/middleware/middleware.go
@@ -1,2 +1,1 @@
-// Package middleware provides middleware for application
 package middleware

--- a/internal/routes/middleware/raw_writer.go
+++ b/internal/routes/middleware/raw_writer.go
@@ -6,9 +6,8 @@ import "github.com/labstack/echo/v4"
 // http.ResponseWriter before the compression middleware wraps it.
 const rawWriterKey = "raw_response_writer"
 
-// RawWriterMiddleware saves the original http.ResponseWriter in the echo
-// context so the error handler can bypass the httpcompression writer after
-// it has been finalized (closed). Register this middleware immediately
+// RawWriterMiddleware stashes the original http.ResponseWriter under rawWriterKey so the
+// error handler can bypass a finalised httpcompression writer; register immediately
 // before the compression middleware.
 func RawWriterMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {

--- a/internal/routes/params/params.go
+++ b/internal/routes/params/params.go
@@ -105,7 +105,7 @@ func ParseFilterParams(c echo.Context, defaultLimit, maxLimit int) FilterParams 
 	}
 }
 
-// ResolveYearWithDefault handles year parsing and default year selection logic
+// ResolveYearWithDefault falls back to availableYears[0] only when ?year was not supplied at all.
 func ResolveYearWithDefault(c echo.Context, year int, availableYears []int) int {
 	yearParamExists := c.Request().URL.Query().Has("year")
 	if year == 0 && !yearParamExists && len(availableYears) > 0 {
@@ -113,4 +113,3 @@ func ResolveYearWithDefault(c echo.Context, year int, availableYears []int) int 
 	}
 	return year
 }
-

--- a/internal/routes/report.go
+++ b/internal/routes/report.go
@@ -2,10 +2,8 @@ package routes
 
 import "github.com/catgoose/promolog"
 
-// IssueReporter handles "Report Issue" actions from the error banner.
-// Implementations decide what to do with the report — send an email, post to
-// a Teams channel, write to a ticket system, etc.
-// The consumer defines the interface; the implementation is plugged in at startup.
+// IssueReporter is the pluggable sink for "Report Issue" actions from the error banner:
+// implementations route to email, Teams, ticketing, etc.; the impl is plugged in at startup.
 type IssueReporter interface {
 	// Report is called when a user submits the Report Issue modal.
 	// requestID identifies the failing request. description is user-provided

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -1,4 +1,3 @@
-// Package routes provides routing configuration and Echo server initialization.
 package routes
 
 import (
@@ -41,7 +40,9 @@ import (
 	echoMiddleware "github.com/labstack/echo/v4/middleware"
 )
 
-// AppRoutes defines the interface for app routes
+// AppRoutes is the lifecycle interface for the app's HTTP routes: InitRoutes
+// wires every endpoint, Close releases broker resources, and the Set* hooks
+// inject runtime dependencies for /health.
 type AppRoutes interface {
 	InitRoutes() error
 	// Close shuts down the SSE broker and releases resources. Call during graceful shutdown.
@@ -73,7 +74,6 @@ type Repos struct {
 	// setup:feature:session_settings:end
 }
 
-// appRoutes implements AppRoutes
 type appRoutes struct {
 	repos     Repos
 	startTime time.Time
@@ -100,9 +100,8 @@ func (ar *appRoutes) Close() {
 	// setup:feature:sse:end
 }
 
-// NewAppRoutes initializes routes.
-// repos.ReqLogStore may be nil if request log capture is disabled.
-// repos.IssueReporter may be nil; a default no-op reporter is used.
+// NewAppRoutes wires the route table onto e; nil ReqLogStore disables request-log capture
+// and nil IssueReporter falls back to a no-op reporter.
 func NewAppRoutes(ctx context.Context, e *echo.Echo, repos Repos) AppRoutes {
 	if repos.IssueReporter == nil {
 		repos.IssueReporter = defaultReporter{}
@@ -312,7 +311,10 @@ func (ar *appRoutes) SetHealthStats(fn health.StatsFunc) {
 	ar.healthCfg.Stats = fn
 }
 
-// InitEcho initializes Echo with global configurations
+// InitEcho assembles the project middleware chain (preload-link, correlation, recovery,
+// server-timing, security headers, raw-writer + httpcompression, and feature-gated
+// auth / session / link-relations); call once at startup, nil reqLogStore disables
+// error-trace promotion.
 func InitEcho(ctx context.Context, staticFS fs.FS, cfg *config.AppConfig,
 	// setup:feature:session_settings:start
 	settingsRepo session.Provider,

--- a/internal/routes/routes_avatar.go
+++ b/internal/routes/routes_avatar.go
@@ -10,7 +10,8 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// RegisterAvatarRoutes adds the avatar photo endpoint to the Echo instance.
+// RegisterAvatarRoutes wires GET /api/avatar/:azureID; the handler is closed
+// over store so callers don't need to re-pass it per request.
 func RegisterAvatarRoutes(e *echo.Echo, store *graph.PhotoStore) {
 	e.GET("/api/avatar/:azureID", handleAvatar(store))
 }

--- a/internal/routes/routes_calendar.go
+++ b/internal/routes/routes_calendar.go
@@ -35,7 +35,6 @@ func (c *calendarRoutes) handlePage(ctx echo.Context) error {
 	return handler.RenderBaseLayout(ctx, views.CalendarPage(data))
 }
 
-// handleMonth returns just the month grid fragment for prev/next navigation.
 func (c *calendarRoutes) handleMonth(ctx echo.Context) error {
 	year, month := parseYearMonth(ctx.QueryParam("y"), ctx.QueryParam("m"))
 	day := parseDay(ctx.QueryParam("d"))
@@ -43,7 +42,6 @@ func (c *calendarRoutes) handleMonth(ctx echo.Context) error {
 	return handler.RenderComponent(ctx, views.CalendarMonthFragment(data))
 }
 
-// handleDay returns the day inspector panel for the selected day.
 func (c *calendarRoutes) handleDay(ctx echo.Context) error {
 	day := parseDay(ctx.QueryParam("d"))
 	if day.IsZero() {

--- a/internal/routes/routes_doc.go
+++ b/internal/routes/routes_doc.go
@@ -14,7 +14,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// Topic constants for the collaborative document demo.
 const (
 	topicDocContent   = "doc/content"
 	topicDocStats     = "doc/stats"

--- a/internal/routes/routes_error_traces.go
+++ b/internal/routes/routes_error_traces.go
@@ -202,7 +202,7 @@ func traceStripParams(u *url.URL, params ...string) string {
 
 // setup:feature:demo:start
 
-// SeedErrorTraces inserts 1000 demo error traces spread over the past 90 days.
+// SeedErrorTraces pre-loads 1000 demo error traces across the past 90 days; no-op if any traces exist.
 func SeedErrorTraces(store promolog.Storer) {
 	// Check if already seeded
 	ctx := context.Background()

--- a/internal/routes/routes_feed.go
+++ b/internal/routes/routes_feed.go
@@ -14,8 +14,8 @@ import (
 	"catgoose/dothog/internal/demo"
 	"catgoose/dothog/internal/routes/handler"
 	"catgoose/dothog/internal/shared"
-	"github.com/catgoose/tavern"
 	"catgoose/dothog/web/views"
+	"github.com/catgoose/tavern"
 
 	"github.com/labstack/echo/v4"
 )
@@ -74,8 +74,8 @@ func (f *feedRoutes) handleFeedMore(c echo.Context) error {
 	return handler.RenderComponent(c, views.FeedMoreItems(filtered, lastID, hasMore))
 }
 
-// BroadcastActivity publishes an activity event to the SSE feed.
-// Always write to the replay buffer so reconnecting clients receive missed events.
+// BroadcastActivity emits e on the activity-feed SSE topic and stamps a fresh event ID
+// into the replay buffer so reconnecting clients catch up.
 func BroadcastActivity(broker *tavern.SSEBroker, e demo.ActivityEvent) {
 	buf := statsBufPool.Get().(*bytes.Buffer)
 	buf.Reset()

--- a/internal/routes/routes_hal.go
+++ b/internal/routes/routes_hal.go
@@ -16,7 +16,7 @@ import (
 
 // ─── HAL types ───────────────────────────────────────────────────────────────
 
-// HALLink represents a single link in a HAL _links object.
+// HALLink is one entry inside a HAL `_links` object.
 type HALLink struct {
 	Href        string `json:"href"`
 	Title       string `json:"title,omitempty"`
@@ -25,7 +25,8 @@ type HALLink struct {
 	Templated   bool   `json:"templated,omitempty"`
 }
 
-// HALResource is a generic HAL+JSON resource with _links and _embedded.
+// HALResource is a HAL+JSON resource; Props are flattened into the top
+// level alongside `_links` and `_embedded` by MarshalJSON.
 type HALResource struct {
 	Links    map[string]any `json:"_links"`
 	Embedded map[string]any `json:"_embedded,omitempty"`
@@ -271,7 +272,6 @@ func handleHALExplore(c echo.Context) error {
 	return handler.RenderComponent(c, views.HALExploreFragment(string(raw), halResourceToView(res), url))
 }
 
-// resolveHALResource maps an internal URL path to a HAL resource.
 func resolveHALResource(url string) (HALResource, error) {
 	// Strip query params for routing
 	path := url
@@ -368,7 +368,6 @@ func parsePathID(path, prefix string) (int, error) {
 	return id, err
 }
 
-// halResourceToView converts a HALResource into the template view model.
 func halResourceToView(r HALResource) views.HALResourceView {
 	v := views.HALResourceView{
 		Props: make([]views.HALPropView, 0),

--- a/internal/routes/routes_hypermedia_components.go
+++ b/internal/routes/routes_hypermedia_components.go
@@ -14,7 +14,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// chatMsg is a single chat message.
 type chatMsg struct {
 	Author string
 	Text   string
@@ -22,7 +21,6 @@ type chatMsg struct {
 	ID     int
 }
 
-// timelineEvt is a single timeline event.
 type timelineEvt struct {
 	Title string
 	Desc  string

--- a/internal/routes/routes_hypermedia_components2.go
+++ b/internal/routes/routes_hypermedia_components2.go
@@ -16,7 +16,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// carouselSlide holds data for a single carousel slide.
 type carouselSlide struct {
 	Title string
 	Desc  string

--- a/internal/routes/routes_hypermedia_controls.go
+++ b/internal/routes/routes_hypermedia_controls.go
@@ -66,7 +66,6 @@ func (gs *controlsGalleryState) resetLocked() {
 	gs.cascadeDeleted = false
 }
 
-// initControlsGalleryRoutes registers the controls page and all its interactive endpoints.
 func (ar *appRoutes) initControlsGalleryRoutes() {
 	gs := newControlsGalleryState()
 	base := patternsBase + "/controls"

--- a/internal/routes/routes_sync.go
+++ b/internal/routes/routes_sync.go
@@ -70,11 +70,10 @@ func (ar *appRoutes) handleSync(c echo.Context) error {
 	})
 }
 
-// processSyncOperation handles a single queued operation.
-// It checks row versions against the database to detect conflicts:
+// processSyncOperation routes a single queued op through version-conflict detection:
 //   - Creates (no version) are accepted unconditionally
 //   - Unknown resource URLs are accepted without version check
-//   - Known resources are checked against the current database version
+//   - Known resources are validated against the current database version
 //   - Version match → applied; mismatch → conflict; row gone → rejected
 func (ar *appRoutes) processSyncOperation(c echo.Context, index int, op SyncOperation) SyncResult {
 	// Creates (no version) are accepted without version check

--- a/internal/routes/routes_tables.go
+++ b/internal/routes/routes_tables.go
@@ -117,7 +117,6 @@ func applyFilterFromCurrentURL(c echo.Context) {
 	}
 }
 
-// buildPageInfo constructs a PageInfo from common pagination parameters.
 func buildPageInfo(c echo.Context, page, perPage, total int, target string) linkwell.PageInfo {
 	pageBase := stripParams(c.Request().URL, "page")
 	return linkwell.PageInfo{

--- a/internal/routes/routes_tavern_calendar.go
+++ b/internal/routes/routes_tavern_calendar.go
@@ -53,7 +53,6 @@ func (ar *appRoutes) initTavernCalendarRoutes(broker *tavern.SSEBroker) {
 	broker.RunPublisher(ar.ctx, r.startSimulator)
 }
 
-// handlePage renders the full calendar lab page.
 func (r *tavernCalendarRoutes) handlePage(c echo.Context) error {
 	data := r.buildPageData()
 	return handler.RenderBaseLayout(c, views.TavernCalendarPage(data))
@@ -173,7 +172,6 @@ func (r *tavernCalendarRoutes) handleSelectDay(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-// handleSetMonth navigates to the prev/next month.
 func (r *tavernCalendarRoutes) handleSetMonth(c echo.Context) error {
 	dir := c.QueryParam("dir")
 	year, month := r.lab.Year(), r.lab.Month()

--- a/internal/routes/routes_tavern_subs.go
+++ b/internal/routes/routes_tavern_subs.go
@@ -21,13 +21,12 @@ import (
 
 const subsGroupCookie = "tavern_subs_group"
 
-// subsTopics contains all the topics used by the subscription lab.
 var subsTopics = struct {
-	scoped    string
-	data      []string
-	multi     []string
-	vip       []string
-	standard  []string
+	scoped   string
+	data     []string
+	multi    []string
+	vip      []string
+	standard []string
 }{
 	scoped: "tavern/subs/scoped",
 	data: []string{

--- a/internal/routes/sync_types.go
+++ b/internal/routes/sync_types.go
@@ -20,10 +20,11 @@ type SyncRequest struct {
 	SchemaVersion int             `json:"schema_version"`
 }
 
-// SyncResultStatus represents the outcome of a sync operation.
+// SyncResultStatus is the per-operation outcome the server returns in a
+// SyncResult; the string value is what the wire payload carries.
 type SyncResultStatus string
 
-// Sync result statuses.
+// SyncResult wire-format status values.
 const (
 	SyncApplied  SyncResultStatus = "applied"
 	SyncConflict SyncResultStatus = "conflict"

--- a/internal/routes/sync_version.go
+++ b/internal/routes/sync_version.go
@@ -24,19 +24,18 @@ type VersionChecker interface {
 	CurrentVersion(ctx context.Context, table string, id int) (int, error)
 }
 
-// SQLVersionChecker checks row versions against a SQL database.
-// It expects tables to have an ID column and a Version column (as created by
-// chuck's WithVersion() schema trait).
+// SQLVersionChecker reads the Version column from SQL tables that include the
+// WithVersion() schema trait (ID + Version columns required).
 type SQLVersionChecker struct {
 	db *sql.DB
 }
 
-// NewSQLVersionChecker creates a version checker backed by the given database.
+// NewSQLVersionChecker binds db and enforces the knownTables allowlist for every query.
 func NewSQLVersionChecker(db *sql.DB) *SQLVersionChecker {
 	return &SQLVersionChecker{db: db}
 }
 
-// CurrentVersion returns the current version of a row, or -1 if not found.
+// CurrentVersion is -1 when the row is missing or soft-deleted (DeletedAt set).
 func (vc *SQLVersionChecker) CurrentVersion(ctx context.Context, table string, id int) (int, error) {
 	if !knownTables[table] {
 		return 0, fmt.Errorf("unknown table: %s", table)

--- a/internal/service/graph/graph_client.go
+++ b/internal/service/graph/graph_client.go
@@ -17,12 +17,12 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 )
 
-// Client wraps the Microsoft Graph SDK client for app-only access.
+// Client is the Microsoft Graph SDK handle scoped for app-only (client-credentials) access.
 type Client struct {
 	client *msgraphsdk.GraphServiceClient
 }
 
-// NewGraphClient creates a Graph client using client credentials (tenant ID, client ID, client secret).
+// NewGraphClient authenticates via azidentity client-secret credentials scoped to https://graph.microsoft.com/.default.
 func NewGraphClient(tenantID, clientID, clientSecret string) (*Client, error) {
 	cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
 	if err != nil {
@@ -45,7 +45,7 @@ func consistencyLevelHeaders() *abstractions.RequestHeaders {
 	return h
 }
 
-// FetchAllEnabledUsers fetches all enabled users from Microsoft Graph with filter and select equivalent to the previous implementation.
+// FetchAllEnabledUsers pages through every accountEnabled=true user (top=999, eventual consistency) and returns a flattened slice.
 func (c *Client) FetchAllEnabledUsers() ([]domain.GraphUser, error) {
 	ctx := context.Background()
 	filter := "accountEnabled eq true"

--- a/internal/service/graph/photo_store.go
+++ b/internal/service/graph/photo_store.go
@@ -16,8 +16,7 @@ type PhotoStore struct {
 	dir string
 }
 
-// NewPhotoStore creates a PhotoStore rooted at dir, creating the directory
-// if it does not exist.
+// NewPhotoStore is rooted at dir, MkdirAll'd on construction.
 func NewPhotoStore(dir string) (*PhotoStore, error) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, fmt.Errorf("create photo dir: %w", err)
@@ -59,12 +58,12 @@ func (ps *PhotoStore) HasPhoto(azureID string) bool {
 	return err == nil
 }
 
-// Open returns a ReadCloser for the cached photo. The caller must close it.
+// Open hands back the cached photo; the caller must Close it.
 func (ps *PhotoStore) Open(azureID string) (io.ReadCloser, error) {
 	return os.Open(ps.PhotoPath(azureID))
 }
 
-// PhotoPath returns the filesystem path for a given Azure ID's photo.
+// PhotoPath is dir/AB/azureID.jpg, where AB is the first two characters of azureID.
 func (ps *PhotoStore) PhotoPath(azureID string) string {
 	prefix := azureID
 	if len(prefix) > 2 {

--- a/internal/service/graph/sync.go
+++ b/internal/service/graph/sync.go
@@ -14,10 +14,11 @@ import (
 	"catgoose/dothog/internal/env"
 )
 
-// SyncType represents the type of sync operation being performed
+// SyncType labels a user-cache refresh for telemetry; the constant value
+// is the human-readable phrase logged alongside each sync.
 type SyncType string
 
-// Sync type constants
+// Sync trigger labels written into logs and admin telemetry.
 const (
 	SyncTypeInitial   SyncType = "initial sync"
 	SyncTypeManual    SyncType = "manual sync"
@@ -25,9 +26,8 @@ const (
 	SyncTypePeriodic  SyncType = "periodic sync"
 )
 
-// InitAndSyncUserCache initializes and (in prod) periodically syncs the Azure user cache.
-// In development mode, it only fetches users if the cache is empty.
-// In production mode, it performs an initial sync and then schedules periodic refreshes.
+// InitAndSyncUserCache primes the Azure user cache; dev fetches only when empty,
+// prod performs an initial sync then schedules a daily refresh at refreshHour.
 func InitAndSyncUserCache(
 	ctx context.Context,
 	userCache *UserCache,
@@ -39,17 +39,14 @@ func InitAndSyncUserCache(
 	log := logger.WithContext(ctx)
 	isDev := env.Dev()
 
-	// Development
 	if isDev {
-		// In development mode, only fetch if the table doesn't exist or is empty
-		// This prevents spamming Azure on every dev restart
+		// In dev, only fetch when the cache is missing or empty to avoid hammering Azure on every restart.
 		exists, err := userCache.UsersTableExists()
 		if err != nil {
 			log.Warn("Users table check failed, will fetch users from Azure", "error", err)
 		} else if !exists {
 			log.Info("Users table does not exist, fetching users from Azure")
 		} else {
-			// Check if table has data
 			userCount, err := userCache.GetUserCount()
 			if err != nil {
 				log.Warn("Failed to get user count, will fetch users from Azure", "error", err)
@@ -77,7 +74,6 @@ func InitAndSyncUserCache(
 		return nil
 	}
 
-	// Production - perform initial sync
 	log.Info("Production mode: performing initial user sync")
 	users, err := fetchUsersFunc()
 	if err != nil {
@@ -92,7 +88,6 @@ func InitAndSyncUserCache(
 		afterSync(ctx, users)
 	}
 
-	// Schedule periodic refreshes
 	doSync := func(syncType SyncType) {
 		syncCtx := shared.WithContextIDAndDescription(ctx, shared.GenerateContextID(), string(syncType))
 		syncLog := logger.WithContext(syncCtx)

--- a/internal/service/graph/user_cache.go
+++ b/internal/service/graph/user_cache.go
@@ -15,21 +15,21 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// UserCache represents the in-memory SQLite database for caching Graph users
+// UserCache is the SQLite-backed cache of Graph users (Users table).
 type UserCache struct {
 	DB *sqlx.DB
 }
 
-// NewUserCache initializes the UserCache with an existing SQLite database connection
+// NewUserCache binds db without verifying the Users table exists; call EnsureSchema or
+// UsersTableExists when that guarantee is needed.
 func NewUserCache(db *sqlx.DB) *UserCache {
 	return &UserCache{DB: db}
 }
 
-// InsertOrUpdateUsers inserts or updates users in the SQLite database using PascalCase column names
+// InsertOrUpdateUsers upserts each user in a single transaction, rolling back on the first row that fails.
 func (c *UserCache) InsertOrUpdateUsers(ctx context.Context, users []domain.GraphUser) error {
 	log := logger.WithContext(ctx)
 
-	// Ensure the Users table exists
 	if err := c.EnsureSchema(ctx); err != nil {
 		return fmt.Errorf("failed to ensure schema: %w", err)
 	}
@@ -89,7 +89,7 @@ const (
 	userSelect = "SELECT AzureId, GivenName, Surname, DisplayName, UserPrincipalName, Mail, JobTitle, OfficeLocation, Department, CompanyName, AccountName"
 )
 
-// SearchUsers finds users who match any of the given search terms
+// SearchUsers ANDs LIKE clauses across GivenName/Surname/DisplayName/AccountName for each term and returns up to limit rows ordered by DisplayName.
 func (c *UserCache) SearchUsers(terms []string, limit int) ([]domain.GraphUser, error) {
 	if len(terms) == 0 {
 		return nil, fmt.Errorf("no search terms provided")
@@ -122,7 +122,8 @@ func (c *UserCache) SearchUsers(terms []string, limit int) ([]domain.GraphUser, 
 	return users, nil
 }
 
-// GetAllUsers retrieves all users from the database
+// GetAllUsers dumps the entire Users table (DisplayName-sorted). Intended
+// for one-off admin views; large directories should prefer SearchUsers.
 func (c *UserCache) GetAllUsers() ([]domain.GraphUser, error) {
 	query := `
 		SELECT AzureId, GivenName, Surname, DisplayName, UserPrincipalName, Mail, JobTitle, OfficeLocation, Department, CompanyName, AccountName
@@ -137,7 +138,7 @@ func (c *UserCache) GetAllUsers() ([]domain.GraphUser, error) {
 	return users, nil
 }
 
-// GetUserByAzureID retrieves a user by their Azure ID
+// GetUserByAzureID wraps sql.ErrNoRows in a contextual error when the row is missing.
 func (c *UserCache) GetUserByAzureID(azureID string) (*domain.GraphUser, error) {
 	query := `
 		SELECT AzureId, GivenName, Surname, DisplayName, UserPrincipalName, Mail, JobTitle, OfficeLocation, Department, CompanyName, AccountName
@@ -152,7 +153,8 @@ func (c *UserCache) GetUserByAzureID(azureID string) (*domain.GraphUser, error) 
 	return &user, nil
 }
 
-// UsersTableExists checks if the Users table exists in the database
+// UsersTableExists probes sqlite_master directly so callers can decide whether
+// to call EnsureSchema before queries.
 func (c *UserCache) UsersTableExists() (bool, error) {
 	var count int
 	err := c.DB.Get(&count, "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='Users'")
@@ -162,7 +164,7 @@ func (c *UserCache) UsersTableExists() (bool, error) {
 	return count > 0, nil
 }
 
-// EnsureSchema ensures that the Users table exists in the database
+// EnsureSchema is idempotent: creates the Users table only when sqlite_master reports it missing.
 func (c *UserCache) EnsureSchema(ctx context.Context) error {
 	exists, err := c.UsersTableExists()
 	if err != nil {
@@ -200,7 +202,7 @@ func (c *UserCache) EnsureSchema(ctx context.Context) error {
 	return nil
 }
 
-// GetUserCount returns the number of users in the cache
+// GetUserCount is the row count of Users (cached and persisted).
 func (c *UserCache) GetUserCount() (int, error) {
 	var count int
 	err := c.DB.Get(&count, "SELECT COUNT(*) FROM Users")

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -30,7 +30,7 @@ type Settings struct {
 	ID          int               `db:"Id"`
 }
 
-// GetExtra returns the value for key, or empty string if not set.
+// GetExtra is "" when key is missing or Extra is nil.
 func (s *Settings) GetExtra(key string) string {
 	if s.Extra == nil {
 		return ""
@@ -38,7 +38,7 @@ func (s *Settings) GetExtra(key string) string {
 	return s.Extra[key]
 }
 
-// SetExtra sets a key-value pair in Extra, initializing the map if nil.
+// SetExtra lazily allocates Extra on first call.
 func (s *Settings) SetExtra(key, value string) {
 	if s.Extra == nil {
 		s.Extra = make(map[string]string)
@@ -46,7 +46,7 @@ func (s *Settings) SetExtra(key, value string) {
 	s.Extra[key] = value
 }
 
-// MarshalExtra returns the Extra map serialized as a JSON string.
+// MarshalExtra serialises Extra to a JSON object; emits "{}" when Extra is nil.
 func (s *Settings) MarshalExtra() (string, error) {
 	if s.Extra == nil {
 		return "{}", nil
@@ -79,7 +79,7 @@ const (
 	LayoutApp     = "app"
 )
 
-// NewDefaultSettings returns a Settings with defaults for the given UUID.
+// NewDefaultSettings seeds Theme=DefaultTheme, Layout=DefaultLayout, and an empty Extra map.
 func NewDefaultSettings(uuid string) *Settings {
 	return &Settings{
 		SessionUUID: uuid,
@@ -116,11 +116,11 @@ type Provider interface {
 	Touch(ctx context.Context, uuid string) error
 }
 
-// IDFunc returns the session identifier for the current request.
+// IDFunc resolves the session identifier from r; "" triggers cookie-based ID derivation.
 type IDFunc func(r *http.Request) string
 
-// Middleware returns middleware that loads per-session settings and stores
-// them on the request context for downstream handlers.
+// Middleware loads per-session settings via repo and stashes them on the request context
+// for GetSettings; refreshes UpdatedAt via Touch once a day.
 func Middleware(repo Provider, idFunc IDFunc, cfgs ...Config) func(http.Handler) http.Handler {
 	var cfg Config
 	if len(cfgs) > 0 {
@@ -166,7 +166,7 @@ func Middleware(repo Provider, idFunc IDFunc, cfgs ...Config) func(http.Handler)
 	}
 }
 
-// GetSettings returns the session settings from the request context.
+// GetSettings reads the context value populated by Middleware; falls back to defaults with "" UUID.
 func GetSettings(r *http.Request) *Settings {
 	if s, ok := r.Context().Value(settingsCtxKey).(*Settings); ok {
 		return s
@@ -174,8 +174,7 @@ func GetSettings(r *http.Request) *Settings {
 	return NewDefaultSettings("")
 }
 
-// ContextWithSettings returns a derived context that GetSettings can read.
-// Test code uses this to seed a session without running the full middleware.
+// ContextWithSettings seeds the GetSettings key on ctx; useful in tests that bypass Middleware.
 func ContextWithSettings(ctx context.Context, s *Settings) context.Context {
 	return context.WithValue(ctx, settingsCtxKey, s)
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -53,8 +53,7 @@ const (
 	FeaturePWA             = "pwa"
 )
 
-// AllFeatures lists every selectable feature tag.
-// "database" is always included (implied by the base template) and is not user-selectable.
+// AllFeatures is every selectable feature tag; "database" is implied by the base template and not user-selectable.
 var AllFeatures = []string{FeatureAuth, FeatureGraph, FeatureDatabase, FeatureMSSQL, FeaturePostgres, FeatureSSE, FeatureCaddy, FeatureAvatar, FeatureDemo, FeatureSessionSettings, FeatureAlpine, FeatureCapacitor, FeatureOffline, FeatureSync, FeatureCSRF, FeatureLinkRelations, FeatureWebStandards, FeatureBrowserAPIs, FeaturePWA}
 
 // ImplicitFeatures are always selected and not presented to the user.
@@ -76,9 +75,7 @@ var featureDeps = map[string][]string{
 	FeatureWebStandards:  {},
 }
 
-// ExpandFeatureDeps adds any transitive dependencies implied by the
-// selected features. For example, selecting "sync" pulls in "offline"
-// and "capacitor".
+// ExpandFeatureDeps walks featureDeps to a fixed point; e.g. "sync" pulls in "offline".
 func ExpandFeatureDeps(features []string) []string {
 	have := make(map[string]bool, len(features))
 	for _, f := range features {
@@ -124,7 +121,7 @@ const (
 	PlatformWindows = "windows"
 )
 
-// SupportedPlatforms lists the host OSes setup can target.
+// SupportedPlatforms is the host-OS allowlist for setup; macOS hosts must cross-target.
 var SupportedPlatforms = []string{PlatformLinux, PlatformWindows}
 
 // Options configures the template setup run.

--- a/internal/shared/shared.go
+++ b/internal/shared/shared.go
@@ -8,22 +8,22 @@ import (
 	"encoding/hex"
 )
 
-// RequestIDKey is a custom type for context keys to avoid collisions
+// RequestIDKey is the context-key type for request IDs (typed to avoid collisions).
 type RequestIDKey struct{}
 
-// RequestIDKeyValue is the exported value used as a key for storing request IDs in context.Context
+// RequestIDKeyValue is the singleton key value for RequestIDKey.
 var RequestIDKeyValue = RequestIDKey{}
 
-// ContextIDKey is a custom type for context keys to avoid collisions
+// ContextIDKey is the context-key type for context IDs (typed to avoid collisions).
 type ContextIDKey struct{}
 
-// ContextIDKeyValue is the exported value used as a key for storing context IDs in context.Context
+// ContextIDKeyValue is the singleton key value for ContextIDKey.
 var ContextIDKeyValue = ContextIDKey{}
 
-// ContextDescriptionKey is a custom type for context keys to avoid collisions
+// ContextDescriptionKey is the context-key type for context descriptions (typed to avoid collisions).
 type ContextDescriptionKey struct{}
 
-// ContextDescriptionKeyValue is the exported value used as a key for storing context descriptions in context.Context
+// ContextDescriptionKeyValue is the singleton key value for ContextDescriptionKey.
 var ContextDescriptionKeyValue = ContextDescriptionKey{}
 
 // RuntimeID is a unique identifier set once at application startup.
@@ -34,7 +34,7 @@ func init() {
 	RuntimeID = GenerateContextID()
 }
 
-// GenerateContextID generates a unique context ID for worker execution tracing
+// GenerateContextID is a hex-encoded 16-byte random ID; empty string if crypto/rand fails.
 func GenerateContextID() string {
 	bytes := make([]byte, 16)
 	if _, err := rand.Read(bytes); err != nil {
@@ -43,17 +43,20 @@ func GenerateContextID() string {
 	return hex.EncodeToString(bytes)
 }
 
-// WithContextID adds a context_id to the context
+// WithContextID stores contextID on ctx under ContextIDKeyValue so downstream
+// loggers can include it in structured fields.
 func WithContextID(ctx context.Context, contextID string) context.Context {
 	return context.WithValue(ctx, ContextIDKeyValue, contextID)
 }
 
-// WithContextDescription adds a context_description to the context
+// WithContextDescription stores a human-readable label on ctx under
+// ContextDescriptionKeyValue for diagnostic logging.
 func WithContextDescription(ctx context.Context, description string) context.Context {
 	return context.WithValue(ctx, ContextDescriptionKeyValue, description)
 }
 
-// WithContextIDAndDescription adds both context_id and context_description to the context
+// WithContextIDAndDescription is the combined-write helper; later
+// retrieval still goes through the individual key lookups.
 func WithContextIDAndDescription(ctx context.Context, contextID string, description string) context.Context {
 	ctx = WithContextID(ctx, contextID)
 	ctx = WithContextDescription(ctx, description)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,7 +16,7 @@ func Asset(path string) string {
 	return path + "?v=" + Version
 }
 
-// Display returns the version string with build date if available.
+// Display formats Version, appending " (BuildDate)" when BuildDate is non-empty.
 func Display() string {
 	if BuildDate != "" {
 		return Version + " (" + BuildDate + ")"

--- a/mage_setup.go
+++ b/mage_setup.go
@@ -20,37 +20,35 @@ import (
 
 const templateModulePath = "catgoose/dothog"
 
-// featureLabels maps feature tags to human-readable labels.
 var featureLabels = map[string]string{
 	// Core
 	setup.FeatureSessionSettings: "Session Settings (SQLite)",
 	setup.FeatureCSRF:            "CSRF Protection",
 	// Auth
-	setup.FeatureAuth:            "Auth (Crooner)",
-	setup.FeatureGraph:           "Graph API",
-	setup.FeatureAvatar:          "Avatar Photos (requires Graph)",
+	setup.FeatureAuth:   "Auth (Crooner)",
+	setup.FeatureGraph:  "Graph API",
+	setup.FeatureAvatar: "Avatar Photos (requires Graph)",
 	// Data
-	setup.FeatureDatabase:        "Database (chuck repository layer)",
-	setup.FeatureMSSQL:           "MSSQL dialect",
-	setup.FeaturePostgres:        "PostgreSQL dialect",
+	setup.FeatureDatabase: "Database (chuck repository layer)",
+	setup.FeatureMSSQL:    "MSSQL dialect",
+	setup.FeaturePostgres: "PostgreSQL dialect",
 	// Real-time
-	setup.FeatureSSE:             "SSE (requires Caddy)",
-	setup.FeatureCaddy:           "Caddy HTTPS/H3 front-proxy (adds local TLS)",
+	setup.FeatureSSE:   "SSE (requires Caddy)",
+	setup.FeatureCaddy: "Caddy HTTPS/H3 front-proxy (adds local TLS)",
 	// Navigation
-	setup.FeatureLinkRelations:   "Link Relations (context bars, breadcrumbs, site map)",
+	setup.FeatureLinkRelations: "Link Relations (context bars, breadcrumbs, site map)",
 	// Performance & Security
-	setup.FeatureWebStandards:    "Web Standards (Server-Timing, Vary, Permissions-Policy, Early Hints)",
-	setup.FeatureBrowserAPIs:     "Browser APIs (sendBeacon, BroadcastChannel)",
+	setup.FeatureWebStandards: "Web Standards (Server-Timing, Vary, Permissions-Policy, Early Hints)",
+	setup.FeatureBrowserAPIs:  "Browser APIs (sendBeacon, BroadcastChannel)",
 	// Mobile & Offline
-	setup.FeatureCapacitor:       "Capacitor (mobile wrapper)",
-	setup.FeatureOffline:         "Offline Mode (service worker, write queue)",
-	setup.FeatureSync:            "Sync (offline data synchronization)",
-	setup.FeaturePWA:             "PWA (Progressive Web App — offline + sync + mobile)",
+	setup.FeatureCapacitor: "Capacitor (mobile wrapper)",
+	setup.FeatureOffline:   "Offline Mode (service worker, write queue)",
+	setup.FeatureSync:      "Sync (offline data synchronization)",
+	setup.FeaturePWA:       "PWA (Progressive Web App — offline + sync + mobile)",
 	// Demo
-	setup.FeatureDemo:            "Demo Content",
+	setup.FeatureDemo: "Demo Content",
 }
 
-// featureLabelOrder is the display order for the feature multi-select.
 var featureLabelOrder = []string{
 	// Core
 	setup.FeatureSessionSettings,
@@ -84,7 +82,8 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-// Setup runs the template setup to initialize a new app.
+// Setup is the template repo's scaffold entrypoint for both the interactive
+// wizard and the flag-driven setup flow.
 // Example:
 //
 //	go tool mage setup
@@ -217,14 +216,13 @@ func Setup() error {
 	return nil
 }
 
-// presets maps preset names to their default feature sets.
 var presets = map[string][]string{
-	"internal": {setup.FeatureAuth, setup.FeatureCSRF, setup.FeatureDatabase, setup.FeatureSessionSettings, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards},
+	"internal":                {setup.FeatureAuth, setup.FeatureCSRF, setup.FeatureDatabase, setup.FeatureSessionSettings, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards},
 	"microsoft-lite-internal": {setup.FeatureSessionSettings, setup.FeatureCSRF, setup.FeatureAuth, setup.FeatureGraph, setup.FeatureAvatar, setup.FeatureDatabase, setup.FeatureMSSQL, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards},
-	"public":   {setup.FeatureSessionSettings, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards, setup.FeatureBrowserAPIs},
+	"public":                  {setup.FeatureSessionSettings, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards, setup.FeatureBrowserAPIs},
 	"microsoft-full-internal": {setup.FeatureSessionSettings, setup.FeatureCSRF, setup.FeatureAuth, setup.FeatureGraph, setup.FeatureAvatar, setup.FeatureDatabase, setup.FeatureMSSQL, setup.FeatureSSE, setup.FeatureCaddy, setup.FeatureLinkRelations, setup.FeatureWebStandards, setup.FeatureBrowserAPIs, setup.FeatureOffline, setup.FeatureSync, setup.FeaturePWA},
-	"demo":     setup.AllFeatures,
-	"minimal":  {},
+	"demo":                    setup.AllFeatures,
+	"minimal":                 {},
 }
 
 func runWizard() (*setup.Options, error) {
@@ -238,20 +236,20 @@ func runWizard() (*setup.Options, error) {
 		preset     string
 		customize  bool
 		// Guided wizard answers
-		dbDialect    string // "sqlite", "mssql", "postgres", "sqlite+mssql", "sqlite+postgres"
-		wantSessions bool
-		wantAuth     bool
-		wantGraph    bool
-		wantAvatar   bool
-		wantSSE      bool
-		wantLinks    bool
+		dbDialect     string // "sqlite", "mssql", "postgres", "sqlite+mssql", "sqlite+postgres"
+		wantSessions  bool
+		wantAuth      bool
+		wantGraph     bool
+		wantAvatar    bool
+		wantSSE       bool
+		wantLinks     bool
 		wantStandards bool
-		wantAPIs     bool
+		wantAPIs      bool
 		wantCapacitor bool
-		wantOffline  bool
-		wantSync     bool
-		wantPWA      bool
-		wantDemo     bool
+		wantOffline   bool
+		wantSync      bool
+		wantPWA       bool
+		wantDemo      bool
 	)
 
 	currentModule := goModulePath()
@@ -442,21 +440,47 @@ func runWizard() (*setup.Options, error) {
 			features = append(features, setup.FeatureDatabase, setup.FeatureMSSQL)
 		case "sqlite+postgres":
 			features = append(features, setup.FeatureDatabase, setup.FeaturePostgres)
-		// "sqlite" — database is implicit, nothing extra needed
+			// "sqlite" — database is implicit, nothing extra needed
 		}
-		if wantSessions { features = append(features, setup.FeatureSessionSettings) }
-		if wantAuth { features = append(features, setup.FeatureAuth, setup.FeatureCSRF) }
-		if wantGraph { features = append(features, setup.FeatureGraph) }
-		if wantAvatar { features = append(features, setup.FeatureAvatar) }
-		if wantSSE { features = append(features, setup.FeatureSSE, setup.FeatureCaddy) }
-		if wantLinks { features = append(features, setup.FeatureLinkRelations, setup.FeatureSessionSettings) }
-		if wantStandards { features = append(features, setup.FeatureWebStandards) }
-		if wantAPIs { features = append(features, setup.FeatureBrowserAPIs, setup.FeatureSSE, setup.FeatureCaddy) }
-		if wantCapacitor { features = append(features, setup.FeatureCapacitor) }
-		if wantOffline { features = append(features, setup.FeatureOffline, setup.FeatureCapacitor) }
-		if wantSync { features = append(features, setup.FeatureSync, setup.FeatureOffline, setup.FeatureCapacitor) }
-		if wantPWA { features = append(features, setup.FeaturePWA, setup.FeatureSync, setup.FeatureOffline, setup.FeatureCapacitor) }
-		if wantDemo { features = append(features, setup.FeatureDemo) }
+		if wantSessions {
+			features = append(features, setup.FeatureSessionSettings)
+		}
+		if wantAuth {
+			features = append(features, setup.FeatureAuth, setup.FeatureCSRF)
+		}
+		if wantGraph {
+			features = append(features, setup.FeatureGraph)
+		}
+		if wantAvatar {
+			features = append(features, setup.FeatureAvatar)
+		}
+		if wantSSE {
+			features = append(features, setup.FeatureSSE, setup.FeatureCaddy)
+		}
+		if wantLinks {
+			features = append(features, setup.FeatureLinkRelations, setup.FeatureSessionSettings)
+		}
+		if wantStandards {
+			features = append(features, setup.FeatureWebStandards)
+		}
+		if wantAPIs {
+			features = append(features, setup.FeatureBrowserAPIs, setup.FeatureSSE, setup.FeatureCaddy)
+		}
+		if wantCapacitor {
+			features = append(features, setup.FeatureCapacitor)
+		}
+		if wantOffline {
+			features = append(features, setup.FeatureOffline, setup.FeatureCapacitor)
+		}
+		if wantSync {
+			features = append(features, setup.FeatureSync, setup.FeatureOffline, setup.FeatureCapacitor)
+		}
+		if wantPWA {
+			features = append(features, setup.FeaturePWA, setup.FeatureSync, setup.FeatureOffline, setup.FeatureCapacitor)
+		}
+		if wantDemo {
+			features = append(features, setup.FeatureDemo)
+		}
 
 	} else {
 		// ── Preset selected: offer to customize ────────────────────
@@ -591,7 +615,6 @@ func runWizard() (*setup.Options, error) {
 	}, nil
 }
 
-// resolveModulePath determines the final module path from user input and defaults.
 func resolveModulePath(appName, modulePathInput, _ string) string {
 	modulePathInput = strings.TrimSpace(modulePathInput)
 	if modulePathInput != "" {
@@ -604,7 +627,6 @@ func resolveModulePath(appName, modulePathInput, _ string) string {
 	return fmt.Sprintf("github.com/you/%s", binaryNameFromApp(name))
 }
 
-// describeFeatures returns a human-readable summary of selected features.
 func describeFeatures(features []string) string {
 	if len(features) == 0 {
 		return "none (bare HTMX app)"
@@ -776,13 +798,12 @@ func setupScriptArgsFromCLI() []string {
 	return args[idx+1:]
 }
 
-// huhConfirm prompts the user with a yes/no confirmation using huh.
+// huhConfirm is huhConfirmDefault with a default of false.
 func huhConfirm(message string) (bool, error) {
 	return huhConfirmDefault(message, false)
 }
 
-// huhConfirmDefault prompts the user with a yes/no confirmation using huh,
-// with a configurable default value.
+// huhConfirmDefault returns false (and a nil error) on user abort, matching how callers handle cancellation.
 func huhConfirmDefault(message string, def bool) (bool, error) {
 	confirmed := def
 	err := huh.NewConfirm().
@@ -800,7 +821,7 @@ func huhConfirmDefault(message string, def bool) (bool, error) {
 	return confirmed, nil
 }
 
-// huhInput prompts the user for text input using huh.
+// huhInput returns "" (and a nil error) on user abort.
 func huhInput(title, placeholder, value string) (string, error) {
 	result := value
 	field := huh.NewInput().

--- a/magefile.go
+++ b/magefile.go
@@ -23,7 +23,6 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-// Default Environment Variables
 var (
 	env        = envOr("ENV", "development")
 	envFile    = fmt.Sprintf(".env.%s", env)
@@ -35,33 +34,32 @@ var (
 	// - APP_HTTP_PORT: Echo origin port (SERVER_LISTEN_PORT) — plain HTTP in dev
 	// - TEMPL_HTTP_PORT: templ's local HTTP proxy port
 	// - CADDY_TLS_PORT: Caddy TLS termination port (only when caddy feature is selected)
-	proxyURL               = fmt.Sprintf("http://%s:{{APP_HTTP_PORT}}", proxyHost)
-	proxyPort              = "{{TEMPL_HTTP_PORT}}"
+	proxyURL  = fmt.Sprintf("http://%s:{{APP_HTTP_PORT}}", proxyHost)
+	proxyPort = "{{TEMPL_HTTP_PORT}}"
 	// setup:feature:caddy:start
-	caddyTLSPort           = "{{CADDY_TLS_PORT}}"
+	caddyTLSPort = "{{CADDY_TLS_PORT}}"
 	// setup:feature:caddy:end
 	htmxURL                = "https://unpkg.com/htmx.org"
 	htmxResponseTargetsURL = "https://unpkg.com/htmx-ext-response-targets"
 	// setup:feature:sse:start
-	htmxSSEURL             = "https://unpkg.com/htmx-ext-sse"
+	htmxSSEURL = "https://unpkg.com/htmx-ext-sse"
 	// setup:feature:sse:end
 	// setup:feature:demo:start
-	tavernJSURL            = "https://cdn.jsdelivr.net/gh/catgoose/tavern-js@latest/dist/tavern.min.js"
+	tavernJSURL = "https://cdn.jsdelivr.net/gh/catgoose/tavern-js@latest/dist/tavern.min.js"
 	// setup:feature:demo:end
-	hyperscriptURL         = "https://unpkg.com/hyperscript.org"
-	alpineURL              = "https://unpkg.com/@alpinejs/csp@3/dist/cdn.min.js"
-	alpineMorphURL         = "https://unpkg.com/@alpinejs/morph@3/dist/cdn.min.js"
-	htmxAlpineMorphURL     = "https://unpkg.com/htmx-ext-alpine-morph@2.0.0/alpine-morph.js"
-	publicSourceDir        = "web/assets/public"
-	publicOutputDir        = filepath.Join(buildPath, publicSourceDir)
-	publicJSDir            = filepath.Join(publicSourceDir, "js")
-	publicCSSDir           = filepath.Join(publicSourceDir, "css")
+	hyperscriptURL     = "https://unpkg.com/hyperscript.org"
+	alpineURL          = "https://unpkg.com/@alpinejs/csp@3/dist/cdn.min.js"
+	alpineMorphURL     = "https://unpkg.com/@alpinejs/morph@3/dist/cdn.min.js"
+	htmxAlpineMorphURL = "https://unpkg.com/htmx-ext-alpine-morph@2.0.0/alpine-morph.js"
+	publicSourceDir    = "web/assets/public"
+	publicOutputDir    = filepath.Join(buildPath, publicSourceDir)
+	publicJSDir        = filepath.Join(publicSourceDir, "js")
+	publicCSSDir       = filepath.Join(publicSourceDir, "css")
 )
 
 const templWatchIgnorePattern = `(^|[\\/])mage_output_file\.go$`
 const caddyModuleVersion = "v2.11.3"
 
-// DaisyUIComponents is the list of DaisyUI CSS component URLs.
 var daisyUIComponents = []string{
 	"npm/daisyui@5/base/rootscrollgutter.css",
 	"npm/daisyui@5/base/reset.css",
@@ -109,7 +107,6 @@ var daisyUIComponents = []string{
 	"npm/daisyui@5/theme/silk.css",
 }
 
-// Helper function to get environment variable with default
 func envOr(env, def string) string {
 	if v := os.Getenv(env); v != "" {
 		return v
@@ -211,7 +208,7 @@ func resolveCaddyBinary() (string, error) {
 	return "", fmt.Errorf("caddy binary not found; run `go tool mage caddyinstall` or rerun setup and choose Caddy install")
 }
 
-// Tailwind runs the Tailwind CSS compilation
+// Tailwind compiles web/styles/input.css to the public tailwind.css bundle (minified).
 func Tailwind() error {
 	return sh.Run(tailwindLocalBin(),
 		"-i", "web/styles/input.css",
@@ -219,7 +216,7 @@ func Tailwind() error {
 		"-m")
 }
 
-// TailwindWatch runs Tailwind in watch mode
+// TailwindWatch runs the Tailwind compiler in watch mode, installing the CLI first if missing.
 func TailwindWatch() error {
 	if _, err := os.Stat(tailwindLocalBin()); os.IsNotExist(err) {
 		fmt.Println("Tailwind binary not found. Running update...")
@@ -315,7 +312,7 @@ func tailwindAssetName() string {
 	}
 }
 
-// DaisyUpdate updates DaisyUI CSS
+// DaisyUpdate downloads the combined DaisyUI CSS bundle into public/css.
 func DaisyUpdate() error {
 	mg.Deps(PrepareDirs)
 	daisyURL := fmt.Sprintf("https://cdn.jsdelivr.net/combine/%s",
@@ -323,7 +320,7 @@ func DaisyUpdate() error {
 	return downloadFile(daisyURL, filepath.Join(publicCSSDir, "daisyui.css"))
 }
 
-// HtmxUpdate updates HTMX and all HTMX extension files
+// HtmxUpdate downloads HTMX core and the response-targets/SSE extensions into public/js.
 func HtmxUpdate() error {
 	mg.Deps(PrepareDirs)
 	if err := downloadFile(htmxURL, filepath.Join(publicJSDir, "htmx.min.js")); err != nil {
@@ -340,7 +337,7 @@ func HtmxUpdate() error {
 	return nil
 }
 
-// HyperscriptUpdate updates Hyperscript file
+// HyperscriptUpdate downloads the _hyperscript runtime into public/js.
 func HyperscriptUpdate() error {
 	return downloadFile(hyperscriptURL, filepath.Join(publicJSDir, "_hyperscript.min.js"))
 }
@@ -366,7 +363,7 @@ func AlpineUpdate() error {
 	return downloadFile(htmxAlpineMorphURL, filepath.Join(publicJSDir, "htmx.alpine-morph.js"))
 }
 
-// UpdateAssets updates all assets
+// UpdateAssets downloads every vendored client asset (HTMX, Alpine, Hyperscript, DaisyUI, Tailwind, tavern-js).
 func UpdateAssets() error {
 	if err := HyperscriptUpdate(); err != nil {
 		return fmt.Errorf("hyperscript update failed: %v", err)
@@ -391,7 +388,7 @@ func UpdateAssets() error {
 	return nil
 }
 
-// Air runs the Air live reload tool.
+// Air watches Go sources via .air/server.toml and rebuilds tmp/main on change.
 func Air() error {
 	fmt.Println("running air")
 	return sh.Run("go", "tool", "air", "-c", ".air/server.toml")
@@ -408,23 +405,23 @@ func AirBuild() error {
 	return sh.RunV(cmd[0], cmd[1:]...)
 }
 
-// Templ runs Templ in watch mode
+// Templ is an alias for TemplWatch.
 func Templ() error {
 	return TemplWatch()
 }
 
-// TemplWatch runs Templ in watch mode
+// TemplWatch runs `templ generate -watch` behind a proxy on TEMPL_HTTP_PORT.
 func TemplWatch() error {
 	cmd := getTemplCmd()
 	return sh.RunV(cmd[0], cmd[1:]...)
 }
 
-// TemplGenerate generates Templ files
+// TemplGenerate produces *_templ.go in one shot; use TemplWatch for live regen.
 func TemplGenerate() error {
 	return sh.Run("go", "tool", "templ", "generate")
 }
 
-// Clean removes build and debug files
+// Clean removes the build/ output tree and any Delve __debug_bin* binaries.
 func Clean() error {
 	if err := CleanBuild(); err != nil {
 		return fmt.Errorf("clean build failed: %v", err)
@@ -435,12 +432,12 @@ func Clean() error {
 	return nil
 }
 
-// CleanBuild removes the build directory
+// CleanBuild deletes build/ recursively (the deployable-output tree).
 func CleanBuild() error {
 	return os.RemoveAll(buildPath)
 }
 
-// CleanDebug removes debug binaries
+// CleanDebug removes Delve __debug_bin* binaries left in the working tree.
 func CleanDebug() error {
 	matches, err := filepath.Glob("__debug_bin*")
 	if err != nil {
@@ -454,7 +451,8 @@ func CleanDebug() error {
 	return nil
 }
 
-// PrepareDirs creates necessary directories
+// PrepareDirs ensures build/, build/public/js, and build/public/css exist
+// before Tailwind/Templ/CopyFiles write into them.
 func PrepareDirs() error {
 	dirs := []string{
 		publicOutputDir,
@@ -469,7 +467,7 @@ func PrepareDirs() error {
 	return nil
 }
 
-// CopyFiles copies necessary files to build directory
+// CopyFiles copies the env file, web/views, and public assets into build/.
 func CopyFiles() error {
 	if err := EnvCheck(); err != nil {
 		return fmt.Errorf("environment check failed: %v", err)
@@ -479,7 +477,6 @@ func CopyFiles() error {
 		return fmt.Errorf("prepare directories failed: %v", err)
 	}
 
-	// Copy env file
 	if err := sh.Copy(filepath.Join(buildPath, filepath.Base(envFile)), envFile); err != nil {
 		return fmt.Errorf("failed to copy env file: %v", err)
 	}
@@ -506,7 +503,7 @@ func CopyFiles() error {
 	return nil
 }
 
-// Compile builds the Go project
+// Compile builds main.go into build/<binaryName> with BuildDate baked in via ldflags.
 func Compile() error {
 	ldflags := "-w -X catgoose/dothog/internal/version.BuildDate=" + time.Now().UTC().Format("2006-01-02")
 	return sh.Run("go", "build",
@@ -515,13 +512,13 @@ func Compile() error {
 		"main.go")
 }
 
-// Run executes the compiled binary
+// Run executes the release-like artifact under build/, rebuilding it first via Build.
 func Run() error {
 	mg.Deps(Build)
 	return sh.Run(filepath.Join(buildPath, binaryName+hostBinaryExt()))
 }
 
-// EnvCheck verifies the environment file exists
+// EnvCheck fails fast when the selected .env.<ENV> file is missing.
 func EnvCheck() error {
 	if _, err := os.Stat(envFile); os.IsNotExist(err) {
 		return fmt.Errorf("error: %s file not found", envFile)
@@ -529,7 +526,7 @@ func EnvCheck() error {
 	return nil
 }
 
-// Watch runs Tailwind, Templ, Air, and Caddy in watch mode
+// Watch runs Tailwind, Templ, Air, and (when enabled) Caddy concurrently for local dev; opens the browser unless OPEN_BROWSER=false.
 func Watch() error {
 	if err := nodeModulesCheck(); err != nil {
 		return err
@@ -572,7 +569,6 @@ func Watch() error {
 		}()
 	}
 
-	// Wait for all tasks to complete or error
 	for range len(tasks) {
 		if err := <-errc; err != nil {
 			return err
@@ -581,7 +577,6 @@ func Watch() error {
 	return nil
 }
 
-// openBrowserURL opens the given URL in the default browser.
 func openBrowserURL(url string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
@@ -605,7 +600,7 @@ func nodeModulesCheck() error {
 	return nil
 }
 
-// Build cleans, updates assets, and builds the project
+// Build runs npm ci (if needed), Clean, Tailwind, Compile, then CopyFiles to produce a deployable build/ tree.
 func Build() error {
 	fmt.Println("Starting build process...")
 
@@ -637,7 +632,6 @@ func Build() error {
 	return nil
 }
 
-// Helper function to join URLs for DaisyUI
 func copyDir(src, dst string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -681,7 +675,6 @@ func joinURLs(urls []string) string {
 	return result
 }
 
-// Helper function to get Templ command
 func getTemplCmd() []string {
 	return []string{
 		"go", "tool", "templ", "generate",
@@ -694,7 +687,6 @@ func getTemplCmd() []string {
 	}
 }
 
-// Helper function to get Templ notify proxy args
 func getTemplNotifyProxyArgs() []string {
 	return []string{
 		"go", "tool", "templ", "generate",
@@ -705,7 +697,6 @@ func getTemplNotifyProxyArgs() []string {
 	}
 }
 
-// Helper function to download a file
 func downloadFile(url, filepath string) error {
 	return sh.Run("curl", "-Lso", filepath, url)
 }
@@ -825,7 +816,7 @@ func runQuiet(name string, args ...string) error {
 	return cmd.Run()
 }
 
-// Lint runs static analysis and style checks on the codebase.
+// Lint runs golangci-lint, golint, fieldalignment, and (when installed) oxlint.
 func Lint() error {
 	if _, err := exec.LookPath("golangci-lint"); err != nil {
 		return errors.New("golangci-lint not found. Please install it: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest")
@@ -884,7 +875,7 @@ func runFilteredFieldAlignment() error {
 	return errors.New("fieldalignment issues found")
 }
 
-// FixFieldAlignment runs fieldalignment with the -fix flag to automatically fix field alignment issues
+// FixFieldAlignment runs `fieldalignment -fix` to rewrite struct field order in place.
 func FixFieldAlignment() error {
 	if _, err := exec.LookPath("fieldalignment"); err != nil {
 		return errors.New("fieldalignment not found. Please install it: go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest")
@@ -893,32 +884,32 @@ func FixFieldAlignment() error {
 	return runQuiet("fieldalignment", "-fix", "./...")
 }
 
-// LintWatch runs Air with lint configuration for automatic linting on file changes
+// LintWatch runs Air with .air/lint.toml to re-lint on file changes.
 func LintWatch() error {
 	fmt.Println("Starting Air lint watch mode...")
 	fmt.Println("Press Ctrl+C to stop")
 	return sh.Run("go", "tool", "air", "-c", ".air/lint.toml")
 }
 
-// Test runs all tests
+// Test is the broadest Go test target; it executes the full package tree.
 func Test() error {
 	fmt.Println("Running tests...")
 	return sh.RunV("go", "test", "./...")
 }
 
-// TestVerbose runs all tests with verbose output
+// TestVerbose adds per-test logging to the full package-tree test run.
 func TestVerbose() error {
 	fmt.Println("Running tests with verbose output...")
 	return sh.RunV("go", "test", "-v", "./...")
 }
 
-// TestCoverage runs tests with coverage report
+// TestCoverage reports statement coverage across the full package tree.
 func TestCoverage() error {
 	fmt.Println("Running tests with coverage...")
 	return sh.RunV("go", "test", "-cover", "./...")
 }
 
-// TestCoverageHTML runs tests and generates HTML coverage report
+// TestCoverageHTML produces coverage.out and renders it to coverage.html.
 func TestCoverageHTML() error {
 	fmt.Println("Running tests with HTML coverage report...")
 	if err := sh.RunV("go", "test", "-coverprofile=coverage.out", "./..."); err != nil {
@@ -927,19 +918,19 @@ func TestCoverageHTML() error {
 	return sh.RunV("go", "tool", "cover", "-html=coverage.out", "-o=coverage.html")
 }
 
-// TestBenchmark runs benchmark tests
+// TestBenchmark enables Go benchmarks across the package tree.
 func TestBenchmark() error {
 	fmt.Println("Running benchmark tests...")
 	return sh.RunV("go", "test", "-bench=.", "./...")
 }
 
-// TestRace runs tests with race detection
+// TestRace enables the race detector across the full package tree.
 func TestRace() error {
 	fmt.Println("Running tests with race detection...")
 	return sh.RunV("go", "test", "-race", "./...")
 }
 
-// TestE2E runs Playwright end-to-end tests
+// TestE2E runs Playwright e2e tests headlessly using e2e/playwright.config.ts.
 func TestE2E() error {
 	if err := nodeModulesCheck(); err != nil {
 		return err
@@ -948,7 +939,7 @@ func TestE2E() error {
 	return sh.RunV("npx", "playwright", "test", "--config", "e2e/playwright.config.ts")
 }
 
-// TestE2EHeaded runs Playwright tests in headed browser mode
+// TestE2EHeaded runs the Playwright e2e suite with a visible browser.
 func TestE2EHeaded() error {
 	if err := nodeModulesCheck(); err != nil {
 		return err
@@ -957,7 +948,7 @@ func TestE2EHeaded() error {
 	return sh.RunV("npx", "playwright", "test", "--config", "e2e/playwright.config.ts", "--headed")
 }
 
-// TestE2EUI opens the Playwright interactive UI
+// TestE2EUI launches the Playwright interactive UI runner.
 func TestE2EUI() error {
 	if err := nodeModulesCheck(); err != nil {
 		return err
@@ -966,24 +957,22 @@ func TestE2EUI() error {
 	return sh.RunV("npx", "playwright", "test", "--config", "e2e/playwright.config.ts", "--ui")
 }
 
-// TestWatch runs tests in watch mode using the Go-based watcher
+// TestWatch builds and runs the Go test watcher (cmd/testwatcher) which re-runs tests on .go file changes.
 func TestWatch() error {
 	fmt.Println("Building and starting Go test watcher...")
 	fmt.Println("Tests will run automatically on .go file changes")
 	fmt.Println("Press Ctrl+C to stop")
 
-	// Build the test watcher
 	if err := sh.Run("go", "build", "-o", filepath.Join(binPath, "testwatcher"), "./cmd/testwatcher"); err != nil {
 		return fmt.Errorf("failed to build test watcher: %w", err)
 	}
 
-	// Run the test watcher
 	return sh.Run(filepath.Join(binPath, "testwatcher"))
 }
 
 // setup:feature:caddy:start
 
-// CaddyInstall installs Caddy for local development
+// CaddyInstall installs the repo-local Caddy binary into ./bin.
 func CaddyInstall() error {
 	fmt.Println("Installing Caddy...")
 	return installRepoLocalCaddy(".")

--- a/web/components/core/error_presentation.go
+++ b/web/components/core/error_presentation.go
@@ -5,6 +5,7 @@ import "github.com/catgoose/linkwell"
 // ErrorSurface identifies which rendering surface an error should use.
 type ErrorSurface string
 
+// ErrorSurface values: where in the page the error renders, which controls Normalize's defaults.
 const (
 	SurfaceBanner     ErrorSurface = "banner"
 	SurfaceInline     ErrorSurface = "inline"
@@ -100,7 +101,7 @@ func (p *ErrorPresentation) toErrorContext() linkwell.ErrorContext {
 
 // --- Ergonomic constructors ---
 
-// NewBannerError creates a banner-surface error presentation.
+// NewBannerError builds an ErrorPresentation on SurfaceBanner; Normalize stamps defaults.
 func NewBannerError(status int, title string, controls ...linkwell.Control) ErrorPresentation {
 	p := ErrorPresentation{
 		Surface:  SurfaceBanner,
@@ -112,7 +113,7 @@ func NewBannerError(status int, title string, controls ...linkwell.Control) Erro
 	return p
 }
 
-// NewInlineError creates an inline-surface error presentation.
+// NewInlineError builds an ErrorPresentation on SurfaceInline (no Normalize pass).
 func NewInlineError(status int, title string, controls ...linkwell.Control) ErrorPresentation {
 	return ErrorPresentation{
 		Surface:  SurfaceInline,
@@ -122,7 +123,7 @@ func NewInlineError(status int, title string, controls ...linkwell.Control) Erro
 	}
 }
 
-// NewInlineFullError creates an inline-full error presentation with explicit size.
+// NewInlineFullError builds an ErrorPresentation on SurfaceInlineFull; empty size defaults to SizeMD.
 func NewInlineFullError(status int, title string, size ErrorSize, controls ...linkwell.Control) ErrorPresentation {
 	p := ErrorPresentation{
 		Surface:  SurfaceInlineFull,
@@ -137,7 +138,7 @@ func NewInlineFullError(status int, title string, size ErrorSize, controls ...li
 	return p
 }
 
-// NewFullPageError creates a full-page error presentation.
+// NewFullPageError builds an ErrorPresentation on SurfaceFullPage; Normalize stamps defaults.
 func NewFullPageError(status int, title, detail, route, requestID, theme string, controls ...linkwell.Control) ErrorPresentation {
 	p := ErrorPresentation{
 		Surface:   SurfaceFullPage,

--- a/web/views/admin_health.go
+++ b/web/views/admin_health.go
@@ -18,7 +18,6 @@ func dbBadgeClass(status string) string {
 	return "badge-error"
 }
 
-// intervalOr returns the interval from the map, or fallback if missing.
 func intervalOr(m map[string]int, key string, fallback int) int {
 	if v, ok := m[key]; ok {
 		return v

--- a/web/views/admin_settings.go
+++ b/web/views/admin_settings.go
@@ -39,7 +39,7 @@ func sseCountBadge(count int) string {
 	return "badge-ghost"
 }
 
-// IntervalMs returns the current interval for a section, falling back to fallback.
+// IntervalMs reads Intervals[section]; missing keys yield fallback.
 func (d AdminPanelData) IntervalMs(section string, fallback int) int {
 	if v, ok := d.Intervals[section]; ok {
 		return v

--- a/web/views/error_modes.go
+++ b/web/views/error_modes.go
@@ -1,4 +1,6 @@
 // setup:feature:demo
+
+// Package views provides server-rendered page and partial views for the dothog demo UI.
 package views
 
 import (
@@ -54,7 +56,7 @@ func errorModesInlineFullRetryEC(size string) linkwell.ErrorContext {
 	}
 }
 
-// ContractDemoPresentations returns sample ErrorPresentations for the contract demo.
+// ContractDemoPresentations is a fixed trio (banner 500, inline 422, inline-full 429) for the contract demo.
 func ContractDemoPresentations() []corecomponents.ErrorPresentation {
 	return []corecomponents.ErrorPresentation{
 		corecomponents.NewBannerError(500, "Background job failed",
@@ -70,7 +72,7 @@ func ContractDemoPresentations() []corecomponents.ErrorPresentation {
 	}
 }
 
-// ContractFullPagePresentation returns a full-page ErrorPresentation for the contract demo.
+// ContractFullPagePresentation is the demo's 503 full-page ErrorPresentation with home/report controls.
 func ContractFullPagePresentation(theme string) corecomponents.ErrorPresentation {
 	return corecomponents.NewFullPageError(
 		503, "Service Unavailable",

--- a/web/views/realtime.go
+++ b/web/views/realtime.go
@@ -12,7 +12,7 @@ import (
 
 // --- Dashboard data types ---
 
-// NetworkPoint is a single data point for network traffic.
+// NetworkPoint is one tick in the inbound/outbound throughput sparkline (MB/s).
 type NetworkPoint struct {
 	InMBps  float64
 	OutMBps float64
@@ -50,7 +50,8 @@ type ServiceLatency struct {
 	History []float64
 }
 
-// MetricsSnapshot holds the current dashboard metrics state.
+// MetricsSnapshot bundles all per-section sparkline series the dashboard
+// templates read for a single render pass.
 type MetricsSnapshot struct {
 	Network      []NetworkPoint
 	DiskIO       []DiskIOPoint
@@ -148,7 +149,8 @@ func fmtSize(v float64) string {
 	return fmt.Sprintf("%.3f", v)
 }
 
-// ServiceStatus represents the health and load of a single service.
+// ServiceStatus is one row in the services panel; Status is one of
+// "healthy", "degraded", or "critical" (drives the bar color).
 type ServiceStatus struct {
 	Name   string
 	Status string
@@ -167,7 +169,8 @@ func serviceBarColor(s ServiceStatus) string {
 	}
 }
 
-// DashboardEvent represents a single entry in the live event feed.
+// DashboardEvent is one entry in the events feed; Kind selects the badge
+// class and indicator letter via eventBadgeClass / eventIcon.
 type DashboardEvent struct {
 	Time    time.Time
 	Kind    string // "deploy", "alert", "scale", "restart", "rollback"
@@ -233,7 +236,7 @@ type DashboardCardState struct {
 	Pinned    map[string]bool   // section -> pinned flag
 }
 
-// CardMs returns the current interval for a section, falling back to fallback.
+// CardMs reads Intervals[section]; missing keys yield fallback.
 func (s DashboardCardState) CardMs(section string, fallback int) int {
 	if v, ok := s.Intervals[section]; ok {
 		return v
@@ -241,7 +244,7 @@ func (s DashboardCardState) CardMs(section string, fallback int) int {
 	return fallback
 }
 
-// CardScale returns the current scale unit for a section, falling back to fallback.
+// CardScale reads Units[section]; missing keys yield fallback.
 func (s DashboardCardState) CardScale(section, fallback string) string {
 	if v, ok := s.Units[section]; ok {
 		return v
@@ -249,7 +252,7 @@ func (s DashboardCardState) CardScale(section, fallback string) string {
 	return fallback
 }
 
-// CardPinned returns whether a section is pinned.
+// CardPinned reports whether the named section is pinned; missing keys are false.
 func (s DashboardCardState) CardPinned(section string) bool {
 	return s.Pinned[section]
 }


### PR DESCRIPTION
## Summary
- remove or rewrite repo-owned Go comments that only restated obvious code behavior
- preserve comments that carry semantic, lifecycle, ordering, failure-mode, or platform/setup detail
- finish the repo-wide breadth pass across the previously missed demo/routes/mage surfaces

## Validation
- go build ./...
- go tool mage lint
- git diff --check