### PR TITLE
Clarify graph usercache eligibility contract

### DIFF
--- a/internal/service/graph/client.go
+++ b/internal/service/graph/client.go
@@ -43,7 +43,11 @@ func consistencyLevelHeaders() *abstractions.RequestHeaders {
 	return h
 }
 
-// FetchAllEnabledUsers pages through every accountEnabled=true user (top=999, eventual consistency) and returns a flattened slice.
+// FetchAllEnabledUsers pages through every accountEnabled=true user
+// (top=999, eventual consistency) and returns a flattened slice. The
+// accountEnabled filter is the single eligibility gate — downstream cache
+// reads (SearchUsers, AllUsers, UserByAzureID) trust the resulting rows
+// without re-checking field-level eligibility.
 func (c *Client) FetchAllEnabledUsers(ctx context.Context) ([]User, error) {
 	filter := "accountEnabled eq true"
 	selectCols := []string{"id", "displayName", "userPrincipalName", "mail", "officeLocation", "department", "givenName", "surname", "companyName", "jobTitle"}

--- a/internal/service/graph/directory.go
+++ b/internal/service/graph/directory.go
@@ -111,7 +111,10 @@ func (d *Directory) InsertOrUpdateUsers(ctx context.Context, users []User) error
 const userSelect = "SELECT AzureId, GivenName, Surname, DisplayName, UserPrincipalName, Mail, JobTitle, OfficeLocation, Department, CompanyName, AccountName"
 
 // SearchUsers ANDs LIKE clauses across GivenName/Surname/DisplayName/AccountName
-// for each term and returns up to limit rows ordered by DisplayName.
+// for each term and returns up to limit rows ordered by DisplayName. The query
+// carries no eligibility predicate on Mail/JobTitle/AzureId/etc.: cache rows
+// are trusted as-is, with eligibility enforced at Graph ingest in
+// FetchAllEnabledUsers.
 func (d *Directory) SearchUsers(ctx context.Context, terms []string, limit int) ([]User, error) {
 	if len(terms) == 0 {
 		return nil, fmt.Errorf("no search terms provided")
@@ -194,10 +197,13 @@ func (d *Directory) UserCount(ctx context.Context) (int, error) {
 // ReplaceUsers upserts the fetched users and deletes any local rows whose
 // AzureId isn't in the fetched set. This is the snapshot-replace path used
 // by full Graph syncs so users disabled/removed in Graph drop out of the
-// local directory rather than living on forever. A successful empty fetch
-// is a valid snapshot — it clears the cache. Degraded fetches show up as a
-// non-nil error from fetchUsersFunc, not as an empty users slice, so the
-// caller can distinguish "Graph said nothing" from "Graph is empty".
+// local directory rather than living on forever. Pruning is snapshot
+// ownership only — rows missing from the latest successful Graph fetch —
+// not field-based eligibility (Mail/JobTitle/etc.); eligibility is enforced
+// upstream in FetchAllEnabledUsers. A successful empty fetch is a valid
+// snapshot — it clears the cache. Degraded fetches show up as a non-nil
+// error from fetchUsersFunc, not as an empty users slice, so the caller
+// can distinguish "Graph said nothing" from "Graph is empty".
 func (d *Directory) ReplaceUsers(ctx context.Context, users []User) error {
 	if len(users) == 0 {
 		// Wipe the table — successful empty snapshot means no Graph users.

--- a/internal/service/graph/directory_sync_test.go
+++ b/internal/service/graph/directory_sync_test.go
@@ -64,6 +64,47 @@ func TestReplaceUsers_EmptySnapshotClearsCache(t *testing.T) {
 	assert.Equal(t, 0, got, "empty successful snapshot must clear cached users")
 }
 
+// TestSearchUsers_TrustsCacheRowsWithoutFieldEligibility proves SearchUsers
+// carries no SQL-side eligibility predicate on
+// Mail/JobTitle/Department/CompanyName/AzureId. Rows with those fields empty
+// must still match a name-style term, because eligibility is enforced
+// upstream at Graph ingest, not at cache read time.
+func TestSearchUsers_TrustsCacheRowsWithoutFieldEligibility(t *testing.T) {
+	ctx := context.Background()
+	dir := openDirectoryForTest(t)
+
+	users := []User{
+		{
+			AzureID:           "azure-empty-fields",
+			GivenName:         "Ada",
+			Surname:           "Lovelace",
+			DisplayName:       "Ada Lovelace",
+			UserPrincipalName: "ada@example.com",
+			AccountName:       "ada",
+			// Mail, JobTitle, OfficeLocation, Department, CompanyName all empty.
+		},
+		{
+			AzureID:     "azure-mail-only",
+			DisplayName: "Grace Hopper",
+			AccountName: "grace",
+			Mail:        "grace@example.com",
+		},
+	}
+	require.NoError(t, dir.ReplaceUsers(ctx, users))
+
+	got, err := dir.SearchUsers(ctx, []string{"ada"}, 10)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "row with empty Mail/JobTitle/etc. must still match by name term")
+	assert.Equal(t, "azure-empty-fields", got[0].AzureID)
+	assert.Empty(t, got[0].Mail, "cache row is returned as-is; no eligibility filter strips empty Mail")
+	assert.Empty(t, got[0].JobTitle)
+
+	got, err = dir.SearchUsers(ctx, []string{"grace"}, 10)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "azure-mail-only", got[0].AzureID)
+}
+
 func TestLastSuccessfulSync_RoundTrips(t *testing.T) {
 	ctx := context.Background()
 	dir := openDirectoryForTest(t)


### PR DESCRIPTION
## Summary
- document that Graph ingest is the single eligibility gate for cached users
- clarify that cache search trusts stored rows and does not re-check field-level eligibility
- clarify that ReplaceUsers prunes by snapshot ownership only
- add a focused graph test proving rows with empty Mail/JobTitle/etc. still match search by name

Closes #738

## Validation
- go test ./internal/service/graph -count=1
- go build ./...
- git diff --check