### PR TITLE
Suppress expected test-mode 4xx error traces

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -73,6 +73,9 @@ func GetDefault(key, fallback string) string {
 // Dev reports whether the current mode is "development".
 func Dev() bool { return mode == "development" }
 
+// Test reports whether the current mode is "test".
+func Test() bool { return mode == "test" }
+
 // Name is the canonical mode string ("development", "production", …) after normalisation.
 func Name() string { return mode }
 

--- a/internal/routes/handler/error_handler.go
+++ b/internal/routes/handler/error_handler.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
+	"catgoose/dothog/internal/env"
 	"catgoose/dothog/internal/htmxutil"
 	"catgoose/dothog/internal/logger"
 	"catgoose/dothog/internal/routes/middleware"
@@ -27,6 +29,9 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 	}
 
 	requestID := promolog.GetRequestID(c.Request().Context())
+	if traceSuppressed(c) {
+		requestID = ""
+	}
 	log := logger.WithContext(c.Request().Context()).With(
 		"status_code", statusCode,
 		"message", message,
@@ -81,6 +86,9 @@ func handleError(c echo.Context, statusCode int, message string, err error) erro
 func handleErrorWithContext(c echo.Context, ec linkwell.ErrorContext) error {
 	if errors.Is(c.Request().Context().Err(), context.Canceled) {
 		return nil
+	}
+	if traceSuppressed(c) {
+		ec.RequestID = ""
 	}
 
 	log := logger.WithContext(c.Request().Context()).With(
@@ -165,6 +173,9 @@ func renderSurfaceError(c echo.Context, se *SurfaceError) error {
 	if errors.Is(c.Request().Context().Err(), context.Canceled) {
 		return nil
 	}
+	if traceSuppressed(c) {
+		se.EC.RequestID = ""
+	}
 
 	log := logger.WithContext(c.Request().Context()).With(
 		"status_code", se.EC.StatusCode,
@@ -225,10 +236,52 @@ func renderHTMXSurfaceError(c echo.Context, se *SurfaceError) error {
 // re-entry into the central error handler does not duplicate that side effect.
 const errPromotedKey = "_promolog_promoted"
 
+// errTraceSuppressedKey marks a request whose trace was intentionally not
+// promoted. The render path reads it to drop the Request ID reference that
+// would otherwise point at a trace nobody stored.
+const errTraceSuppressedKey = "_promolog_suppressed"
+
+// envIsTest and captureTest4xx are the promotion policy's environment inputs,
+// kept as package vars so suppression tests drive them deterministically
+// without mutating global env state.
+var (
+	envIsTest      = env.Test
+	captureTest4xx = envCaptureTest4xx
+)
+
+// envCaptureTest4xx reports whether ERROR_TRACE_CAPTURE_TEST_4XX opts test-mode
+// 4xx traces back into promotion. Accepts "true" and "1", case-insensitive.
+func envCaptureTest4xx() bool {
+	switch strings.ToLower(strings.TrimSpace(env.GetDefault("ERROR_TRACE_CAPTURE_TEST_4XX", ""))) {
+	case "true", "1":
+		return true
+	}
+	return false
+}
+
+// shouldPromoteTrace decides whether an error trace at statusCode is stored.
+// 5xx always promotes. 4xx promotes everywhere except ENV=test, where expected
+// browser-test 4xx noise is suppressed unless the capture opt-in is set.
+func shouldPromoteTrace(statusCode int, isTest, capture bool) bool {
+	if statusCode >= 500 {
+		return true
+	}
+	if statusCode >= 400 && isTest && !capture {
+		return false
+	}
+	return true
+}
+
+func traceSuppressed(c echo.Context) bool {
+	v, _ := c.Get(errTraceSuppressedKey).(bool)
+	return v
+}
+
 // NewHTTPErrorHandler is the e.HTTPErrorHandler replacement that renders
 // errors through the route-owned surface contract; non-nil reqLogStore
-// promotes the per-request log buffer to the shared store so issue reports
-// can retrieve it. Trace promotion is idempotent per request.
+// promotes the per-request log buffer to the shared store when
+// shouldPromoteTrace allows it, so issue reports can retrieve it. Trace
+// promotion is idempotent per request.
 func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Context) {
 	return func(err error, c echo.Context) {
 		// The httpcompression writer is finalized (closed) by the time the
@@ -250,7 +303,9 @@ func NewHTTPErrorHandler(reqLogStore promolog.Storer) func(err error, c echo.Con
 		}
 
 		alreadyPromoted, _ := c.Get(errPromotedKey).(bool)
-		if reqLogStore != nil && !alreadyPromoted {
+		if !shouldPromoteTrace(statusCode, envIsTest(), captureTest4xx()) {
+			c.Set(errTraceSuppressedKey, true)
+		} else if reqLogStore != nil && !alreadyPromoted {
 			requestID := promolog.GetRequestID(c.Request().Context())
 			if requestID != "" {
 				c.Set(errPromotedKey, true)

--- a/internal/routes/handler/error_handler_trace_policy_test.go
+++ b/internal/routes/handler/error_handler_trace_policy_test.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/catgoose/promolog"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// forceTraceEnv drives the promotion policy's environment inputs for one test
+// without mutating global env state.
+func forceTraceEnv(t *testing.T, isTest, capture bool) {
+	t.Helper()
+	prevTest, prevCapture := envIsTest, captureTest4xx
+	envIsTest = func() bool { return isTest }
+	captureTest4xx = func() bool { return capture }
+	t.Cleanup(func() { envIsTest, captureTest4xx = prevTest, prevCapture })
+}
+
+func newEchoForStatus(store promolog.Storer, route string, status int) *echo.Echo {
+	e := echo.New()
+	e.Use(echo.WrapMiddleware(promolog.CorrelationMiddleware))
+	e.HTTPErrorHandler = NewHTTPErrorHandler(store)
+	e.GET(route, func(_ echo.Context) error { return echo.NewHTTPError(status, http.StatusText(status)) })
+	return e
+}
+
+func serve(e *echo.Echo, method, target string, htmx bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, target, http.NoBody)
+	if htmx {
+		req.Header.Set("HX-Request", "true")
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestShouldPromoteTrace(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		isTest  bool
+		capture bool
+		want    bool
+	}{
+		{"5xx promotes in test", 500, true, false, true},
+		{"5xx promotes outside test", 503, false, false, true},
+		{"4xx promotes outside test", 404, false, false, true},
+		{"4xx suppressed in test", 404, true, false, false},
+		{"4xx promotes in test with opt-in", 404, true, true, true},
+		{"422 suppressed in test", 422, true, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shouldPromoteTrace(tc.status, tc.isTest, tc.capture))
+		})
+	}
+}
+
+func TestEnvCaptureTest4xx(t *testing.T) {
+	cases := map[string]bool{
+		"true": true, "TRUE": true, "1": true, " true ": true,
+		"": false, "false": false, "0": false, "yes": false,
+	}
+	for value, want := range cases {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("ERROR_TRACE_CAPTURE_TEST_4XX", value)
+			assert.Equal(t, want, envCaptureTest4xx())
+		})
+	}
+}
+
+func TestTracePromotion_TestMode4xxSuppressed(t *testing.T) {
+	forceTraceEnv(t, true, false)
+	store := &recordingStore{}
+	rec := serve(newEchoWithPromotion(store), http.MethodGet, "/missing", false)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Empty(t, store.snapshot(), "ENV=test 4xx must not promote a trace")
+}
+
+func TestTracePromotion_TestMode5xxStillPromotes(t *testing.T) {
+	forceTraceEnv(t, true, false)
+	store := &recordingStore{}
+	rec := serve(newEchoForStatus(store, "/boom", http.StatusInternalServerError), http.MethodGet, "/boom", false)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Len(t, store.snapshot(), 1, "5xx always promotes, even in ENV=test")
+}
+
+func TestTracePromotion_NonTest4xxPromotes(t *testing.T) {
+	forceTraceEnv(t, false, false)
+	store := &recordingStore{}
+	rec := serve(newEchoWithPromotion(store), http.MethodGet, "/missing", false)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Len(t, store.snapshot(), 1, "4xx outside ENV=test still promotes")
+}
+
+func TestTracePromotion_OptInRestoresTestMode4xx(t *testing.T) {
+	forceTraceEnv(t, true, true)
+	store := &recordingStore{}
+	rec := serve(newEchoWithPromotion(store), http.MethodGet, "/missing", false)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Len(t, store.snapshot(), 1, "ERROR_TRACE_CAPTURE_TEST_4XX re-enables test-mode 4xx promotion")
+}
+
+func TestTraceSuppression_NonTest4xxShowsRequestID(t *testing.T) {
+	forceTraceEnv(t, false, false)
+	rec := serve(newEchoForStatus(&recordingStore{}, "/bad", http.StatusBadRequest), http.MethodGet, "/bad", false)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Request ID", "a promoted 4xx surfaces its trace reference")
+}
+
+func TestTraceSuppression_TestMode4xxOmitsRequestID(t *testing.T) {
+	forceTraceEnv(t, true, false)
+	rec := serve(newEchoForStatus(&recordingStore{}, "/bad", http.StatusBadRequest), http.MethodGet, "/bad", false)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "Request ID", "a suppressed 4xx must not surface a dead trace reference")
+}
+
+func TestTraceSuppression_5xxKeepsReportAffordance(t *testing.T) {
+	forceTraceEnv(t, true, false)
+	rec := serve(newEchoForStatus(&recordingStore{}, "/boom", http.StatusInternalServerError), http.MethodGet, "/boom", false)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, "Request ID", "a reportable 5xx still surfaces its trace reference")
+	assert.Contains(t, body, "Report Issue", "a reportable 5xx still offers Report Issue")
+}


### PR DESCRIPTION
## Summary
- add a test-mode trace promotion policy that suppresses expected 4xx traces under ENV=test
- preserve 5xx promotion, non-test 4xx promotion, and an ERROR_TRACE_CAPTURE_TEST_4XX opt-in
- clear request IDs from suppressed error renders so Report Issue does not target a missing trace

## Validation
- go test ./internal/routes/handler
- go test ./internal/routes/handler ./internal/routes ./internal/env
- go test ./...
- mage lint
- git diff --check

Closes #747