### PR TITLE
Make trace promotion idempotent and trim changelog comments

### DIFF
--- a/internal/responsepolicy/policy_test.go
+++ b/internal/responsepolicy/policy_test.go
@@ -79,9 +79,8 @@ func TestPreload_FallbackEmitsLinkHeader(t *testing.T) {
 	assert.ElementsMatch(t, links, got)
 }
 
-// TestInstall_RegistersServerTimingAndVary wires Install onto a fresh Echo
-// and asserts the canonical chain is in effect on a real request, so a
-// reorder/regression in the package surface is caught here.
+// TestInstall_RegistersServerTimingAndVary verifies that Install wires the
+// expected response-policy middleware onto a real request path.
 func TestInstall_RegistersServerTimingAndVary(t *testing.T) {
 	e := echo.New()
 	Install(e, Config{})
@@ -96,11 +95,9 @@ func TestInstall_RegistersServerTimingAndVary(t *testing.T) {
 	assert.Contains(t, rec.Header().Values("Vary"), "HX-Request")
 }
 
-// TestInstall_CSPEmittedWhenConfigured pins the CSP-selected derived-app
-// contract: a non-empty ContentSecurityPolicy lands on every response as the
-// Content-Security-Policy header. dorman's SecurityHeaders middleware owns
-// the actual emission; this test exercises the path through responsepolicy
-// so a regression in either layer is caught here.
+// TestInstall_CSPEmittedWhenConfigured verifies that a configured
+// ContentSecurityPolicy is emitted as the Content-Security-Policy header via
+// the responsepolicy + dorman path.
 func TestInstall_CSPEmittedWhenConfigured(t *testing.T) {
 	e := echo.New()
 	policy := "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"

--- a/internal/routes/handler/error_handler.go
+++ b/internal/routes/handler/error_handler.go
@@ -221,10 +221,14 @@ func renderHTMXSurfaceError(c echo.Context, se *SurfaceError) error {
 	}
 }
 
+// errPromotedKey marks a request whose trace has already been promoted so
+// re-entry into the central error handler does not duplicate that side effect.
+const errPromotedKey = "_promolog_promoted"
+
 // NewHTTPErrorHandler is the e.HTTPErrorHandler replacement that renders
 // errors through the route-owned surface contract; non-nil reqLogStore
 // promotes the per-request log buffer to the shared store so issue reports
-// can retrieve it.
+// can retrieve it. Trace promotion is idempotent per request.
 func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Context) {
 	return func(err error, c echo.Context) {
 		// The httpcompression writer is finalized (closed) by the time the
@@ -245,9 +249,11 @@ func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Con
 			statusCode = he.Code
 		}
 
-		if reqLogStore != nil {
+		alreadyPromoted, _ := c.Get(errPromotedKey).(bool)
+		if reqLogStore != nil && !alreadyPromoted {
 			requestID := promolog.GetRequestID(c.Request().Context())
 			if requestID != "" {
+				c.Set(errPromotedKey, true)
 				var entries []promolog.Entry
 				if buf := promolog.GetBuffer(c.Request().Context()); buf != nil {
 					entries = buf.Entries()

--- a/internal/routes/handler/handler_notfound_promotion_test.go
+++ b/internal/routes/handler/handler_notfound_promotion_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/catgoose/promolog"
 	"github.com/labstack/echo/v4"
+	echoMiddleware "github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/require"
 )
 
@@ -86,9 +87,8 @@ func newEchoWithPromotion(store promolog.Storer) *echo.Echo {
 	return e
 }
 
-// TestHandleNotFound_NonHTMX_PromotesTrace pins down the regression where
-// a direct unmatched-route visit rendered the 404 page but never made it
-// into the promolog error-trace store.
+// TestHandleNotFound_NonHTMX_PromotesTrace verifies that an unmatched
+// non-HTMX route promotes one 404 trace.
 func TestHandleNotFound_NonHTMX_PromotesTrace(t *testing.T) {
 	store := &recordingStore{}
 	e := newEchoWithPromotion(store)
@@ -107,8 +107,8 @@ func TestHandleNotFound_NonHTMX_PromotesTrace(t *testing.T) {
 	require.NotEmpty(t, traces[0].RequestID, "promoted trace should carry the correlation request ID")
 }
 
-// TestHandleNotFound_HTMX_PromotesTrace guards the pre-existing HTMX path:
-// it should still reach the promote step.
+// TestHandleNotFound_HTMX_PromotesTrace verifies that an unmatched HTMX route
+// also promotes one 404 trace.
 func TestHandleNotFound_HTMX_PromotesTrace(t *testing.T) {
 	store := &recordingStore{}
 	e := newEchoWithPromotion(store)
@@ -125,8 +125,31 @@ func TestHandleNotFound_HTMX_PromotesTrace(t *testing.T) {
 	require.Equal(t, "/fakeroute/asdf", traces[0].Route)
 }
 
-// TestHandleNotFound_NonHTMX_RendersBody protects the existing UX: non-HTMX
-// 404 still emits a non-empty HTML body (not just an OOB swap).
+// TestNewHTTPErrorHandler_PromotesOnceWithRequestLogger verifies that central
+// error handling promotes a trace at most once per request, even when Echo's
+// request logger re-enters the global error handler.
+func TestNewHTTPErrorHandler_PromotesOnceWithRequestLogger(t *testing.T) {
+	store := &recordingStore{}
+	e := echo.New()
+	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
+	e.Use(echoMiddleware.RequestLogger())
+	e.HTTPErrorHandler = NewHTTPErrorHandler(store)
+	e.GET("/boom", func(_ echo.Context) error {
+		return echo.NewHTTPError(http.StatusInternalServerError, "boom")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/boom", http.NoBody)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	traces := store.snapshot()
+	require.Len(t, traces, 1,
+		"error handler must promote exactly once even when RequestLogger HandleError: true causes the central handler to fire twice")
+}
+
+// TestHandleNotFound_NonHTMX_RendersBody verifies that non-HTMX 404 responses
+// render a full HTML body instead of an OOB-only swap.
 func TestHandleNotFound_NonHTMX_RendersBody(t *testing.T) {
 	store := &recordingStore{}
 	e := newEchoWithPromotion(store)

--- a/internal/routes/handler/production_stack_test.go
+++ b/internal/routes/handler/production_stack_test.go
@@ -93,14 +93,10 @@ func TestProductionStack_GzipCompressesSuccessResponse(t *testing.T) {
 	assert.Contains(t, string(body), "Hello, this is a test response")
 }
 
-// TestProductionStack_ErrorHandlerSurvivesCompressedHotPath is the regression
-// guard for the RawWriter + httpcompression + NewHTTPErrorHandler interaction.
-// httpcompression finalizes its writer when the middleware chain unwinds, so
-// the error handler — which runs after — must restore the raw writer (saved
-// by RawWriterMiddleware) before rendering. Without that restore, writing
-// through the closed compression writer panics. The handler returns a generic
-// error so the fallback 500 path runs; Accept-Encoding: gzip forces
-// compression to engage and close on unwind.
+// TestProductionStack_ErrorHandlerSurvivesCompressedHotPath verifies the
+// RawWriter + httpcompression + NewHTTPErrorHandler interaction. The error
+// handler runs after httpcompression has finalized its writer, so it must
+// restore the raw writer before rendering the fallback 500 page.
 func TestProductionStack_ErrorHandlerSurvivesCompressedHotPath(t *testing.T) {
 	e := setupProductionStack(t)
 	e.GET("/boom", func(c echo.Context) error {
@@ -121,9 +117,8 @@ func TestProductionStack_ErrorHandlerSurvivesCompressedHotPath(t *testing.T) {
 	assert.Contains(t, body, "<!doctype html>", "non-HTMX errors render the full page")
 }
 
-// TestProductionStack_ErrorHandlerHTMXOnCompressedHotPath covers the HTMX
-// branch of the error handler over the same compressed hot path so a
-// regression in either render mode fails loudly.
+// TestProductionStack_ErrorHandlerHTMXOnCompressedHotPath verifies the HTMX
+// branch over the same compressed error path.
 func TestProductionStack_ErrorHandlerHTMXOnCompressedHotPath(t *testing.T) {
 	e := setupProductionStack(t)
 	e.GET("/boom", func(c echo.Context) error {
@@ -145,9 +140,7 @@ func TestProductionStack_ErrorHandlerHTMXOnCompressedHotPath(t *testing.T) {
 }
 
 // decodeResponseBody returns the response body as a string, transparently
-// gunzipping when Content-Encoding: gzip is set. Errors in body or invalid
-// gzip framing fail the test, since either points at a real compression-path
-// regression.
+// gunzipping when Content-Encoding: gzip is set.
 func decodeResponseBody(t *testing.T, rec *httptest.ResponseRecorder) string {
 	t.Helper()
 	if rec.Header().Get("Content-Encoding") != "gzip" {

--- a/internal/routes/theme_test.go
+++ b/internal/routes/theme_test.go
@@ -225,11 +225,9 @@ func TestInitThemeRoutes_WithBroker_HTMXThemeChangeUsesSendOnlyResponse(t *testi
 	require.Equal(t, "dark", last.Theme)
 }
 
-// TestInitThemeRoutes_PublishScopedToSessionTopic pins the per-session SSE
-// contract: a POST /settings/theme for session A publishes only to A's
-// topic, so a subscriber on session B's topic sees nothing. Prevents the
-// global-broadcast regression where one user's theme change rethemed every
-// connected browser.
+// TestInitThemeRoutes_PublishScopedToSessionTopic verifies the per-session SSE
+// contract: a POST /settings/theme for session A publishes only to A's topic,
+// so a subscriber on session B's topic sees nothing.
 func TestInitThemeRoutes_PublishScopedToSessionTopic(t *testing.T) {
 	store := &fakeSettingsStore{}
 	broker := tavern.NewSSEBroker()

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -93,9 +93,9 @@ var featureDeps = map[string][]string{
 // both surfaces in the same scaffold yields a runtime contract setup cannot
 // honestly deliver, so Run rejects the combination up front.
 //
-//   - csp + demo: the strict CSP header (script-src 'self') would break the
-//     demo views, which still ship inline <script> blocks and inline event
-//     handlers. Honest csp coverage of demo surfaces is a separate pass.
+//   - csp + demo: the strict CSP header (script-src 'self') is incompatible
+//     with demo views that still rely on inline <script> blocks and inline
+//     event handlers.
 var featureIncompatibilities = [][2]string{
 	{FeatureCSP, FeatureDemo},
 }
@@ -636,7 +636,8 @@ func removeOptionalContent(dir string, opts Options) error {
 	// derived apps.  The generated README is sufficient.
 	_ = os.RemoveAll(filepath.Join(dir, "docs"))
 
-	// Remove the setup package itself — it only exists for template setup (#377).
+	// Remove the setup package itself; it is only needed while turning the
+	// template into a derived app.
 	_ = os.RemoveAll(filepath.Join(dir, "internal", "setup"))
 	_ = os.Remove(filepath.Join(dir, "tests", "setup_test.go"))
 
@@ -647,9 +648,8 @@ func removeOptionalContent(dir string, opts Options) error {
 	_ = os.Remove(filepath.Join(dir, "mage_setup.go"))
 	_ = os.RemoveAll(filepath.Join(dir, TemplateSetupDir))
 
-	// Replace demo-specific e2e tests with a minimal smoke suite (#356).
-	// Keep helpers.ts and playwright.config.ts (they contain general utilities
-	// and the binary-name aware config). Remove all demo page spec files and
+	// Replace demo-specific e2e tests with a minimal smoke suite. Keep
+	// helpers.ts and playwright.config.ts, remove demo page specs, and
 	// generate a smoke test that verifies the app loads.
 	replaceE2EWithSmoke(dir, opts.AppName)
 
@@ -1209,7 +1209,7 @@ func goPkgName(importPath string) string {
 }
 
 // ---------------------------------------------------------------------------
-// README feature generation (#360)
+// README feature generation
 // ---------------------------------------------------------------------------
 
 // featureDescriptions maps feature tags to human-readable descriptions
@@ -1555,9 +1555,9 @@ func stripEnvBlocks(content string, removeTags map[string]bool) string {
 	return collapseBlankLines(out)
 }
 
-// replaceE2EWithSmoke removes all demo-specific e2e spec files and generates a
+// replaceE2EWithSmoke removes demo-specific e2e spec files and generates a
 // minimal smoke test that verifies the home page loads and the health endpoint
-// returns the configured app name (#356).
+// returns the configured app name.
 func replaceE2EWithSmoke(dir, appName string) {
 	e2eDir := filepath.Join(dir, "e2e")
 	entries, err := os.ReadDir(e2eDir)

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1395,9 +1395,9 @@ func TestRepresentativeBundle_MicrosoftInternal(t *testing.T) {
 	)
 }
 
-// TestRepresentativeBundle_AvatarPullsGraph guards the Avatar→Graph hard dep
-// against regression at the bundle level: a bundle that names Avatar without
-// Graph must still keep Graph (avatar.go imports the Graph package directly).
+// TestRepresentativeBundle_AvatarPullsGraph verifies that selecting Avatar
+// keeps Graph in the stripped bundle because avatar.go imports Graph
+// directly.
 func TestRepresentativeBundle_AvatarPullsGraph(t *testing.T) {
 	got := stripWithBundle(t, []string{FeatureAvatar})
 	assertBundleSurvival(t, got,

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -431,14 +431,14 @@ func TestSetup_FeaturesAll(t *testing.T) {
 	assertDirExists(t, filepath.Join(dest, "internal", "service", "graph"))
 	assertDirExists(t, filepath.Join(dest, "internal", "demo"))
 
-	// e2e smoke test should exist (#356)
+	// A derived app keeps the generated smoke test.
 	_, err = os.Stat(filepath.Join(dest, "e2e", "smoke.spec.ts"))
 	require.NoError(t, err, "smoke.spec.ts should exist after setup")
 	// Demo spec files should be removed
 	_, err = os.Stat(filepath.Join(dest, "e2e", "dashboard.spec.ts"))
 	require.True(t, os.IsNotExist(err), "demo e2e tests should be removed after setup")
 
-	// README should list all features (#360)
+	// The generated README should list the selected features.
 	readmeBytes, err := os.ReadFile(filepath.Join(dest, "README.md"))
 	require.NoError(t, err)
 	readmeContent := string(readmeBytes)
@@ -486,22 +486,22 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	_, err = os.Stat(filepath.Join(dest, "web", "assets", "public", "js", "htmx.ext.sse.js"))
 	require.True(t, os.IsNotExist(err), "htmx.ext.sse.js should be removed when sse not selected")
 
-	// Dothog-specific docs should be removed (#354)
+	// Dothog-specific top-level docs should be removed.
 	for _, f := range []string{"MANIFESTO.md", "AGENTS.md", "README.harmony.md"} {
 		_, err = os.Stat(filepath.Join(dest, f))
 		require.True(t, os.IsNotExist(err), "%s should be removed during setup", f)
 	}
 
-	// scripts/ directory should be removed (#361)
+	// scripts/ should not ship in the derived app.
 	assertDirRemoved(t, filepath.Join(dest, "scripts"))
 	_, err = os.Stat(filepath.Join(dest, ".github", "workflows", "pipeline.yml"))
 	require.True(t, os.IsNotExist(err), "pipeline.yml should be removed during setup (#367)")
 	assertDirRemoved(t, filepath.Join(dest, ".github", "harmony"))
 
-	// db/gen_seed should be removed when demo not selected (#358)
+	// db/gen_seed is demo-only and should be removed when demo is absent.
 	assertDirRemoved(t, filepath.Join(dest, "db", "gen_seed"))
 
-	// Capacitor files should be removed when capacitor not selected (#353)
+	// Capacitor files should be removed when capacitor is not selected.
 	for _, f := range []string{"capacitor.config.ts", "tsconfig.json", "Gemfile"} {
 		_, err = os.Stat(filepath.Join(dest, f))
 		require.True(t, os.IsNotExist(err), "%s should be removed when capacitor not selected", f)
@@ -516,12 +516,12 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	// Entire docs/ directory should be removed — it's all dothog-specific.
 	assertDirRemoved(t, filepath.Join(dest, "docs"))
 
-	// Setup package and setup tests should be removed (#377)
+	// Setup machinery should not ship in the derived app.
 	assertDirRemoved(t, filepath.Join(dest, "internal", "setup"))
 	_, err = os.Stat(filepath.Join(dest, "tests", "setup_test.go"))
 	require.True(t, os.IsNotExist(err), "tests/setup_test.go should be removed during setup")
 
-	// e2e should contain only smoke test, helpers, and config (#356)
+	// e2e should contain only the smoke test, helpers, and config.
 	e2eEntries, err := os.ReadDir(filepath.Join(dest, "e2e"))
 	require.NoError(t, err)
 	var e2eNames []string
@@ -535,12 +535,12 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	require.NotContains(t, e2eNames, "inventory.spec.ts", "demo e2e tests should be removed")
 	require.NotContains(t, e2eNames, "home.spec.ts", "demo e2e tests should be removed")
 
-	// Smoke test should reference the app's binary name (#356)
+	// The smoke test should reference the app's binary name.
 	smokeBytes, err := os.ReadFile(filepath.Join(dest, "e2e", "smoke.spec.ts"))
 	require.NoError(t, err)
 	require.Contains(t, string(smokeBytes), "no-features-app", "smoke test should use the app binary name")
 
-	// README should contain a feature table (#360)
+	// The README should contain a feature table.
 	readmeBytes, err := os.ReadFile(filepath.Join(dest, "README.md"))
 	require.NoError(t, err)
 	readmeContent := string(readmeBytes)
@@ -556,7 +556,8 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	require.NotContains(t, readmeContent, "Database (chuck)",
 		"legacy 'Database (chuck)' label must not reappear in derived-app docs")
 
-	// env substitution must survive feature stripping (#regression)
+	// Feature stripping must preserve APP_NAME substitution in the copied
+	// environment file.
 	envBytes, err := os.ReadFile(filepath.Join(dest, ".env.development"))
 	require.NoError(t, err)
 	require.Contains(t, string(envBytes), "APP_NAME=No Features App",
@@ -566,8 +567,8 @@ func TestSetup_FeaturesNone(t *testing.T) {
 	require.NotContains(t, string(envBytes), "SESSION_SETTINGS_COOKIE_NAME=",
 		".env.development should omit session-settings cookie config when session_settings is stripped")
 
-	// Non-demo apps must still register GET / so breadcrumbs and not-found
-	// recovery links to Home point at a real route (#regression).
+	// Non-demo apps must still register GET / so breadcrumb and recovery
+	// links to Home point at a real route.
 	routesBytes, err := os.ReadFile(filepath.Join(dest, "internal", "routes", "routes.go"))
 	require.NoError(t, err)
 	require.Contains(t, string(routesBytes), `ar.e.GET("/"`,
@@ -794,15 +795,12 @@ func TestSetup_FeaturesDemo(t *testing.T) {
 	assertBuildSucceeds(t, dest)
 	assertDirExists(t, filepath.Join(dest, "internal", "demo"))
 
-	// db/gen_seed should be kept when demo is selected (#358)
+	// db/gen_seed stays when demo is selected.
 	assertDirExists(t, filepath.Join(dest, "db", "gen_seed"))
 }
 
-// TestSetup_FeaturesDemoWithoutSSE pins down the regression where the demo
-// block in routes.go used `ar.broker` outside of `setup:feature:sse` markers.
-// When sse was stripped but demo was kept, derived apps failed to build
-// with "ar.broker undefined" (#606). This test forces that exact combo and
-// ensures the demo block stays buildable when SSE is absent.
+// TestSetup_FeaturesDemoWithoutSSE verifies that the demo feature remains
+// buildable when SSE is stripped.
 func TestSetup_FeaturesDemoWithoutSSE(t *testing.T) {
 	t.Parallel()
 	repoRoot, err := findRepoRoot()
@@ -830,11 +828,8 @@ func TestSetup_FeaturesDemoWithoutSSE(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "htmx.ext.sse.js should be removed when sse stripped")
 }
 
-// TestSetup_SessionSettingsWithoutSSE pins down the theme-persistence
-// regression: a scaffold that keeps session_settings but omits sse must
-// still register POST /settings/theme so theme changes survive a reload.
-// Before the fix, initThemeRoutes was nested under both session_settings
-// AND sse markers, so stripping sse silently removed the registration.
+// TestSetup_SessionSettingsWithoutSSE verifies that a scaffold with
+// session_settings but without sse still registers POST /settings/theme.
 func TestSetup_SessionSettingsWithoutSSE(t *testing.T) {
 	t.Parallel()
 	repoRoot, err := findRepoRoot()
@@ -1225,10 +1220,8 @@ func TestSetup_NoSessionSettings_StripsPageScopedAlpine(t *testing.T) {
 	}
 }
 
-// TestSetup_GraphWithoutAvatar pins down the regression where Graph runtime
-// initialization lived under avatar markers in main.go. A graph-only scaffold
-// must still bootstrap the Graph client/user cache while stripping avatar-only
-// photo routes and storage.
+// TestSetup_GraphWithoutAvatar verifies that a graph-only scaffold still
+// initializes Graph runtime while stripping avatar-only routes and storage.
 func TestSetup_GraphWithoutAvatar(t *testing.T) {
 	t.Parallel()
 	repoRoot, err := findRepoRoot()

--- a/web/assets/error_capabilities_bundle_test.go
+++ b/web/assets/error_capabilities_bundle_test.go
@@ -6,12 +6,9 @@ import (
 	"testing"
 )
 
-// TestErrorCapabilitiesBundleContract pins the JS-side hook that injects
-// X-Error-Accept-Surfaces / X-Error-Fallback-Surface so the negotiation in
-// internal/routes/handler/error_capabilities.go has a wire counterpart. The
-// server parses these headers and degrades surfaces accordingly; a silent
-// regression in the JS file would break that contract without surfacing in
-// Go tests.
+// TestErrorCapabilitiesBundleContract verifies that the HTMX-side hook still
+// emits the request headers consumed by error-capability negotiation on the
+// server.
 func TestErrorCapabilitiesBundleContract(t *testing.T) {
 	data, err := os.ReadFile("public/js/app/htmx.error-capabilities.js")
 	if err != nil {

--- a/web/assets/tavern_bundle_test.go
+++ b/web/assets/tavern_bundle_test.go
@@ -9,9 +9,7 @@ import (
 )
 
 // TestTavernBundleContract verifies that the committed tavern.min.js bundle
-// matches the capabilities required by the templates. This catches silent
-// regressions where the JS asset reverts to an older version during branch
-// operations or squash merges.
+// still exposes the capabilities required by the templates.
 func TestTavernBundleContract(t *testing.T) {
 	data, err := os.ReadFile("public/js/vendor/tavern.min.js")
 	if err != nil {


### PR DESCRIPTION
## Summary
- make error-trace promotion one-shot per request even if Echo re-enters the central error handler
- add a regression test for the `RequestLogger()` double-invocation path
- rewrite process-history comments into current-contract wording across the touched runtime and test files

## Validation
- `go test ./internal/routes/handler ./internal/responsepolicy ./internal/setup -count=1`
- `go test ./tests ./web/assets -count=1 -timeout 300s`
- `go build ./...`
- `git diff --check`
