### PR TITLE
Add hyperscript details dropdown attributes

### DIFF
--- a/docs/JAVASCRIPT.md
+++ b/docs/JAVASCRIPT.md
@@ -133,7 +133,10 @@ identifies what kind of file it is:
 Shell behaviors that only react to local DOM events — toast spawning,
 nav dropdown exclusivity, close-on-outside-click — live in `_hyperscript`
 on the element that owns them. Alpine is reserved for coordinated client
-state that spans multiple DOM regions. Feature-local Alpine components
+state that spans multiple DOM regions. A standalone `<details>` dropdown
+(profile menu, action menu) gets close-on-outside and optional autofocus by
+spreading `components.DetailsDropdownAttrs(focusSelector)` onto it — no Alpine
+component needed. Feature-local Alpine components
 ship in their own `*.alpine.js` file and register through
 `dothog.alpine.register(name, factory)` exposed by `alpine-helper.js`, so
 the helper can queue them until `alpine:init` fires. The helper exists for

--- a/web/components/core/attrs.go
+++ b/web/components/core/attrs.go
@@ -1,8 +1,10 @@
 package components
 
 import (
-	"github.com/catgoose/linkwell"
+	"strconv"
+
 	"github.com/a-h/templ"
+	"github.com/catgoose/linkwell"
 )
 
 // hxAttrsFromControl converts HxRequest fields to templ.Attributes with "hx-" prefix.
@@ -35,4 +37,30 @@ func hxAttrsFromControl(ctrl linkwell.Control) templ.Attributes {
 		attrs["hx-target-error"] = ctrl.ErrorTarget
 	}
 	return attrs
+}
+
+// DetailsDropdownAttrs is the _hyperscript wiring for a standalone <details>
+// dropdown: spread it onto the <details> to close the menu on an outside click
+// and, when focusSelector is non-empty, focus the first matching descendant
+// each time it opens. The lookup runs inside the element (me.querySelector), so
+// duplicate desktop/mobile copies never steal focus from each other.
+//
+// Pass "" for close-on-outside only. The navbar shell already closes its own
+// nested <details>; reach for this on dropdowns outside that shell.
+func DetailsDropdownAttrs(focusSelector string) templ.Attributes {
+	script := `on click from window
+  if me.open and event.target is not within me
+    set me.open to false
+  end`
+	if focusSelector != "" {
+		script += `
+on toggle
+  if me.open
+    set focusTarget to me.querySelector(` + strconv.Quote(focusSelector) + `)
+    if focusTarget
+      call focusTarget.focus()
+    end
+  end`
+	}
+	return templ.Attributes{"_": script}
 }

--- a/web/components/core/attrs_test.go
+++ b/web/components/core/attrs_test.go
@@ -97,3 +97,27 @@ func TestHxAttrsFromControl_ZeroHxRequest(t *testing.T) {
 	attrs := hxAttrsFromControl(ctrl)
 	require.Equal(t, "Sure?", attrs["hx-confirm"])
 }
+
+func TestDetailsDropdownAttrs_CloseOnly(t *testing.T) {
+	script, ok := DetailsDropdownAttrs("")["_"].(string)
+	require.True(t, ok)
+	require.Contains(t, script, "on click from window")
+	require.Contains(t, script, "event.target is not within me")
+	require.Contains(t, script, "set me.open to false")
+	require.NotContains(t, script, "on toggle")
+}
+
+func TestDetailsDropdownAttrs_WithFocus(t *testing.T) {
+	script, ok := DetailsDropdownAttrs("[data-search]")["_"].(string)
+	require.True(t, ok)
+	require.Contains(t, script, "on click from window")
+	require.Contains(t, script, "on toggle")
+	require.Contains(t, script, `me.querySelector("[data-search]")`)
+	require.Contains(t, script, "call focusTarget.focus()")
+}
+
+func TestDetailsDropdownAttrs_FocusSelectorWithQuotes(t *testing.T) {
+	script, ok := DetailsDropdownAttrs(`[data-label="Bob's menu"]`)["_"].(string)
+	require.True(t, ok)
+	require.Contains(t, script, `me.querySelector("[data-label=\"Bob's menu\"]")`)
+}


### PR DESCRIPTION
## Summary
- Add a reusable _hyperscript-backed DetailsDropdownAttrs helper for standalone <details> dropdowns
- Cover close-only, autofocus, and quoted selector generation
- Document the helper as the dothog path for local details dropdown behavior instead of an Alpine component

Closes #749

## Validation
- go test ./web/components/core/
- go test ./...
- mage lint
- git diff --check