### PR TITLE
Trim process-history wording from responsepolicy and surface-error comments

### DIFF
--- a/internal/responsepolicy/policy_test.go
+++ b/internal/responsepolicy/policy_test.go
@@ -22,7 +22,7 @@ func newCtx(method, path string) (echo.Context, *httptest.ResponseRecorder) {
 
 // TestServerTiming_HeaderFormatOnCommittedResponse pins the wire shape on a
 // real (committed) response so DevTools / synthetic monitors keep parsing
-// the header. ServerTiming now hooks Response.Before, so it fires when the
+// the header. ServerTiming hooks Response.Before, so it fires when the
 // inner handler writes; nil-return handlers don't trigger a write and so
 // (correctly) don't emit the header.
 func TestServerTiming_HeaderFormatOnCommittedResponse(t *testing.T) {

--- a/internal/responsepolicy/server_timing.go
+++ b/internal/responsepolicy/server_timing.go
@@ -9,10 +9,8 @@ import (
 
 // ServerTiming measures the wall-clock duration of the inner handler and
 // emits a Server-Timing header so browser DevTools can chart it. The header
-// is written via echo.Response.Before so it sticks even on responses that
-// commit through c.String / c.JSON / c.Render — the previous "set after
-// next" shape was a no-op for every real handler because the body had
-// already flushed by the time the outer middleware ran.
+// is written via echo.Response.Before so it lands before the body flushes
+// even on responses that commit through c.String / c.JSON / c.Render.
 func ServerTiming() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {

--- a/internal/responsepolicy/vary.go
+++ b/internal/responsepolicy/vary.go
@@ -4,8 +4,8 @@ import "github.com/labstack/echo/v4"
 
 // Vary appends a single field to the Vary header on every response. Using
 // Add (not Set) preserves any prior Vary values upstream middleware or
-// handlers already declared, so the cache key shape is the union rather than
-// the last-write-wins clobber the previous routes.go helper produced.
+// handlers already declared, so the cache key shape is the union of all
+// declarations rather than a last-write-wins clobber.
 func Vary(field string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {

--- a/internal/routes/handler/surface_error_test.go
+++ b/internal/routes/handler/surface_error_test.go
@@ -64,9 +64,8 @@ func TestHTTPErrorHandler_SurfaceError_PageBodyOverrideHonored(t *testing.T) {
 }
 
 // TestHTTPErrorHandler_SurfaceError_DocumentStillStandalone pins the runtime
-// document-surface path against the page-surface change: a SurfaceDocument
-// SurfaceError must still produce a standalone shell, not get pulled into
-// host chrome.
+// document-surface path: a SurfaceDocument SurfaceError produces a
+// standalone shell rather than composing into host chrome.
 func TestHTTPErrorHandler_SurfaceError_DocumentStillStandalone(t *testing.T) {
 	e := setupEcho(nil)
 	e.GET("/test", func(c echo.Context) error {
@@ -108,10 +107,9 @@ func TestHTTPErrorHandler_SurfaceError_HTMXFallsBackToBanner(t *testing.T) {
 }
 
 // TestHTTPErrorHandler_SurfaceError_500AppendsReportIssue pins the
-// request-ID/report-issue contract that the pre-refactor central error path
-// preserved for 500+ responses: when the caller doesn't supply explicit
-// controls, the default control set must include a Report Issue button so
-// the user can attach the request trace.
+// request-ID/report-issue contract for 500+ responses: when the caller
+// doesn't supply explicit controls, the default control set must include
+// a Report Issue button so the user can attach the request trace.
 func TestHTTPErrorHandler_SurfaceError_500AppendsReportIssue(t *testing.T) {
 	e := setupEcho(nil)
 	e.GET("/test", func(c echo.Context) error {
@@ -133,9 +131,8 @@ func TestHTTPErrorHandler_SurfaceError_500AppendsReportIssue(t *testing.T) {
 
 // TestNewSurfaceError_500DefaultControlsIncludeReport guards the constructor
 // contract directly: the default control set for 500+ statuses ends with a
-// ReportIssueButton bound to the current request ID. Caller-supplied controls
-// override the default and are not augmented (matches the pre-refactor
-// HandleHypermediaError behavior).
+// ReportIssueButton bound to the current request ID. Caller-supplied
+// controls override the default and are not augmented.
 func TestNewSurfaceError_500DefaultControlsIncludeReport(t *testing.T) {
 	e := echo.New()
 	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))


### PR DESCRIPTION
## Summary
- trim remaining process-history wording from responsepolicy comments
- rewrite surface-error test comments to describe the current contract instead of pre-refactor behavior
- keep the cleanup narrowly scoped to source/test commentary with no behavior change

## Validation
- `gofmt -w internal/responsepolicy/policy_test.go internal/responsepolicy/server_timing.go internal/responsepolicy/vary.go internal/routes/handler/surface_error_test.go`
- `go test ./internal/responsepolicy ./internal/routes/handler -count=1 -timeout 300s`
- `go build ./...`
- `git diff --check`
