### PR TITLE
chore(setup): auto-install caddy for caddy-enabled scaffolds

### DIFF
--- a/mage_setup.go
+++ b/mage_setup.go
@@ -677,12 +677,8 @@ func maybeInstallCaddyForSetup(projectDir string, opts *setup.Options) error {
 	if !setupUsesCaddy(opts) {
 		return nil
 	}
-	install, err := huhConfirm("Caddy is required for local HTTPS in this scaffold. Install Caddy into ./bin for this app now?")
-	if err != nil {
-		return err
-	}
-	if !install {
-		fmt.Println("Skipping Caddy install. `mage watch` will require ./bin/caddy (or caddy.exe) or a global `caddy` binary later.")
+	if _, err := os.Stat(caddyLocalBinIn(projectDir)); err == nil {
+		fmt.Println("Using existing ./bin/caddy for this app.")
 		return nil
 	}
 	fmt.Println("Installing Caddy into ./bin...")

--- a/magefile.go
+++ b/magefile.go
@@ -182,7 +182,11 @@ func hostBinaryExt() string {
 }
 
 func caddyLocalBin() string {
-	return filepath.Join(binPath, "caddy"+hostBinaryExt())
+	return caddyLocalBinIn(".")
+}
+
+func caddyLocalBinIn(projectDir string) string {
+	return filepath.Join(projectDir, binPath, "caddy"+hostBinaryExt())
 }
 
 func installRepoLocalCaddy(projectDir string) error {


### PR DESCRIPTION
## Summary
- remove the setup-time caddy confirmation for caddy-enabled scaffolds
- automatically install Caddy into `./bin` during setup when the scaffold uses caddy
- keep the runtime `mage watch`/`caddystart` fallback prompt for repos missing Caddy later

## Validation
- go tool mage -l
- git diff --check