### PR TITLE
Trim remaining repo-wide history wording

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // setTestDefaults ensures the required machine-facing env vars are set for
-// non-demo apps. SESSION_SETTINGS_COOKIE_NAME is now strict: tests must
-// supply it explicitly because config no longer derives it from APP_NAME.
+// non-demo apps. SESSION_SETTINGS_COOKIE_NAME must be supplied explicitly;
+// config does not derive it from APP_NAME.
 func setTestDefaults(t *testing.T) {
 	t.Helper()
 	if os.Getenv("APP_NAME") == "" {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -26,9 +26,9 @@ func resetLogger() {
 	mu.Unlock()
 }
 
-// captureLogger installs a JSON-backed test logger that writes into buf, then
-// restores the previous package-level logger when the test ends. Use this to
-// assert on log output without depending on the file/stdout sinks Init wires.
+// captureLogger installs a JSON-backed test logger that writes into buf and
+// restores the package-level logger on test cleanup. Use this to assert on
+// log output without depending on the file/stdout sinks Init wires.
 func captureLogger(t *testing.T, buf *bytes.Buffer) {
 	t.Helper()
 	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -842,8 +842,8 @@ func TestRemoveOrphanedImportLines(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDatabaseBlocksStrippedWhenNoMSSQLOrPostgres(t *testing.T) {
-	// "database" is no longer implicit: scaffolds without MSSQL or PostgreSQL
-	// strip the app-data marker blocks entirely.
+	// "database" is opt-in: scaffolds without MSSQL or PostgreSQL strip the
+	// app-data marker blocks entirely.
 	content := strings.Join([]string{
 		"before",
 		"// setup:feature:database:start",

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -630,9 +630,9 @@ func TestSetup_FeaturesAuthOnly(t *testing.T) {
 
 // TestSetup_FeaturesNoAppData verifies that scaffolds without MSSQL or
 // PostgreSQL strip the chuck-backed app-data seam entirely: the internal
-// `database` feature is no longer implicit, so `internal/dbschema/` is
-// removed and main.go drops its app-data block. Framework SQLite stores
-// (in internal/database) stay wired in regardless.
+// `database` feature is opt-in, so `internal/dbschema/` is removed and
+// main.go drops its app-data block. Framework SQLite stores (in
+// internal/database) stay wired in regardless.
 func TestSetup_FeaturesNoAppData(t *testing.T) {
 	t.Parallel()
 	repoRoot, err := findRepoRoot()
@@ -703,9 +703,9 @@ func TestSetup_FeaturesMSSQL(t *testing.T) {
 		"main.go must reference dbschema.Tables when mssql is selected")
 }
 
-// TestSetup_FeaturesPostgres pins down the postgres-side of the user-facing
-// chuck-backed app-data feature model: selecting postgres must register the
-// chuck postgres driver and leave mssql out.
+// TestSetup_FeaturesPostgres pins the postgres side of the chuck-backed
+// app-data feature: selecting postgres must register the chuck postgres
+// driver and leave mssql out.
 func TestSetup_FeaturesPostgres(t *testing.T) {
 	t.Parallel()
 	repoRoot, err := findRepoRoot()


### PR DESCRIPTION
## Summary
- rewrite the remaining low-signal history/process comments found in the repo-wide cleanup sweep
- keep the touched comments present-tense and contract-focused
- leave runtime strings and honest behavior-oriented test comments alone

## Validation
- go test ./internal/config ./internal/logger ./internal/setup -count=1 -timeout 300s
- go test ./tests/ -run 'TestSetup_FeaturesPostgres|TestSetup_FeaturesNoAppData' -count=1 -timeout 600s
- go build ./...
- git diff --check