### PR TITLE
chore(setup): clarify caddy bin install behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,7 +1009,7 @@ All commands run with `go tool mage <target>`.
 | `lint`              | Code Quality | Run static analysis (golangci-lint, golint, fieldalignment) |
 | `fixfieldalignment` | Code Quality | Auto-fix field alignment                                    |
 | `clean`             | Utility      | Remove build and debug files                                |
-| `caddyinstall`      | HTTPS        | Install Caddy for local dev                                 |
+| `caddyinstall`      | HTTPS        | Install Caddy into `./bin` for this repo                    |
 | `caddystart`        | HTTPS        | Start Caddy with TLS termination                            |
 
 ## OFFICIAL DISCLAIMER

--- a/mage_setup.go
+++ b/mage_setup.go
@@ -677,15 +677,15 @@ func maybeInstallCaddyForSetup(projectDir string, opts *setup.Options) error {
 	if !setupUsesCaddy(opts) {
 		return nil
 	}
-	install, err := huhConfirm("Caddy is required for local HTTPS in this scaffold. Install repo-local Caddy now?")
+	install, err := huhConfirm("Caddy is required for local HTTPS in this scaffold. Install Caddy into ./bin for this app now?")
 	if err != nil {
 		return err
 	}
 	if !install {
-		fmt.Println("Skipping Caddy install. `mage watch` will require repo-local Caddy or a global `caddy` binary later.")
+		fmt.Println("Skipping Caddy install. `mage watch` will require ./bin/caddy (or caddy.exe) or a global `caddy` binary later.")
 		return nil
 	}
-	fmt.Println("Installing repo-local Caddy...")
+	fmt.Println("Installing Caddy into ./bin...")
 	return installRepoLocalCaddy(projectDir)
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -198,6 +199,28 @@ func installRepoLocalCaddy(projectDir string) error {
 	)
 }
 
+func confirmInstallCaddy() (bool, error) {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return false, err
+	}
+	if info.Mode()&os.ModeCharDevice == 0 {
+		return false, fmt.Errorf("caddy binary not found and no interactive terminal is available; run `go tool mage caddyinstall` to install ./bin/caddy")
+	}
+	fmt.Print("Caddy not found in ./bin or PATH. Install Caddy into ./bin now? [y/N]: ")
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
 func resolveCaddyBinary() (string, error) {
 	if _, err := os.Stat(caddyLocalBin()); err == nil {
 		return caddyLocalBin(), nil
@@ -205,7 +228,18 @@ func resolveCaddyBinary() (string, error) {
 	if path, err := exec.LookPath("caddy"); err == nil {
 		return path, nil
 	}
-	return "", fmt.Errorf("caddy binary not found; run `go tool mage caddyinstall` or rerun setup and choose Caddy install")
+	install, err := confirmInstallCaddy()
+	if err != nil {
+		return "", err
+	}
+	if !install {
+		return "", fmt.Errorf("caddy binary not found; run `go tool mage caddyinstall` to install ./bin/caddy")
+	}
+	fmt.Println("Installing Caddy into ./bin...")
+	if err := installRepoLocalCaddy("."); err != nil {
+		return "", err
+	}
+	return caddyLocalBin(), nil
 }
 
 // Tailwind compiles web/styles/input.css to the public tailwind.css bundle (minified).
@@ -972,7 +1006,7 @@ func TestWatch() error {
 
 // setup:feature:caddy:start
 
-// CaddyInstall installs the repo-local Caddy binary into ./bin.
+// CaddyInstall installs the Caddy binary into this repo's ./bin directory.
 func CaddyInstall() error {
 	fmt.Println("Installing Caddy...")
 	return installRepoLocalCaddy(".")


### PR DESCRIPTION
## Summary
- clarify that setup installs Caddy into the scaffold app's `./bin` directory
- make `mage watch` / `caddystart` prompt to install `./bin/caddy` when neither repo-local nor global Caddy exists
- update the README target description to match the repo-local install behavior

## Validation
- go tool mage -l
- git diff --check