### PR TITLE
Add multi-region OOB hypermedia response builder

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -388,6 +388,29 @@ templ MySettingsPage() {
 
 These are too thin to warrant a reusable component — the HTML is self-explanatory and hiding it behind `Card(title)` or `StackedLayout()` adds indirection without reducing complexity. Write the markup directly.
 
+## Multi-Region OOB Responses
+
+Most HTMX updates are a single fragment swapped into the request's `hx-target` via `handler.RenderComponent`. When one action must also refresh other regions, the standard mechanism is out-of-band swaps: a component bakes its own `id` and `hx-swap-oob` attribute, and the response carries it alongside the main fragment.
+
+`handler.RenderHypermedia` composes such a response from explicit, named regions without a bespoke per-endpoint composite template. It renders `Main` into the `hx-target`, then each `OOBFragment` in declared order:
+
+```go
+func (d *cartRoutes) handleAddToCart(c echo.Context) error {
+    // ...mutate, then reload the regions this action changed...
+    return handler.RenderHypermedia(c, handler.HypermediaResponse{
+        Main: views.CartLineItems(items),
+        Fragments: []handler.OOBFragment{
+            {TargetID: "cart-count", Swap: "true", Component: views.CartCount(n)},
+            {TargetID: "flash", Swap: "outerHTML", Component: views.Flash("Added to cart")},
+        },
+    })
+}
+```
+
+Each component renders verbatim and owns its own `id` + `hx-swap-oob` markup (the standard OOB contract). `TargetID`/`Swap` restate that contract in code so the response shape is reviewable and testable; the builder never parses or rewrites the markup, so the author keeps each declared field and the component's own attribute in sync.
+
+This complements self-OOB templ regions rather than replacing them. A single component that emits several `hx-swap-oob` blocks is still the right choice when those regions always update together; reach for `RenderHypermedia` when a handler assembles a varying set of regions from independent components.
+
 ## Adding a New Component
 
 ### 1. Create the component

--- a/internal/routes/handler/handler.go
+++ b/internal/routes/handler/handler.go
@@ -255,6 +255,49 @@ func RenderComponent(c echo.Context, cmp templ.Component) error {
 	return nil
 }
 
+// OOBFragment is one out-of-band region of a HypermediaResponse. TargetID and
+// Swap restate, in code, the DOM id and hx-swap-oob mode ("true", "outerHTML",
+// "beforeend", ...) the component already bakes into its own markup. The
+// builder renders Component verbatim and never rewrites it, so this metadata is
+// declarative: it exists so route tests can assert the response shape and so
+// drift from the component's own attributes is reviewable — it does not drive
+// the swap.
+type OOBFragment struct {
+	Component templ.Component
+	TargetID  string
+	Swap      string
+}
+
+// HypermediaResponse is a multi-region HTMX response: a Main fragment for the
+// request's hx-target plus ordered out-of-band Fragments, composed from named
+// components without a per-endpoint composite template. Set any HX-Trigger
+// headers directly on the response; the builder carries none.
+type HypermediaResponse struct {
+	Main      templ.Component
+	Fragments []OOBFragment
+}
+
+// RenderHypermedia renders Main, then each fragment's component in declared
+// order, sharing RenderComponent's context, writer, and render-error fallback.
+// A nil Main or a fragment with a nil Component is skipped.
+func RenderHypermedia(c echo.Context, r HypermediaResponse) error {
+	ctx := c.Request().Context()
+	if r.Main != nil {
+		if err := r.Main.Render(ctx, c.Response()); err != nil {
+			return HandleError(c, http.StatusInternalServerError, "Failed to render component", err)
+		}
+	}
+	for _, f := range r.Fragments {
+		if f.Component == nil {
+			continue
+		}
+		if err := f.Component.Render(ctx, c.Response()); err != nil {
+			return HandleError(c, http.StatusInternalServerError, "Failed to render component", err)
+		}
+	}
+	return nil
+}
+
 // HandleError logs the error and return Hypermedia response
 func HandleError(c echo.Context, statusCode int, message string, err error) error {
 	// Check if the request context is canceled

--- a/internal/routes/handler/handler_test.go
+++ b/internal/routes/handler/handler_test.go
@@ -3,10 +3,13 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
+	"strings"
 	"testing"
 
 	"catgoose/dothog/internal/logger"
@@ -184,4 +187,100 @@ func TestHandleComponent(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "Admin")
 	assert.Contains(t, rec.Body.String(), "<span>content</span>")
+}
+
+func oobDiv(id, swap, body string) templ.Component {
+	return templ.Raw(fmt.Sprintf(`<div id=%q hx-swap-oob=%q>%s</div>`, id, swap, body))
+}
+
+func TestRenderHypermedia_MainThenFragmentsInOrder(t *testing.T) {
+	c, rec := newEchoContext(http.MethodGet, "/", nil)
+	err := RenderHypermedia(c, HypermediaResponse{
+		Main: templ.Raw("<main>main</main>"),
+		Fragments: []OOBFragment{
+			{TargetID: "first", Swap: "true", Component: oobDiv("first", "true", "one")},
+			{TargetID: "second", Swap: "beforeend", Component: oobDiv("second", "beforeend", "two")},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	body := rec.Body.String()
+	mainAt := strings.Index(body, "<main>main</main>")
+	firstAt := strings.Index(body, `id="first"`)
+	secondAt := strings.Index(body, `id="second"`)
+	require.True(t, mainAt >= 0 && firstAt >= 0 && secondAt >= 0, "all regions render")
+	assert.Less(t, mainAt, firstAt, "main renders before the fragments")
+	assert.Less(t, firstAt, secondAt, "fragments render in declared order")
+}
+
+func TestRenderHypermedia_SkipsNilMainAndNilFragments(t *testing.T) {
+	c, rec := newEchoContext(http.MethodGet, "/", nil)
+	err := RenderHypermedia(c, HypermediaResponse{
+		Main: nil,
+		Fragments: []OOBFragment{
+			{TargetID: "skip", Swap: "true", Component: nil},
+			{TargetID: "kept", Swap: "true", Component: oobDiv("kept", "true", "here")},
+		},
+	})
+	require.NoError(t, err)
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `id="kept"`)
+	assert.NotContains(t, body, `id="skip"`)
+}
+
+func TestRenderHypermedia_RenderErrorReturns500(t *testing.T) {
+	tests := []struct {
+		name string
+		resp HypermediaResponse
+	}{
+		{"bad main", HypermediaResponse{Main: badComponent{}}},
+		{"bad fragment", HypermediaResponse{Fragments: []OOBFragment{
+			{TargetID: "x", Swap: "true", Component: badComponent{}},
+		}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, rec := newEchoContext(http.MethodGet, "/", nil)
+			err := RenderHypermedia(c, tt.resp)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+			assert.Contains(t, rec.Body.String(), "error-message-content")
+		})
+	}
+}
+
+func oobSwapByID(body string) map[string]string {
+	openTag := regexp.MustCompile(`<[a-zA-Z][^>]*>`)
+	idAttr := regexp.MustCompile(`\bid="([^"]*)"`)
+	swapAttr := regexp.MustCompile(`\bhx-swap-oob="([^"]*)"`)
+	byID := map[string]string{}
+	for _, tag := range openTag.FindAllString(body, -1) {
+		id := idAttr.FindStringSubmatch(tag)
+		swap := swapAttr.FindStringSubmatch(tag)
+		if id != nil && swap != nil {
+			byID[id[1]] = swap[1]
+		}
+	}
+	return byID
+}
+
+func TestRenderHypermedia_DeclaredMetadataMatchesRenderedAttributes(t *testing.T) {
+	frags := []OOBFragment{
+		{TargetID: "cart-count", Swap: "true", Component: oobDiv("cart-count", "true", "3")},
+		{TargetID: "flash", Swap: "outerHTML", Component: oobDiv("flash", "outerHTML", "Saved")},
+	}
+	c, rec := newEchoContext(http.MethodGet, "/", nil)
+	require.NoError(t, RenderHypermedia(c, HypermediaResponse{
+		Main:      templ.Raw("<main></main>"),
+		Fragments: frags,
+	}))
+
+	swapByID := oobSwapByID(rec.Body.String())
+	for _, f := range frags {
+		swap, ok := swapByID[f.TargetID]
+		require.Truef(t, ok, "rendered OOB element with id %q must exist", f.TargetID)
+		assert.Equalf(t, f.Swap, swap, "declared Swap for %q must match the hx-swap-oob on that same element", f.TargetID)
+	}
 }


### PR DESCRIPTION
## Summary
- add handler-owned OOBFragment, HypermediaResponse, and RenderHypermedia for explicit multi-region HTMX responses
- cover render order, nil skipping, render-error fallback, and id/hx-swap-oob metadata pairing in handler tests
- document the pattern as a complement to self-OOB templ regions

## Validation
- go test ./internal/routes/handler ./internal/routes
- mage lint
- git diff --check

Closes #742